### PR TITLE
Keycloak, token verification and the provider-neutral identity directory port (#6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,23 @@ ORACLE_USER=cerbos_poc
 ORACLE_PASSWORD=change-me
 ORACLE_SYS_PASSWORD=change-me
 ORACLE_SERVICE=FREEPDB1
+
+# Keycloak. Published, because a browser has to reach it to log in. The hostname
+# is what a token claims as its issuer, so it must be the address the browser
+# uses; the ADS verifies against exactly this string.
+KEYCLOAK_PORT=8081
+KEYCLOAK_HOSTNAME=http://localhost:8081
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=change-me
+
+# §7.1 installation selection. Set IDP_TYPE=WSO2_IS to select the other adapter;
+# nothing else changes and no image is rebuilt. The service account secret is not
+# here on purpose: it is mounted from deploy/secrets/idp-admin-credentials, so it
+# never appears in `docker inspect` or in a child process' environment.
+IDP_TYPE=KEYCLOAK
+IDP_REALM=cerbos-poc
+IDP_TENANT_ID=tenant-a
+IDP_TENANT_MAPPING_MODE=CLAIM
+IDP_ROLE_SOURCE=CLIENT
+IDP_CLIENT_ID=patient-app
+IDP_SERVICE_CLIENT_ID=authorization-admin-service

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ db-test-dual: ## Prove portability: the same contract against both engines
 .PHONY: smoke
 smoke: ## Verify a running stack end to end
 	bash scripts/tests/stack-smoke.sh
+	bash scripts/tests/identity-e2e.sh
 	bash scripts/tests/decision-e2e.sh
 
 .PHONY: gen

--- a/apps/ads/Dockerfile
+++ b/apps/ads/Dockerfile
@@ -11,6 +11,9 @@ COPY apps/ads/go.mod apps/ads/go.sum ./apps/ads/
 COPY libs/assignmentstore/go.mod libs/assignmentstore/go.sum ./libs/assignmentstore/
 COPY libs/cerbosclient/go.mod libs/cerbosclient/go.sum ./libs/cerbosclient/
 COPY libs/permissioncontext/go.mod ./libs/permissioncontext/
+COPY libs/canonicalid/go.mod ./libs/canonicalid/
+COPY libs/tokenverifier/go.mod ./libs/tokenverifier/
+COPY libs/idpdirectory/go.mod ./libs/idpdirectory/
 WORKDIR /src/apps/ads
 RUN go mod download
 

--- a/apps/ads/cmd/ads/main.go
+++ b/apps/ads/cmd/ads/main.go
@@ -15,10 +15,13 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/cerbos"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/config"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/directoryapi"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/netprobe"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/server"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/postgresstore"
 	"github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/provider"
 )
 
 func main() {
@@ -48,12 +51,38 @@ func main() {
 	}
 	defer func() { _ = store.Close() }()
 
+	// The identity provider is selected here and nowhere else (§7.1). Every
+	// handler below sees only the port, so switching provider is a change to
+	// IDP_TYPE rather than to any of this.
+	idpConfig, err := provider.FromEnv(os.LookupEnv)
+	if err != nil {
+		logger.Error("could not read the identity provider configuration", slog.Any("error", err))
+		os.Exit(1)
+	}
+	directory, err := provider.New(idpConfig)
+	if err != nil {
+		logger.Error("could not prepare the identity directory", slog.Any("error", err))
+		os.Exit(1)
+	}
+	verifier, err := provider.NewVerifier(idpConfig)
+	if err != nil {
+		logger.Error("could not prepare token verification", slog.Any("error", err))
+		os.Exit(1)
+	}
+
+	// One middleware, applied to every route that acts on a caller's behalf.
+	// Nothing downstream reads an identity from a request body.
+	authenticated := func(next http.Handler) http.Handler {
+		return tokenauth.Require(tokenauth.Config{Verifier: verifier, Logger: logger}, next)
+	}
+
 	handler := server.New(server.Config{
 		Dependencies: []server.Dependency{
 			{Name: "cerbos", Probe: cerbos.NewGRPCProbe(cfg.CerbosGRPCAddr)},
 			{Name: "postgres", Probe: netprobe.NewTCPProbe(cfg.PostgresAddr)},
+			{Name: "idp", Probe: netprobe.NewTCPProbe(cfg.IdPAddr)},
 		},
-		AuthzHandler: authz.NewHandler(authz.Config{
+		AuthzHandler: authenticated(authz.NewHandler(authz.Config{
 			PDP: pdp,
 			Assignments: assignments.NewResolver(assignments.ResolverConfig{
 				Matrix: assignments.NewCachingRoleMatrix(assignments.CacheConfig{
@@ -63,7 +92,15 @@ func main() {
 				Overrides: assignments.NewSeededOverrides(),
 			}),
 			Logger: logger,
-		}),
+		})),
+		DirectoryUsersHandler: authenticated(directoryapi.NewUsersHandler(directoryapi.Config{
+			Directory: directory,
+			Logger:    logger,
+		})),
+		DirectoryRolesHandler: authenticated(directoryapi.NewRolesHandler(directoryapi.Config{
+			Directory: directory,
+			Logger:    logger,
+		})),
 	})
 
 	httpServer := &http.Server{
@@ -88,6 +125,8 @@ func main() {
 		slog.String("addr", cfg.HTTPAddr),
 		slog.String("cerbos", cfg.CerbosGRPCAddr),
 		slog.String("postgres", cfg.PostgresAddr),
+		slog.String("idpType", string(idpConfig.Type)),
+		slog.String("idpIssuer", idpConfig.Issuer),
 		slog.Duration("roleMatrixCacheTtl", cfg.RoleMatrixCacheTTL),
 		slog.String("overridePrincipals", assignments.Describe()),
 	)

--- a/apps/ads/go.mod
+++ b/apps/ads/go.mod
@@ -2,7 +2,10 @@ module github.com/tishan-harischandra/cerbos-poc/apps/ads
 
 go 1.25.11
 
-require google.golang.org/grpc v1.82.1
+require (
+	github.com/tishan-harischandra/cerbos-poc/libs/canonicalid v0.0.0
+	google.golang.org/grpc v1.82.1
+)
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1 // indirect

--- a/apps/ads/go.mod
+++ b/apps/ads/go.mod
@@ -71,7 +71,9 @@ require (
 require (
 	github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore v0.0.0
 	github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient v0.0.0
+	github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory v0.0.0
 	github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext v0.0.0
+	github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier v0.0.0
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
@@ -84,3 +86,9 @@ replace github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore => ../../
 replace github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient => ../../libs/cerbosclient
 
 replace github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext => ../../libs/permissioncontext
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/canonicalid => ../../libs/canonicalid
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier => ../../libs/tokenverifier
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory => ../../libs/idpdirectory

--- a/apps/ads/internal/assignments/resolver_test.go
+++ b/apps/ads/internal/assignments/resolver_test.go
@@ -98,12 +98,12 @@ func doctorQuery(roles ...string) authz.AssignmentQuery {
 func TestASeededRoleGrantResolvesToARoleGrantedAction(t *testing.T) {
 	matrix := &recordingMatrix{
 		permissions: []assignmentstore.RolePermission{
-			grant("tenant-a", "kc:realm:patient-app:doctor", "read", true),
+			grant("tenant-a", "kc:cerbos-poc:patient-app:doctor", "read", true),
 		},
 	}
 
 	input, err := newResolver(matrix).For(context.Background(),
-		doctorQuery("kc:realm:patient-app:doctor"))
+		doctorQuery("kc:cerbos-poc:patient-app:doctor"))
 	if err != nil {
 		t.Fatalf("For: %v", err)
 	}
@@ -120,12 +120,12 @@ func TestASeededRoleGrantResolvesToARoleGrantedAction(t *testing.T) {
 func TestADisabledRolePermissionGrantsNothingAndRevokesNothing(t *testing.T) {
 	matrix := &recordingMatrix{
 		permissions: []assignmentstore.RolePermission{
-			grant("tenant-a", "kc:realm:patient-app:doctor", "delete", false),
+			grant("tenant-a", "kc:cerbos-poc:patient-app:doctor", "delete", false),
 		},
 	}
 
 	input, err := newResolver(matrix).For(context.Background(),
-		doctorQuery("kc:realm:patient-app:doctor"))
+		doctorQuery("kc:cerbos-poc:patient-app:doctor"))
 	if err != nil {
 		t.Fatalf("For: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestTheValidityWindowIsJudgedAtTheInstantOfTheDecision(t *testing.T) {
 	matrix := &recordingMatrix{}
 
 	if _, err := newResolver(matrix).For(context.Background(),
-		doctorQuery("kc:realm:patient-app:doctor")); err != nil {
+		doctorQuery("kc:cerbos-poc:patient-app:doctor")); err != nil {
 		t.Fatalf("For: %v", err)
 	}
 
@@ -166,12 +166,12 @@ func TestTheValidityWindowIsJudgedAtTheInstantOfTheDecision(t *testing.T) {
 func TestTheMatrixIsQueriedForTheCallersTenantAndResourceOnly(t *testing.T) {
 	matrix := &recordingMatrix{
 		permissions: []assignmentstore.RolePermission{
-			grant("tenant-b", "kc:realm:patient-app:doctor", "read", true),
+			grant("tenant-b", "kc:cerbos-poc:patient-app:doctor", "read", true),
 		},
 	}
 
 	input, err := newResolver(matrix).For(context.Background(),
-		doctorQuery("kc:realm:patient-app:doctor"))
+		doctorQuery("kc:cerbos-poc:patient-app:doctor"))
 	if err != nil {
 		t.Fatalf("For: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestManyRolesCostABoundedNumberOfQueries(t *testing.T) {
 	roles := make([]string, 0, 70)
 	permissions := make([]assignmentstore.RolePermission, 0, 70)
 	for index := range 70 {
-		role := fmt.Sprintf("kc:realm:patient-app:role-%02d", index)
+		role := fmt.Sprintf("kc:cerbos-poc:patient-app:role-%02d", index)
 		roles = append(roles, role)
 		permissions = append(permissions, grant("tenant-a", role, fmt.Sprintf("action-%02d", index), true))
 	}
@@ -227,7 +227,7 @@ func TestTheResolvedRevisionIsTheTenantsCurrentRevision(t *testing.T) {
 	}
 
 	input, err := newResolver(matrix).For(context.Background(),
-		doctorQuery("kc:realm:patient-app:doctor"))
+		doctorQuery("kc:cerbos-poc:patient-app:doctor"))
 	if err != nil {
 		t.Fatalf("For: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestATenantWithNoSavedMatrixResolvesToRevisionZero(t *testing.T) {
 	matrix := &recordingMatrix{}
 
 	input, err := newResolver(matrix).For(context.Background(),
-		doctorQuery("kc:realm:patient-app:doctor"))
+		doctorQuery("kc:cerbos-poc:patient-app:doctor"))
 	if err != nil {
 		t.Fatalf("For: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestATenantWithNoSavedMatrixResolvesToRevisionZero(t *testing.T) {
 func TestAPrincipalWithNoRolesResolvesToNoPermissions(t *testing.T) {
 	matrix := &recordingMatrix{
 		permissions: []assignmentstore.RolePermission{
-			grant("tenant-a", "kc:realm:patient-app:doctor", "read", true),
+			grant("tenant-a", "kc:cerbos-poc:patient-app:doctor", "read", true),
 		},
 	}
 
@@ -277,13 +277,13 @@ func TestAPrincipalWithNoRolesResolvesToNoPermissions(t *testing.T) {
 func TestABlankOrRepeatedRoleClaimNeverReachesTheQuery(t *testing.T) {
 	matrix := &recordingMatrix{}
 
-	query := doctorQuery("kc:realm:patient-app:doctor", "", "kc:realm:patient-app:doctor")
+	query := doctorQuery("kc:cerbos-poc:patient-app:doctor", "", "kc:cerbos-poc:patient-app:doctor")
 	if _, err := newResolver(matrix).For(context.Background(), query); err != nil {
 		t.Fatalf("For: %v", err)
 	}
 
 	asked := matrix.queries[0].RoleExternalIDs
-	if len(asked) != 1 || asked[0] != "kc:realm:patient-app:doctor" {
+	if len(asked) != 1 || asked[0] != "kc:cerbos-poc:patient-app:doctor" {
 		t.Errorf("the matrix was asked for %v, want the one role once", asked)
 	}
 }
@@ -295,7 +295,7 @@ func TestAnUnreachableMatrixIsAnErrorRatherThanAnEmptyResult(t *testing.T) {
 	matrix := &recordingMatrix{err: errors.New("connection refused")}
 
 	if _, err := newResolver(matrix).For(context.Background(),
-		doctorQuery("kc:realm:patient-app:doctor")); err == nil {
+		doctorQuery("kc:cerbos-poc:patient-app:doctor")); err == nil {
 		t.Fatal("For returned no error when the matrix was unreachable")
 	}
 }

--- a/apps/ads/internal/authz/authz.go
+++ b/apps/ads/internal/authz/authz.go
@@ -14,15 +14,12 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strings"
 
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/canonicalid"
 	"github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient"
 	"github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext"
 )
-
-// ReservedRolePrefix marks roles only the platform may assign. A token
-// presenting one is refused before a decision is attempted (§21).
-const ReservedRolePrefix = "sys:"
 
 // PDP is the policy decision point the handler asks.
 type PDP interface {
@@ -53,12 +50,13 @@ type Config struct {
 }
 
 // Request is the Appendix B decision request.
+//
+// It names resources and actions only. Principal, tenant, hospital and roles
+// are derived from the verified token (§16.1), so there is no field here for a
+// browser to put them in - and because unknown fields are refused, a caller
+// that tries is told rather than quietly ignored.
 type Request struct {
-	TenantID    string            `json:"tenantId"`
-	HospitalID  string            `json:"hospitalId"`
-	PrincipalID string            `json:"principalId"`
-	IdPRoles    []string          `json:"idpRoles"`
-	Resources   []RequestResource `json:"resources"`
+	Resources []RequestResource `json:"resources"`
 }
 
 // RequestResource is one resource and the actions asked about it.
@@ -97,6 +95,16 @@ func NewHandler(cfg Config) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The identity is the middleware's, never the body's. A handler
+		// reached without one has been mounted outside the authenticated
+		// routes, which is a wiring defect rather than a caller error.
+		identity, ok := tokenauth.From(r.Context())
+		if !ok {
+			logger.ErrorContext(r.Context(), "the decision endpoint was reached without a verified identity")
+			writeError(w, http.StatusUnauthorized, "a bearer token is required")
+			return
+		}
+
 		var req Request
 		decoder := json.NewDecoder(r.Body)
 		decoder.DisallowUnknownFields()
@@ -110,9 +118,13 @@ func NewHandler(cfg Config) http.Handler {
 			return
 		}
 
-		if role, found := reservedRole(req.IdPRoles); found {
-			logger.WarnContext(r.Context(), "rejected a token presenting a reserved role",
-				slog.String("principalId", req.PrincipalID),
+		// Defence in depth. Token verification already refuses a reserved
+		// role, so reaching this is a bug in the wiring rather than an
+		// attack that got through - but the synthetic role is the one claim
+		// that must never reach the PDP from outside.
+		if role, found := reservedRole(identity.Roles); found {
+			logger.ErrorContext(r.Context(), "a verified identity carried a reserved role",
+				slog.String("principalId", identity.PrincipalID),
 				slog.String("role", role))
 			writeError(w, http.StatusForbidden,
 				fmt.Sprintf("role %q is reserved for the platform", role))
@@ -121,11 +133,11 @@ func NewHandler(cfg Config) http.Handler {
 
 		checkReq := cerbosclient.Request{
 			Principal: cerbosclient.Principal{
-				ID: req.PrincipalID,
+				ID: identity.PrincipalID,
 				Attr: map[string]any{
-					"tenantId":   req.TenantID,
-					"hospitalId": req.HospitalID,
-					"idpRoles":   req.IdPRoles,
+					"tenantId":   identity.TenantID,
+					"hospitalId": identity.HospitalID,
+					"idpRoles":   identity.Roles,
 				},
 			},
 		}
@@ -133,16 +145,16 @@ func NewHandler(cfg Config) http.Handler {
 		revisions := make(map[cerbosclient.ResourceRef]int64, len(req.Resources))
 		for _, resource := range req.Resources {
 			input, err := cfg.Assignments.For(r.Context(), AssignmentQuery{
-				TenantID:     req.TenantID,
-				HospitalID:   req.HospitalID,
-				PrincipalID:  req.PrincipalID,
+				TenantID:     identity.TenantID,
+				HospitalID:   identity.HospitalID,
+				PrincipalID:  identity.PrincipalID,
 				ResourceKind: resource.Kind,
 				ResourceID:   resource.ID,
-				IdPRoles:     req.IdPRoles,
+				IdPRoles:     identity.Roles,
 			})
 			if err != nil {
 				logger.ErrorContext(r.Context(), "resolving assignments failed",
-					slog.String("principalId", req.PrincipalID),
+					slog.String("principalId", identity.PrincipalID),
 					slog.String("resourceId", resource.ID),
 					slog.Any("error", err))
 				writeError(w, http.StatusServiceUnavailable, "could not resolve permissions")
@@ -171,7 +183,7 @@ func NewHandler(cfg Config) http.Handler {
 		result, err := cfg.PDP.Check(r.Context(), checkReq)
 		if err != nil {
 			logger.ErrorContext(r.Context(), "the PDP could not be reached",
-				slog.String("principalId", req.PrincipalID),
+				slog.String("principalId", identity.PrincipalID),
 				slog.Any("error", err))
 			writeError(w, http.StatusServiceUnavailable, "could not reach the policy decision point")
 			return
@@ -199,22 +211,15 @@ func NewHandler(cfg Config) http.Handler {
 		logger.InfoContext(r.Context(), "authorization decision served",
 			slog.String("correlationId", correlationID(r)),
 			slog.String("cerbosCallId", result.CallID),
-			slog.String("principalId", req.PrincipalID),
-			slog.String("tenantId", req.TenantID))
+			slog.String("principalId", identity.PrincipalID),
+			slog.String("tenantId", identity.TenantID))
 
 		writeJSON(w, http.StatusOK, response)
 	})
 }
 
 func (r Request) validate() error {
-	switch {
-	case r.TenantID == "":
-		return errors.New("tenantId is required")
-	case r.HospitalID == "":
-		return errors.New("hospitalId is required")
-	case r.PrincipalID == "":
-		return errors.New("principalId is required")
-	case len(r.Resources) == 0:
+	if len(r.Resources) == 0 {
 		return errors.New("at least one resource is required")
 	}
 
@@ -233,7 +238,7 @@ func (r Request) validate() error {
 
 func reservedRole(roles []string) (string, bool) {
 	for _, role := range roles {
-		if strings.HasPrefix(strings.ToLower(role), ReservedRolePrefix) {
+		if canonicalid.IsReserved(role) {
 			return role, true
 		}
 	}

--- a/apps/ads/internal/authz/authz_test.go
+++ b/apps/ads/internal/authz/authz_test.go
@@ -12,15 +12,14 @@ import (
 	"testing"
 
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
 	"github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient"
 	"github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext"
 )
 
+// The request names resources and actions only. Who is asking comes from the
+// verified token, so there is nothing here a browser could use to name itself.
 const validRequest = `{
-  "tenantId": "tenant-a",
-  "hospitalId": "hospital-1",
-  "principalId": "user-123",
-  "idpRoles": ["kc:realm:patient-app:doctor"],
   "resources": [
     {
       "kind": "patient_record",
@@ -31,39 +30,67 @@ const validRequest = `{
   ]
 }`
 
-// The synthetic role is the ADS' to inject, never the caller's to claim. A token
-// presenting one must be refused before any decision is attempted (§21, ADR-003).
-func TestARequestPresentingTheSyntheticRoleIsRefusedWithoutCallingThePDP(t *testing.T) {
-	pdp := &recordingPDP{}
-	handler := authz.NewHandler(authz.Config{PDP: pdp, Assignments: emptyAssignments{}})
+const doctorRole = "kc:cerbos-poc:patient-app:doctor"
 
-	body := strings.Replace(validRequest,
-		`"idpRoles": ["kc:realm:patient-app:doctor"]`,
-		`"idpRoles": ["kc:realm:patient-app:doctor", "sys:permission-evaluator"]`, 1)
-
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, post(body))
-
-	if rec.Code != http.StatusForbidden {
-		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+// §16.1: tenant and hospital context are derived server-side. A browser that
+// sends its own is refused rather than quietly ignored, because a caller who
+// believes those fields work will keep believing it until something depends on
+// it.
+func TestIdentityFieldsInTheRequestBodyAreRefused(t *testing.T) {
+	smuggled := map[string]string{
+		"a tenant":    `{"tenantId": "tenant-b", "resources": []}`,
+		"a hospital":  `{"hospitalId": "hospital-9", "resources": []}`,
+		"a principal": `{"principalId": "user-somebody-else", "resources": []}`,
+		"roles":       `{"idpRoles": ["` + doctorRole + `"], "resources": []}`,
 	}
-	if pdp.calls != 0 {
-		t.Errorf("the PDP was called %d times for a rejected token, want 0", pdp.calls)
+
+	for name, body := range smuggled {
+		t.Run(name, func(t *testing.T) {
+			pdp := &recordingPDP{}
+			handler := authz.NewHandler(authz.Config{PDP: pdp, Assignments: emptyAssignments{}})
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, post(body))
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+			}
+			if pdp.calls != 0 {
+				t.Error("the PDP was called for a request that named its own identity")
+			}
+		})
 	}
 }
 
-func TestAnyReservedRolePrefixIsRefused(t *testing.T) {
+// The handler must be unusable without authentication, so that mounting it on
+// an unauthenticated route fails instead of answering.
+func TestARequestWithNoVerifiedIdentityIsRefusedWithoutCallingThePDP(t *testing.T) {
+	pdp := &recordingPDP{}
+	handler := authz.NewHandler(authz.Config{PDP: pdp, Assignments: emptyAssignments{}})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/authz/check",
+		strings.NewReader(validRequest)))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if pdp.calls != 0 {
+		t.Error("the PDP was called for an unauthenticated request")
+	}
+}
+
+// Defence in depth for §16.1's synthetic role rule: verification rejects such a
+// token first, so an identity carrying one means something upstream is broken -
+// and it still must not reach the PDP.
+func TestAnIdentityCarryingTheSyntheticRoleNeverReachesThePDP(t *testing.T) {
 	for _, role := range []string{"sys:permission-evaluator", "sys:anything", "SYS:UPPERCASE"} {
 		t.Run(role, func(t *testing.T) {
 			pdp := &recordingPDP{}
 			handler := authz.NewHandler(authz.Config{PDP: pdp, Assignments: emptyAssignments{}})
 
-			body := strings.Replace(validRequest,
-				`"idpRoles": ["kc:realm:patient-app:doctor"]`,
-				`"idpRoles": ["`+role+`"]`, 1)
-
 			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, post(body))
+			handler.ServeHTTP(rec, postAs(identityWithRoles(role), validRequest))
 
 			if rec.Code != http.StatusForbidden {
 				t.Errorf("status = %d for role %q, want %d", rec.Code, role, http.StatusForbidden)
@@ -175,10 +202,6 @@ func TestACallerCannotInjectItsOwnPermissionContext(t *testing.T) {
 	})
 
 	forged := `{
-  "tenantId": "tenant-a",
-  "hospitalId": "hospital-1",
-  "principalId": "user-123",
-  "idpRoles": ["kc:realm:patient-app:doctor"],
   "resources": [{
     "kind": "patient_record",
     "id": "patient-456",
@@ -276,8 +299,11 @@ func TestTheRealIdPRolesTravelAsPrincipalAttributes(t *testing.T) {
 	if !ok {
 		t.Fatalf("idpRoles attribute = %#v, want []string", pdp.request.Principal.Attr["idpRoles"])
 	}
-	if len(roles) != 1 || roles[0] != "kc:realm:patient-app:doctor" {
-		t.Errorf("idpRoles = %v, want [kc:realm:patient-app:doctor]", roles)
+	if len(roles) != 1 || roles[0] != doctorRole {
+		t.Errorf("idpRoles = %v, want [%s]", roles, doctorRole)
+	}
+	if got := pdp.request.Principal.ID; got != "user-doctor" {
+		t.Errorf("principal = %q, want the subject of the verified token", got)
 	}
 	if got := pdp.request.Principal.Attr["tenantId"]; got != "tenant-a" {
 		t.Errorf("tenantId attribute = %v, want tenant-a", got)
@@ -334,10 +360,7 @@ func TestALeafThePDPDidNotAnswerForIsDenied(t *testing.T) {
 func TestMalformedRequestsAreRejected(t *testing.T) {
 	cases := map[string]string{
 		"not JSON at all":       `{`,
-		"no tenantId":           strings.Replace(validRequest, `"tenantId": "tenant-a",`, "", 1),
-		"no hospitalId":         strings.Replace(validRequest, `"hospitalId": "hospital-1",`, "", 1),
-		"no principalId":        strings.Replace(validRequest, `"principalId": "user-123",`, "", 1),
-		"no resources":          `{"tenantId":"tenant-a","hospitalId":"hospital-1","principalId":"user-123","resources":[]}`,
+		"no resources":          `{"resources":[]}`,
 		"a resource with no id": strings.Replace(validRequest, `"id": "patient-456",`, "", 1),
 		"a resource with no actions": strings.Replace(validRequest,
 			`"actions": ["read", "update"]`, `"actions": []`, 1),
@@ -361,10 +384,26 @@ func TestMalformedRequestsAreRejected(t *testing.T) {
 	}
 }
 
+// post sends a request as the demo doctor, the way the token middleware would
+// have left it.
 func post(body string) *http.Request {
+	return postAs(identityWithRoles(doctorRole), body)
+}
+
+func postAs(identity tokenauth.Identity, body string) *http.Request {
 	req := httptest.NewRequest(http.MethodPost, "/internal/authz/check", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	return req
+	return req.WithContext(tokenauth.WithIdentity(req.Context(), identity))
+}
+
+func identityWithRoles(roles ...string) tokenauth.Identity {
+	return tokenauth.Identity{
+		PrincipalID: "user-doctor",
+		Username:    "doctor",
+		TenantID:    "tenant-a",
+		HospitalID:  "hospital-1",
+		Roles:       roles,
+	}
 }
 
 func leaf(id, action string) cerbosclient.Leaf {

--- a/apps/ads/internal/config/config.go
+++ b/apps/ads/internal/config/config.go
@@ -20,6 +20,9 @@ type Config struct {
 	// environment rather than being assembled from parts here.
 	PostgresDSN        string
 	RoleMatrixCacheTTL time.Duration
+	// IdPAddr is the host:port the readiness probe dials. Like PostgresAddr it
+	// carries no credential, because a readiness probe must not need one.
+	IdPAddr string
 }
 
 // LookupFunc mirrors os.LookupEnv so configuration stays testable.
@@ -34,6 +37,7 @@ func FromEnv(lookup LookupFunc) Config {
 		PostgresAddr:       valueOr(lookup, "POSTGRES_ADDR", "postgres:5432"),
 		PostgresDSN:        valueOr(lookup, "ASSIGNMENTSTORE_POSTGRES_DSN", ""),
 		RoleMatrixCacheTTL: durationOr(lookup, "ADS_ROLE_MATRIX_CACHE_TTL", DefaultRoleMatrixCacheTTL),
+		IdPAddr:            valueOr(lookup, "IDP_ADDR", "keycloak:8080"),
 	}
 }
 

--- a/apps/ads/internal/directoryapi/directoryapi.go
+++ b/apps/ads/internal/directoryapi/directoryapi.go
@@ -1,0 +1,189 @@
+// Package directoryapi exposes the identity directory to the Admin Console.
+//
+// The console needs to pick users and roles when it edits the permission
+// matrix, and it must do so without ever holding an identity provider
+// credential (§7.3, §16.1): the ADS holds the service account, the browser
+// holds only its own token. The handlers here depend on the provider-neutral
+// port, so the console cannot tell Keycloak from WSO2 either.
+package directoryapi
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+)
+
+// Config holds the handlers' collaborators.
+type Config struct {
+	Directory idpdirectory.IdentityDirectory
+	Logger    *slog.Logger
+}
+
+type userPayload struct {
+	ExternalID  string `json:"externalId"`
+	Username    string `json:"username"`
+	DisplayName string `json:"displayName"`
+	Email       string `json:"email"`
+	Enabled     bool   `json:"enabled"`
+}
+
+type rolePayload struct {
+	// CanonicalID is the §7.5 identifier the role-permission matrix is keyed
+	// by. The console writes it back verbatim.
+	CanonicalID string `json:"canonicalId"`
+	ExternalID  string `json:"externalId"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type pagePayload[T any] struct {
+	Items   []T  `json:"items"`
+	Offset  int  `json:"offset"`
+	Limit   int  `json:"limit"`
+	HasMore bool `json:"hasMore"`
+}
+
+// NewUsersHandler serves GET /internal/directory/users.
+func NewUsersHandler(cfg Config) http.Handler {
+	logger := loggerOf(cfg)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity, page, ok := requestContext(w, r)
+		if !ok {
+			return
+		}
+
+		found, err := cfg.Directory.SearchUsers(r.Context(),
+			idpdirectory.TenantID(identity.TenantID),
+			idpdirectory.UserSearch{Query: r.URL.Query().Get("query"), Page: page})
+		if err != nil {
+			fail(w, logger, r, "searching users", err)
+			return
+		}
+
+		items := make([]userPayload, 0, len(found.Items))
+		for _, user := range found.Items {
+			items = append(items, userPayload{
+				ExternalID:  user.ExternalID,
+				Username:    user.Username,
+				DisplayName: user.DisplayName,
+				Email:       user.Email,
+				Enabled:     user.Enabled,
+			})
+		}
+		writeJSON(w, http.StatusOK, pagePayload[userPayload]{
+			Items: items, Offset: found.Offset, Limit: found.Limit, HasMore: found.HasMore,
+		})
+	})
+}
+
+// NewRolesHandler serves GET /internal/directory/roles.
+func NewRolesHandler(cfg Config) http.Handler {
+	logger := loggerOf(cfg)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity, page, ok := requestContext(w, r)
+		if !ok {
+			return
+		}
+
+		found, err := cfg.Directory.SearchRoles(r.Context(),
+			idpdirectory.TenantID(identity.TenantID),
+			idpdirectory.RoleSearch{Query: r.URL.Query().Get("query"), Page: page})
+		if err != nil {
+			fail(w, logger, r, "searching roles", err)
+			return
+		}
+
+		items := make([]rolePayload, 0, len(found.Items))
+		for _, role := range found.Items {
+			items = append(items, rolePayload{
+				CanonicalID: role.CanonicalID,
+				ExternalID:  role.ExternalID,
+				Name:        role.Name,
+				Description: role.Description,
+			})
+		}
+		writeJSON(w, http.StatusOK, pagePayload[rolePayload]{
+			Items: items, Offset: found.Offset, Limit: found.Limit, HasMore: found.HasMore,
+		})
+	})
+}
+
+// requestContext resolves who is asking and which window they want, answering
+// the caller itself when either is unusable.
+func requestContext(w http.ResponseWriter, r *http.Request) (tokenauth.Identity, idpdirectory.PageRequest, bool) {
+	identity, ok := tokenauth.From(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "a bearer token is required")
+		return identity, idpdirectory.PageRequest{}, false
+	}
+	// A tenant in the query string is refused rather than ignored: a console
+	// built against it would appear to work until the day it was pointed at
+	// another tenant's data.
+	if r.URL.Query().Has("tenantId") {
+		writeError(w, http.StatusBadRequest,
+			"the tenant is taken from the caller's token; remove tenantId")
+		return identity, idpdirectory.PageRequest{}, false
+	}
+
+	page, err := pageOf(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return identity, page, false
+	}
+	return identity, page, true
+}
+
+// pageOf reads the window, refusing anything it cannot read rather than
+// silently substituting a default: a console paging with a broken parameter
+// would otherwise loop over page one forever.
+func pageOf(r *http.Request) (idpdirectory.PageRequest, error) {
+	page := idpdirectory.PageRequest{Limit: idpdirectory.DefaultPageLimit}
+	query := r.URL.Query()
+
+	if raw := query.Get("offset"); raw != "" {
+		offset, err := strconv.Atoi(raw)
+		if err != nil || offset < 0 {
+			return page, errors.New("offset must be a number of zero or more")
+		}
+		page.Offset = offset
+	}
+	if raw := query.Get("limit"); raw != "" {
+		limit, err := strconv.Atoi(raw)
+		if err != nil || limit <= 0 || limit > idpdirectory.MaxPageLimit {
+			return page, errors.New("limit must be between 1 and " +
+				strconv.Itoa(idpdirectory.MaxPageLimit))
+		}
+		page.Limit = limit
+	}
+	return page, nil
+}
+
+// fail logs the provider's own error and tells the caller nothing about it. The
+// message may quote the request the adapter made, which carried the service
+// account credential (§16.1).
+func fail(w http.ResponseWriter, logger *slog.Logger, r *http.Request, operation string, err error) {
+	logger.ErrorContext(r.Context(), operation+" failed", slog.Any("error", err))
+	writeError(w, http.StatusServiceUnavailable, "the identity directory could not be reached")
+}
+
+func loggerOf(cfg Config) *slog.Logger {
+	if cfg.Logger != nil {
+		return cfg.Logger
+	}
+	return slog.Default()
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/apps/ads/internal/directoryapi/directoryapi_test.go
+++ b/apps/ads/internal/directoryapi/directoryapi_test.go
@@ -1,0 +1,221 @@
+package directoryapi_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/directoryapi"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+const adminSecret = "a-secret-nobody-should-see"
+
+func TestUserSearchReturnsOnePageAndSaysWhetherThereIsAnother(t *testing.T) {
+	directory := &recordingDirectory{
+		users: idpdirectory.Page[idpdirectory.UserRef]{
+			Items: []idpdirectory.UserRef{
+				{ExternalID: "user-doctor", Username: "doctor", DisplayName: "Dana Doctor"},
+				{ExternalID: "user-auditor", Username: "auditor", DisplayName: "Alex Auditor"},
+			},
+			Offset: 20, Limit: 2, HasMore: true,
+		},
+	}
+	handler := directoryapi.NewUsersHandler(directoryapi.Config{Directory: directory})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, get("/internal/directory/users?query=do&offset=20&limit=2"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+	var body struct {
+		Items []struct {
+			ExternalID  string `json:"externalId"`
+			Username    string `json:"username"`
+			DisplayName string `json:"displayName"`
+		} `json:"items"`
+		Offset  int  `json:"offset"`
+		Limit   int  `json:"limit"`
+		HasMore bool `json:"hasMore"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+
+	if len(body.Items) != 2 {
+		t.Fatalf("items = %d, want 2", len(body.Items))
+	}
+	if body.Items[0].ExternalID != "user-doctor" {
+		t.Errorf("first item = %q, want the directory's first user", body.Items[0].ExternalID)
+	}
+	if body.Offset != 20 || body.Limit != 2 || !body.HasMore {
+		t.Errorf("page = offset %d limit %d hasMore %t, want 20/2/true",
+			body.Offset, body.Limit, body.HasMore)
+	}
+	if directory.userSearch.Page.Offset != 20 || directory.userSearch.Page.Limit != 2 {
+		t.Errorf("the directory was asked for %+v, want the caller's window", directory.userSearch.Page)
+	}
+	if directory.userSearch.Query != "do" {
+		t.Errorf("query = %q, want the caller's query", directory.userSearch.Query)
+	}
+}
+
+// The tenant is the token's, never the query string's: otherwise any
+// authenticated user could enumerate another tenant's directory.
+func TestTheTenantSearchedIsTheOneInTheToken(t *testing.T) {
+	directory := &recordingDirectory{}
+	handler := directoryapi.NewUsersHandler(directoryapi.Config{Directory: directory})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, get("/internal/directory/users?tenantId=tenant-b"))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: a tenant in the query string is refused", rec.Code, http.StatusBadRequest)
+	}
+	if directory.calls != 0 {
+		t.Error("the directory was searched for a request that named its own tenant")
+	}
+}
+
+func TestTheTenantComesFromTheVerifiedIdentity(t *testing.T) {
+	directory := &recordingDirectory{}
+	handler := directoryapi.NewUsersHandler(directoryapi.Config{Directory: directory})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, get("/internal/directory/users"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+	if directory.tenant != "tenant-a" {
+		t.Errorf("tenant searched = %q, want the token's tenant", directory.tenant)
+	}
+}
+
+func TestRoleSearchReportsCanonicalIdentifiers(t *testing.T) {
+	directory := &recordingDirectory{
+		roles: idpdirectory.Page[idpdirectory.RoleRef]{
+			Items: []idpdirectory.RoleRef{{
+				CanonicalID: "kc:cerbos-poc:patient-app:doctor",
+				ExternalID:  "58d1e7c8-role",
+				Name:        "doctor",
+			}},
+			Limit: 50,
+		},
+	}
+	handler := directoryapi.NewRolesHandler(directoryapi.Config{Directory: directory})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, get("/internal/directory/roles"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+	// The canonical identifier is what the role-permission matrix is keyed by,
+	// so a console that could not read it could not write a matrix row.
+	if !strings.Contains(rec.Body.String(), "kc:cerbos-poc:patient-app:doctor") {
+		t.Errorf("response carries no canonical identifier: %s", rec.Body)
+	}
+}
+
+// §16.1 and §7.4: the IdP machine credential must never reach a browser. The
+// realistic leak is an error path, so the failing case is the one asserted.
+func TestADirectoryFailureNeverEchoesTheAdminCredential(t *testing.T) {
+	directory := &recordingDirectory{
+		err: fmt.Errorf("keycloak rejected the request for client_secret=%s", adminSecret),
+	}
+	handler := directoryapi.NewUsersHandler(directoryapi.Config{Directory: directory})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, get("/internal/directory/users"))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if strings.Contains(rec.Body.String(), adminSecret) {
+		t.Errorf("the response echoed the admin credential: %s", rec.Body)
+	}
+}
+
+func TestAnUnauthenticatedRequestIsRefused(t *testing.T) {
+	directory := &recordingDirectory{}
+	handler := directoryapi.NewUsersHandler(directoryapi.Config{Directory: directory})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/internal/directory/users", nil))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if directory.calls != 0 {
+		t.Error("the directory was searched for an unauthenticated request")
+	}
+}
+
+func TestAnUnreadablePageWindowIsRefusedRatherThanGuessed(t *testing.T) {
+	for _, query := range []string{"?limit=all", "?offset=-1", "?limit=0"} {
+		t.Run(query, func(t *testing.T) {
+			directory := &recordingDirectory{}
+			handler := directoryapi.NewUsersHandler(directoryapi.Config{Directory: directory})
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, get("/internal/directory/users"+query))
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+func get(target string) *http.Request {
+	request := httptest.NewRequest(http.MethodGet, target, nil)
+	return request.WithContext(tokenauth.WithIdentity(request.Context(), tokenauth.Identity{
+		PrincipalID: "user-admin",
+		TenantID:    "tenant-a",
+		HospitalID:  "hospital-1",
+		Roles:       []string{"kc:cerbos-poc:patient-app:administrator"},
+	}))
+}
+
+type recordingDirectory struct {
+	calls      int
+	tenant     idpdirectory.TenantID
+	userSearch idpdirectory.UserSearch
+	roleSearch idpdirectory.RoleSearch
+
+	users idpdirectory.Page[idpdirectory.UserRef]
+	roles idpdirectory.Page[idpdirectory.RoleRef]
+	err   error
+}
+
+func (d *recordingDirectory) SearchUsers(_ context.Context, tenant idpdirectory.TenantID, query idpdirectory.UserSearch) (idpdirectory.Page[idpdirectory.UserRef], error) {
+	d.calls++
+	d.tenant, d.userSearch = tenant, query
+	return d.users, d.err
+}
+
+func (d *recordingDirectory) SearchRoles(_ context.Context, tenant idpdirectory.TenantID, query idpdirectory.RoleSearch) (idpdirectory.Page[idpdirectory.RoleRef], error) {
+	d.calls++
+	d.tenant, d.roleSearch = tenant, query
+	return d.roles, d.err
+}
+
+func (d *recordingDirectory) GetUser(context.Context, idpdirectory.TenantID, string) (idpdirectory.UserRef, error) {
+	return idpdirectory.UserRef{}, idpdirectory.ErrNotFound
+}
+
+func (d *recordingDirectory) GetRole(context.Context, idpdirectory.TenantID, string) (idpdirectory.RoleRef, error) {
+	return idpdirectory.RoleRef{}, idpdirectory.ErrNotFound
+}
+
+func (d *recordingDirectory) ResolveRuntimeRoles(_ context.Context, token tokenverifier.VerifiedToken, _ idpdirectory.TenantID) ([]string, error) {
+	return token.Roles, nil
+}

--- a/apps/ads/internal/server/server.go
+++ b/apps/ads/internal/server/server.go
@@ -30,7 +30,17 @@ type Config struct {
 	// AuthzHandler serves POST /internal/authz/check. When nil the route is
 	// not registered at all, so a misconfigured build fails with 404 rather
 	// than answering authorization questions from a stub.
+	//
+	// Every handler below arrives already wrapped in the token middleware.
+	// Authentication is not applied here: a route that forgot it would then
+	// look identical to one that did not need it.
 	AuthzHandler http.Handler
+
+	// DirectoryUsersHandler and DirectoryRolesHandler serve the Admin
+	// Console's identity directory reads. Nil when no identity provider is
+	// configured, in which case the routes do not exist.
+	DirectoryUsersHandler http.Handler
+	DirectoryRolesHandler http.Handler
 }
 
 // New builds the ADS HTTP handler.
@@ -41,6 +51,12 @@ func New(cfg Config) http.Handler {
 	})
 	if cfg.AuthzHandler != nil {
 		mux.Handle("POST /internal/authz/check", cfg.AuthzHandler)
+	}
+	if cfg.DirectoryUsersHandler != nil {
+		mux.Handle("GET /internal/directory/users", cfg.DirectoryUsersHandler)
+	}
+	if cfg.DirectoryRolesHandler != nil {
+		mux.Handle("GET /internal/directory/roles", cfg.DirectoryRolesHandler)
 	}
 
 	timeout := cfg.ReadinessTimeout

--- a/apps/ads/internal/tokenauth/tokenauth.go
+++ b/apps/ads/internal/tokenauth/tokenauth.go
@@ -1,0 +1,118 @@
+// Package tokenauth turns a bearer token into the identity a handler may act
+// on.
+//
+// It is the only place the ADS decides who a caller is. Handlers read the
+// identity from the request context, so no handler can be written that trusts a
+// principal, tenant or role that arrived in a request body (§16.1: tenant and
+// hospital context are derived server-side).
+package tokenauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+// Identity is who the caller is, as the identity provider attested.
+type Identity struct {
+	PrincipalID string
+	Username    string
+	TenantID    string
+	HospitalID  string
+	// Roles are canonical §7.5 identifiers, ready to be matched against the
+	// role-permission matrix.
+	Roles []string
+}
+
+// Verifier is the token verification this middleware delegates to.
+type Verifier interface {
+	Verify(ctx context.Context, raw string) (tokenverifier.VerifiedToken, error)
+}
+
+// Config holds the middleware's collaborators.
+type Config struct {
+	Verifier Verifier
+	Logger   *slog.Logger
+}
+
+type contextKey struct{}
+
+// From returns the identity established for this request, if any.
+func From(ctx context.Context) (Identity, bool) {
+	identity, ok := ctx.Value(contextKey{}).(Identity)
+	return identity, ok
+}
+
+// WithIdentity puts an identity in a context. It exists for tests and for
+// callers that have already verified a token; the middleware is the only
+// production path.
+func WithIdentity(ctx context.Context, identity Identity) context.Context {
+	return context.WithValue(ctx, contextKey{}, identity)
+}
+
+const bearerPrefix = "Bearer "
+
+// Require verifies the caller's bearer token and passes the resulting identity
+// to next. A request that fails verification never reaches next.
+func Require(cfg Config, next http.Handler) http.Handler {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, ok := bearerToken(r)
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "a bearer token is required")
+			return
+		}
+
+		verified, err := cfg.Verifier.Verify(r.Context(), raw)
+		if err != nil {
+			// The reserved role is not a malformed token, it is an attempt to
+			// be the platform. Separating the status is what makes it
+			// alertable rather than lost among expired tokens.
+			if errors.Is(err, tokenverifier.ErrReservedRole) {
+				logger.WarnContext(r.Context(), "rejected a token presenting a reserved role",
+					slog.Any("error", err))
+				writeError(w, http.StatusForbidden, "the token carries a role reserved for the platform")
+				return
+			}
+			// Which check failed goes to the log, not to the caller: telling
+			// an unauthenticated caller whether the signature or the audience
+			// was wrong is telling them how to get closer.
+			logger.WarnContext(r.Context(), "rejected a bearer token", slog.Any("error", err))
+			writeError(w, http.StatusUnauthorized, "the bearer token was refused")
+			return
+		}
+
+		identity := Identity{
+			PrincipalID: verified.Subject,
+			Username:    verified.Username,
+			TenantID:    verified.TenantID,
+			HospitalID:  verified.HospitalID,
+			Roles:       verified.Roles,
+		}
+		next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), identity)))
+	})
+}
+
+func bearerToken(r *http.Request) (string, bool) {
+	header := r.Header.Get("Authorization")
+	if len(header) <= len(bearerPrefix) || !strings.EqualFold(header[:len(bearerPrefix)], bearerPrefix) {
+		return "", false
+	}
+	token := strings.TrimSpace(header[len(bearerPrefix):])
+	return token, token != ""
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}

--- a/apps/ads/internal/tokenauth/tokenauth_test.go
+++ b/apps/ads/internal/tokenauth/tokenauth_test.go
@@ -1,0 +1,141 @@
+package tokenauth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+// The identity a handler acts on comes from the token and from nothing else.
+func TestAVerifiedTokenPutsTheIdentityInTheRequestContext(t *testing.T) {
+	var seen tokenauth.Identity
+	handler := tokenauth.Require(tokenauth.Config{Verifier: verifier{token: tokenverifier.VerifiedToken{
+		Subject:    "user-doctor",
+		TenantID:   "tenant-a",
+		HospitalID: "hospital-1",
+		Roles:      []string{"kc:cerbos-poc:patient-app:doctor"},
+	}}}, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		identity, ok := tokenauth.From(r.Context())
+		if !ok {
+			t.Error("the handler saw no identity")
+		}
+		seen = identity
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, authorized("a-token"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if seen.PrincipalID != "user-doctor" {
+		t.Errorf("PrincipalID = %q, want %q", seen.PrincipalID, "user-doctor")
+	}
+	if seen.TenantID != "tenant-a" || seen.HospitalID != "hospital-1" {
+		t.Errorf("tenant/hospital = %q/%q, want tenant-a/hospital-1", seen.TenantID, seen.HospitalID)
+	}
+	if len(seen.Roles) != 1 || seen.Roles[0] != "kc:cerbos-poc:patient-app:doctor" {
+		t.Errorf("Roles = %v, want the token's canonical roles", seen.Roles)
+	}
+}
+
+func TestARequestWithNoBearerTokenIsUnauthorized(t *testing.T) {
+	requests := map[string]*http.Request{
+		"no Authorization header": httptest.NewRequest(http.MethodPost, "/internal/authz/check", nil),
+		"a scheme nobody agreed to": withHeader(
+			httptest.NewRequest(http.MethodPost, "/internal/authz/check", nil),
+			"Basic dXNlcjpwYXNz"),
+		"an empty bearer token": withHeader(
+			httptest.NewRequest(http.MethodPost, "/internal/authz/check", nil), "Bearer "),
+	}
+
+	for name, request := range requests {
+		t.Run(name, func(t *testing.T) {
+			handler := tokenauth.Require(
+				tokenauth.Config{Verifier: verifier{token: tokenverifier.VerifiedToken{Subject: "user-doctor"}}},
+				refuseToRun(t))
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, request)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+			}
+		})
+	}
+}
+
+func TestARejectedTokenNeverReachesTheHandler(t *testing.T) {
+	handler := tokenauth.Require(
+		tokenauth.Config{Verifier: verifier{err: tokenverifier.ErrExpired}},
+		refuseToRun(t))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, authorized("an-expired-token"))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	// The caller learns that the token was refused, not which check refused
+	// it: the detail belongs in the service log, not in a probe's response.
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if strings.Contains(strings.ToLower(body["error"]), "expired") {
+		t.Errorf("the response told the caller which check failed: %q", body["error"])
+	}
+}
+
+// §16.1: a token claiming the synthetic role is a caller trying to be the
+// platform. It is refused, and the refusal is distinguishable from a merely
+// invalid token so it can be alerted on.
+func TestATokenClaimingTheSyntheticRoleIsForbiddenRatherThanUnauthorized(t *testing.T) {
+	handler := tokenauth.Require(
+		tokenauth.Config{Verifier: verifier{err: tokenverifier.ErrReservedRole}},
+		refuseToRun(t))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, authorized("a-forged-token"))
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestAHandlerReadingTheContextWithoutMiddlewareGetsNoIdentity(t *testing.T) {
+	if _, ok := tokenauth.From(context.Background()); ok {
+		t.Error("an identity appeared in a context nothing authenticated")
+	}
+}
+
+type verifier struct {
+	token tokenverifier.VerifiedToken
+	err   error
+}
+
+func (v verifier) Verify(context.Context, string) (tokenverifier.VerifiedToken, error) {
+	return v.token, v.err
+}
+
+func authorized(token string) *http.Request {
+	return withHeader(httptest.NewRequest(http.MethodPost, "/internal/authz/check", nil), "Bearer "+token)
+}
+
+func withHeader(r *http.Request, authorization string) *http.Request {
+	r.Header.Set("Authorization", authorization)
+	return r
+}
+
+func refuseToRun(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("the handler ran for a request that should never have been authenticated")
+	})
+}

--- a/deploy/cerbos/policies/tests/patient_record_schema_test.yaml
+++ b/deploy/cerbos/policies/tests/patient_record_schema_test.yaml
@@ -18,7 +18,7 @@ principals:
       tenantId: tenant-a
       hospitalId: hospital-1
       idpRoles:
-        - "kc:realm:patient-app:doctor"
+        - "kc:cerbos-poc:patient-app:doctor"
 
   principal_without_tenant:
     id: idp-user-124

--- a/deploy/cerbos/policies/tests/patient_record_test.yaml
+++ b/deploy/cerbos/policies/tests/patient_record_test.yaml
@@ -16,7 +16,7 @@ principals:
       tenantId: tenant-a
       hospitalId: hospital-1
       idpRoles:
-        - "kc:realm:patient-app:doctor"
+        - "kc:cerbos-poc:patient-app:doctor"
 
   doctor_of_other_tenant:
     id: idp-user-999
@@ -26,7 +26,7 @@ principals:
       tenantId: tenant-b
       hospitalId: hospital-1
       idpRoles:
-        - "kc:realm:patient-app:doctor"
+        - "kc:cerbos-poc:patient-app:doctor"
 
   doctor_of_other_hospital:
     id: idp-user-888
@@ -36,7 +36,7 @@ principals:
       tenantId: tenant-a
       hospitalId: hospital-2
       idpRoles:
-        - "kc:realm:patient-app:doctor"
+        - "kc:cerbos-poc:patient-app:doctor"
 
 resources:
   # Row 2: mandatory passes, user revokes, role grants.

--- a/deploy/keycloak/realm-cerbos-poc.json
+++ b/deploy/keycloak/realm-cerbos-poc.json
@@ -1,0 +1,197 @@
+{
+  "realm": "cerbos-poc",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "accessTokenLifespan": 900,
+  "clients": [
+    {
+      "clientId": "patient-app",
+      "name": "Patient application",
+      "description": "The browser-facing client. Public, so it holds no secret, and it has no administrative permission of any kind.",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": ["http://localhost:4200/*", "http://127.0.0.1:4200/*"],
+      "webOrigins": ["http://localhost:4200", "http://127.0.0.1:4200"],
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:4200/*"
+      },
+      "defaultClientScopes": ["web-origins", "profile", "roles", "email"],
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "patient-app",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "tenant",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "config": {
+            "user.attribute": "tenant_id",
+            "claim.name": "tenant_id",
+            "jsonType.label": "String",
+            "access.token.claim": "true",
+            "id.token.claim": "true"
+          }
+        },
+        {
+          "name": "hospital",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "config": {
+            "user.attribute": "hospital_id",
+            "claim.name": "hospital_id",
+            "jsonType.label": "String",
+            "access.token.claim": "true",
+            "id.token.claim": "true"
+          }
+        }
+      ],
+      "roles": []
+    },
+    {
+      "clientId": "authorization-admin-service",
+      "name": "Authorization admin service",
+      "description": "The confidential service account the ADS reads the directory with. It is never used by a browser and never issued to one (7.3).",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "secret": "admin-service-secret",
+      "redirectUris": [],
+      "webOrigins": []
+    }
+  ],
+  "roles": {
+    "client": {
+      "patient-app": [
+        {
+          "name": "doctor",
+          "description": "Treating clinician"
+        },
+        {
+          "name": "auditor",
+          "description": "Read-only auditor"
+        },
+        {
+          "name": "clerk",
+          "description": "Records clerk"
+        },
+        {
+          "name": "administrator",
+          "description": "Authorization administrator"
+        }
+      ]
+    }
+  },
+  "users": [
+    {
+      "id": "user-doctor",
+      "username": "user-doctor",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dana",
+      "lastName": "Doctor",
+      "email": "dana.doctor@example.test",
+      "attributes": {
+        "tenant_id": ["tenant-a"],
+        "hospital_id": ["hospital-1"]
+      },
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "clientRoles": { "patient-app": ["doctor"] }
+    },
+    {
+      "id": "user-doctor-revoked",
+      "username": "user-doctor-revoked",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Ravi",
+      "lastName": "Doctor",
+      "email": "ravi.doctor@example.test",
+      "attributes": {
+        "tenant_id": ["tenant-a"],
+        "hospital_id": ["hospital-1"]
+      },
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "clientRoles": { "patient-app": ["doctor"] }
+    },
+    {
+      "id": "user-auditor",
+      "username": "user-auditor",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alex",
+      "lastName": "Auditor",
+      "email": "alex.auditor@example.test",
+      "attributes": {
+        "tenant_id": ["tenant-a"],
+        "hospital_id": ["hospital-1"]
+      },
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "clientRoles": { "patient-app": ["auditor"] }
+    },
+    {
+      "id": "user-clerk-granted",
+      "username": "user-clerk-granted",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Chris",
+      "lastName": "Clerk",
+      "email": "chris.clerk@example.test",
+      "attributes": {
+        "tenant_id": ["tenant-a"],
+        "hospital_id": ["hospital-1"]
+      },
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "clientRoles": { "patient-app": ["clerk"] }
+    },
+    {
+      "id": "user-unassigned",
+      "username": "user-unassigned",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Uma",
+      "lastName": "Unassigned",
+      "email": "uma.unassigned@example.test",
+      "attributes": {
+        "tenant_id": ["tenant-a"],
+        "hospital_id": ["hospital-1"]
+      },
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "clientRoles": {}
+    },
+    {
+      "id": "user-admin",
+      "username": "user-admin",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Ada",
+      "lastName": "Admin",
+      "email": "ada.admin@example.test",
+      "attributes": {
+        "tenant_id": ["tenant-a"],
+        "hospital_id": ["hospital-1"]
+      },
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "clientRoles": { "patient-app": ["administrator"] }
+    },
+    {
+      "username": "service-account-authorization-admin-service",
+      "enabled": true,
+      "serviceAccountClientId": "authorization-admin-service",
+      "clientRoles": {
+        "realm-management": ["view-users", "query-users", "view-clients", "view-realm"]
+      }
+    }
+  ]
+}

--- a/deploy/keycloak/realm-cerbos-poc.json
+++ b/deploy/keycloak/realm-cerbos-poc.json
@@ -59,6 +59,30 @@
       "roles": []
     },
     {
+      "clientId": "reporting-app",
+      "name": "Reporting application",
+      "description": "A second client, present so the audience check has something real to reject. A token minted here is valid, signed by this realm, and still not for the ADS.",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [],
+      "webOrigins": [],
+      "defaultClientScopes": ["web-origins", "profile", "roles", "email"],
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "reporting-app",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
       "clientId": "authorization-admin-service",
       "name": "Authorization admin service",
       "description": "The confidential service account the ADS reads the directory with. It is never used by a browser and never issued to one (7.3).",
@@ -90,6 +114,10 @@
         {
           "name": "administrator",
           "description": "Authorization administrator"
+        },
+        {
+          "name": "sys:forged-evaluator",
+          "description": "A hostile fixture. The sys: prefix is the platform's, so a token carrying this role must be rejected outright (16.1). It exists to make that rejection provable end to end rather than only in a unit test."
         }
       ]
     }
@@ -184,6 +212,21 @@
       },
       "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
       "clientRoles": { "patient-app": ["administrator"] }
+    },
+    {
+      "id": "user-forger",
+      "username": "user-forger",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Mal",
+      "lastName": "Forger",
+      "email": "mal.forger@example.test",
+      "attributes": {
+        "tenant_id": ["tenant-a"],
+        "hospital_id": ["hospital-1"]
+      },
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "clientRoles": { "patient-app": ["sys:forged-evaluator"] }
     },
     {
       "username": "service-account-authorization-admin-service",

--- a/deploy/keycloak/realm-cerbos-poc.json
+++ b/deploy/keycloak/realm-cerbos-poc.json
@@ -20,7 +20,7 @@
       "attributes": {
         "post.logout.redirect.uris": "http://localhost:4200/*"
       },
-      "defaultClientScopes": ["web-origins", "profile", "roles", "email"],
+      "defaultClientScopes": ["basic", "web-origins", "profile", "roles", "email"],
       "protocolMappers": [
         {
           "name": "audience",
@@ -55,8 +55,7 @@
             "id.token.claim": "true"
           }
         }
-      ],
-      "roles": []
+      ]
     },
     {
       "clientId": "reporting-app",
@@ -69,7 +68,7 @@
       "serviceAccountsEnabled": false,
       "redirectUris": [],
       "webOrigins": [],
-      "defaultClientScopes": ["web-origins", "profile", "roles", "email"],
+      "defaultClientScopes": ["basic", "web-origins", "profile", "roles", "email"],
       "protocolMappers": [
         {
           "name": "audience",

--- a/deploy/keycloak/realm-other-issuer.json
+++ b/deploy/keycloak/realm-other-issuer.json
@@ -1,0 +1,44 @@
+{
+  "realm": "other-issuer",
+  "displayName": "Wrong issuer fixture: genuine tokens the ADS must still refuse",
+  "enabled": true,
+  "sslRequired": "none",
+  "clients": [
+    {
+      "clientId": "patient-app",
+      "name": "A client with the same name in a different realm",
+      "description": "Tokens from here are genuine - real user, valid signature, right audience - and must still be refused, because a key set the ADS does not trust signed them. A malformed token could not prove that.",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [],
+      "webOrigins": [],
+      "defaultClientScopes": ["basic", "web-origins", "profile", "roles", "email"],
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "patient-app",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "user-doctor",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dana",
+      "lastName": "Elsewhere",
+      "email": "dana.doctor@elsewhere.test",
+      "requiredActions": [],
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }]
+    }
+  ]
+}

--- a/deploy/secrets/idp-admin-credentials
+++ b/deploy/secrets/idp-admin-credentials
@@ -1,0 +1,1 @@
+admin-service-secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,39 @@ services:
       timeout: 5s
       retries: 20
 
+  # Keycloak is the only service a browser authenticates against, so unlike the
+  # PDP and the database it is published to the host: an OIDC redirect the user
+  # cannot reach is not a login. Hostname and port are pinned so the issuer in a
+  # token is the same string whether it was minted for the browser or read by
+  # the ADS - a mismatch there rejects every token with a confusing message.
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.4
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-change-me}
+      KC_HTTP_ENABLED: "true"
+      KC_HTTP_PORT: "8080"
+      KC_HOSTNAME: ${KEYCLOAK_HOSTNAME:-http://localhost:8081}
+      KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"
+      KC_HEALTH_ENABLED: "true"
+    volumes:
+      - ./deploy/keycloak/realm-cerbos-poc.json:/opt/keycloak/data/import/realm-cerbos-poc.json:ro
+    ports:
+      - "${KEYCLOAK_PORT:-8081}:8080"
+    # The image ships no curl or wget, so readiness is probed over bash's own
+    # /dev/tcp against the management port health endpoint.
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "exec 3<>/dev/tcp/127.0.0.1/9000 && printf 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && grep -q '\"status\": \"UP\"' <&3",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 40
+      start_period: 20s
+
   ads:
     build:
       context: .
@@ -71,10 +104,31 @@ services:
       POSTGRES_ADDR: "postgres:5432"
       ASSIGNMENTSTORE_POSTGRES_DSN: "postgres://${POSTGRES_USER:-cerbos_poc}:${POSTGRES_PASSWORD:-change-me}@postgres:5432/${POSTGRES_DB:-cerbos_poc}?sslmode=disable"
       ADS_ROLE_MATRIX_CACHE_TTL: "${ADS_ROLE_MATRIX_CACHE_TTL:-30s}"
+      # §7.1's installation selection, in full. Changing IDP_TYPE to WSO2_IS
+      # selects the other adapter with no image rebuilt.
+      IDP_TYPE: "${IDP_TYPE:-KEYCLOAK}"
+      IDP_BASE_URL: "http://keycloak:8080"
+      IDP_ADDR: "keycloak:8080"
+      IDP_REALM: "${IDP_REALM:-cerbos-poc}"
+      IDP_TENANT_ID: "${IDP_TENANT_ID:-tenant-a}"
+      IDP_TENANT_MAPPING_MODE: "${IDP_TENANT_MAPPING_MODE:-CLAIM}"
+      IDP_ROLE_SOURCE: "${IDP_ROLE_SOURCE:-CLIENT}"
+      IDP_CLIENT_ID: "${IDP_CLIENT_ID:-patient-app}"
+      IDP_SERVICE_CLIENT_ID: "${IDP_SERVICE_CLIENT_ID:-authorization-admin-service}"
+      # The issuer is what the browser's token claims, so it is the published
+      # address rather than the compose-internal one.
+      IDP_ISSUER: "${KEYCLOAK_HOSTNAME:-http://localhost:8081}/realms/${IDP_REALM:-cerbos-poc}"
+      # By reference, never by value: a secret in an environment variable is
+      # visible in `docker inspect` and inherited by every child process.
+      IDP_CREDENTIALS_SECRET_REF: "/run/secrets/idp-admin-credentials"
+    volumes:
+      - ./deploy/secrets/idp-admin-credentials:/run/secrets/idp-admin-credentials:ro
     depends_on:
       cerbos:
         condition: service_healthy
       postgres:
+        condition: service_healthy
+      keycloak:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8080/readyz"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       KC_HEALTH_ENABLED: "true"
     volumes:
       - ./deploy/keycloak/realm-cerbos-poc.json:/opt/keycloak/data/import/realm-cerbos-poc.json:ro
+      - ./deploy/keycloak/realm-other-issuer.json:/opt/keycloak/data/import/realm-other-issuer.json:ro
     ports:
       - "${KEYCLOAK_PORT:-8081}:8080"
     # The image ships no curl or wget, so readiness is probed over bash's own

--- a/go.work
+++ b/go.work
@@ -1,10 +1,11 @@
 go 1.25.11
 
 use (
-	./apps/ads
-	./libs/assignmentstore
-	./libs/canonicalid
-	./libs/cerbosclient
-	./libs/permissioncontext
-	./tests/architecture
+./apps/ads
+./libs/assignmentstore
+./libs/canonicalid
+./libs/cerbosclient
+./libs/permissioncontext
+./libs/tokenverifier
+./tests/architecture
 )

--- a/go.work
+++ b/go.work
@@ -5,6 +5,7 @@ use (
 ./libs/assignmentstore
 ./libs/canonicalid
 ./libs/cerbosclient
+./libs/idpdirectory
 ./libs/permissioncontext
 ./libs/tokenverifier
 ./tests/architecture

--- a/go.work
+++ b/go.work
@@ -3,6 +3,7 @@ go 1.25.11
 use (
 	./apps/ads
 	./libs/assignmentstore
+	./libs/canonicalid
 	./libs/cerbosclient
 	./libs/permissioncontext
 	./tests/architecture

--- a/libs/assignmentstore/demoseed/demoseed.go
+++ b/libs/assignmentstore/demoseed/demoseed.go
@@ -36,8 +36,8 @@ const (
 	// them. §7.5 is explicit that token-to-role normalisation must produce the
 	// same identifiers the matrix is keyed by, so a second spelling anywhere
 	// would silently resolve to no permissions at all.
-	DoctorRole  = "kc:realm:patient-app:doctor"
-	AuditorRole = "kc:realm:patient-app:auditor"
+	DoctorRole  = "kc:cerbos-poc:patient-app:doctor"
+	AuditorRole = "kc:cerbos-poc:patient-app:auditor"
 	// ResourceKey is the one resource the root policy tree covers so far.
 	ResourceKey = "patient_record"
 	// Revision is the demo tenant's permission revision, reported alongside

--- a/libs/canonicalid/canonicalid.go
+++ b/libs/canonicalid/canonicalid.go
@@ -1,0 +1,47 @@
+// Package canonicalid builds the §7.5 canonical role identifiers.
+//
+// It exists so there is exactly one place that knows the spelling. Token
+// normalisation and the identity directory adapter both produce identifiers
+// that are compared against the role-permission matrix, and §7.5 requires them
+// to be identical. Two implementations of the same format would agree until the
+// day one of them changed, and the symptom would be a principal that silently
+// resolves to no permissions rather than an error anybody could see.
+package canonicalid
+
+import "strings"
+
+// RealmRoleSegment is the client segment used for a Keycloak realm role, which
+// belongs to the realm rather than to any client.
+const RealmRoleSegment = "realm"
+
+// ReservedPrefix marks the synthetic roles only the platform may assign. §16.1
+// requires a token carrying one to be rejected rather than merely ignored.
+const ReservedPrefix = "sys:"
+
+// KeycloakRealmRole renders `kc:<realm>:realm:<role-id>`.
+func KeycloakRealmRole(realm, roleID string) string {
+	return KeycloakClientRole(realm, RealmRoleSegment, roleID)
+}
+
+// KeycloakClientRole renders `kc:<realm>:<client-id>:<role-id>`.
+//
+// For this prototype the role-id segment carries the Keycloak role *name*.
+// Access tokens carry role names and nothing else, so a UUID-based identifier
+// could never be reconstructed from a token without a directory round trip on
+// the decision hot path. §7.3's preference for stable IDs is therefore honoured
+// by the directory adapter's display metadata, not by this identifier.
+func KeycloakClientRole(realm, clientID, roleID string) string {
+	return strings.Join([]string{"kc", realm, clientID, roleID}, ":")
+}
+
+// WSO2Role renders `wso2:<tenant-domain>:<role-id>`.
+func WSO2Role(tenantDomain, roleID string) string {
+	return strings.Join([]string{"wso2", tenantDomain, roleID}, ":")
+}
+
+// IsReserved reports whether a role is one the platform reserves for itself.
+// The comparison is case-insensitive because the check is a security control:
+// a claim of `SYS:permission-evaluator` is the same attempt as `sys:`.
+func IsReserved(role string) bool {
+	return strings.HasPrefix(strings.ToLower(role), ReservedPrefix)
+}

--- a/libs/canonicalid/canonicalid_test.go
+++ b/libs/canonicalid/canonicalid_test.go
@@ -1,0 +1,71 @@
+package canonicalid_test
+
+import (
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/canonicalid"
+)
+
+// §7.5 fixes the three spellings. They are the join between a token and the
+// role-permission matrix, so the formats are asserted literally: a change here
+// silently resolves every principal to no permissions at all.
+func TestTheCanonicalFormatsAreTheOnesSection75Specifies(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "a Keycloak realm role",
+			got:  canonicalid.KeycloakRealmRole("cerbos-poc", "auditor"),
+			want: "kc:cerbos-poc:realm:auditor",
+		},
+		{
+			name: "a Keycloak client role",
+			got:  canonicalid.KeycloakClientRole("cerbos-poc", "patient-app", "doctor"),
+			want: "kc:cerbos-poc:patient-app:doctor",
+		},
+		{
+			name: "a WSO2 role or group",
+			got:  canonicalid.WSO2Role("carbon.super", "doctor"),
+			want: "wso2:carbon.super:doctor",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.got != test.want {
+				t.Errorf("= %q, want %q", test.got, test.want)
+			}
+		})
+	}
+}
+
+func TestReservedRolesAreRecognisedWhateverTheirCase(t *testing.T) {
+	reserved := []string{
+		"sys:permission-evaluator",
+		"sys:anything",
+		"SYS:UPPERCASE",
+		"Sys:Mixed",
+	}
+	for _, role := range reserved {
+		if !canonicalid.IsReserved(role) {
+			t.Errorf("IsReserved(%q) = false, want true", role)
+		}
+	}
+}
+
+func TestAnOrdinaryRoleIsNotReserved(t *testing.T) {
+	ordinary := []string{
+		"kc:cerbos-poc:patient-app:doctor",
+		"kc:cerbos-poc:realm:auditor",
+		"wso2:carbon.super:doctor",
+		"doctor",
+		"",
+	}
+	for _, role := range ordinary {
+		if canonicalid.IsReserved(role) {
+			t.Errorf("IsReserved(%q) = true, want false", role)
+		}
+	}
+}

--- a/libs/canonicalid/go.mod
+++ b/libs/canonicalid/go.mod
@@ -1,0 +1,3 @@
+module github.com/tishan-harischandra/cerbos-poc/libs/canonicalid
+
+go 1.25

--- a/libs/cerbosclient/cerbosclient_test.go
+++ b/libs/cerbosclient/cerbosclient_test.go
@@ -250,7 +250,7 @@ func TestStringSliceAttributesSurviveEncoding(t *testing.T) {
 		Principal: cerbosclient.Principal{
 			ID: "user-123",
 			Attr: map[string]any{
-				"idpRoles": []string{"kc:realm:patient-app:doctor", "kc:realm:patient-app:nurse"},
+				"idpRoles": []string{"kc:cerbos-poc:patient-app:doctor", "kc:cerbos-poc:patient-app:nurse"},
 			},
 		},
 		Resources: []cerbosclient.ResourceCheck{{
@@ -273,7 +273,7 @@ func TestStringSliceAttributesSurviveEncoding(t *testing.T) {
 	if len(values) != 2 {
 		t.Fatalf("idpRoles arrived as %v, want a two-element list", roles)
 	}
-	if got := values[0].GetStringValue(); got != "kc:realm:patient-app:doctor" {
+	if got := values[0].GetStringValue(); got != "kc:cerbos-poc:patient-app:doctor" {
 		t.Errorf("idpRoles[0] = %q, want the role the caller presented", got)
 	}
 }

--- a/libs/idpdirectory/go.mod
+++ b/libs/idpdirectory/go.mod
@@ -1,0 +1,12 @@
+module github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory
+
+go 1.25
+
+require (
+	github.com/tishan-harischandra/cerbos-poc/libs/canonicalid v0.0.0
+	github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier v0.0.0
+)
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/canonicalid => ../canonicalid
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier => ../tokenverifier

--- a/libs/idpdirectory/keycloak/keycloak.go
+++ b/libs/idpdirectory/keycloak/keycloak.go
@@ -1,0 +1,426 @@
+// Package keycloak implements the identity directory port against Keycloak's
+// Admin REST API (§7.3).
+//
+// Nothing outside the provider factory may import this package: consumers see
+// only idpdirectory.IdentityDirectory, so replacing Keycloak is a configuration
+// change. An architecture test enforces that.
+//
+// The adapter authenticates as a dedicated confidential service account and
+// never accepts, forwards or echoes a browser's credentials (§7.3, §16.1).
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+// DefaultTimeout bounds one Admin REST call. The Admin Console is a human
+// waiting on a page, so a hung directory has to fail rather than hang.
+const DefaultTimeout = 10 * time.Second
+
+// tokenRefreshMargin renews the service account token before it expires, so a
+// call never fails on a token that expired mid-flight.
+const tokenRefreshMargin = 30 * time.Second
+
+// Config describes the Keycloak installation this adapter serves.
+type Config struct {
+	BaseURL string
+	Realm   string
+	// TenantID is the authorization tenant this realm maps to (§7.1's
+	// tenantMappingMode: REALM).
+	TenantID idpdirectory.TenantID
+
+	RoleSource tokenverifier.RoleSource
+	// ClientID is the client whose roles are authoritative when RoleSource is
+	// CLIENT.
+	ClientID string
+
+	// ServiceUser is the confidential client the adapter authenticates as. It
+	// is separate from ClientID: the browser-facing client must not hold admin
+	// permissions.
+	ServiceUser  string
+	ClientSecret string
+
+	HTTPClient *http.Client
+	Now        func() time.Time
+}
+
+// Directory is the Keycloak identity directory adapter.
+type Directory struct {
+	cfg  Config
+	http *http.Client
+
+	mu            sync.Mutex
+	token         string
+	tokenExpires  time.Time
+	clientUUID    string
+	clientUUIDSet bool
+}
+
+// New validates the configuration and returns the adapter.
+func New(cfg Config) (*Directory, error) {
+	switch {
+	case cfg.BaseURL == "":
+		return nil, errors.New("keycloak: a base url is required")
+	case cfg.Realm == "":
+		return nil, errors.New("keycloak: a realm is required")
+	case cfg.TenantID == "":
+		return nil, errors.New("keycloak: a tenant is required")
+	case cfg.ServiceUser == "":
+		return nil, errors.New("keycloak: a service account client id is required")
+	case cfg.ClientSecret == "":
+		return nil, errors.New("keycloak: a service account secret is required")
+	}
+	if cfg.RoleSource == "" {
+		cfg.RoleSource = tokenverifier.RoleSourceClient
+	}
+	if cfg.RoleSource == tokenverifier.RoleSourceClient && cfg.ClientID == "" {
+		return nil, errors.New("keycloak: a client id is required when roles come from a client")
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: DefaultTimeout}
+	}
+	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
+
+	return &Directory{cfg: cfg, http: client}, nil
+}
+
+// SearchUsers returns one window of the realm's users.
+func (d *Directory) SearchUsers(ctx context.Context, tenant idpdirectory.TenantID, query idpdirectory.UserSearch) (idpdirectory.Page[idpdirectory.UserRef], error) {
+	var empty idpdirectory.Page[idpdirectory.UserRef]
+	if err := d.checkTenant(tenant); err != nil {
+		return empty, err
+	}
+
+	page := query.Page.Normalised()
+	params := url.Values{}
+	params.Set("briefRepresentation", "true")
+	if query.Query != "" {
+		params.Set("search", query.Query)
+	}
+	applyWindow(params, page)
+
+	var found []userRepresentation
+	if err := d.getJSON(ctx, d.adminPath("users"), params, &found); err != nil {
+		return empty, err
+	}
+
+	items, hasMore := trim(found, page.Limit)
+	refs := make([]idpdirectory.UserRef, 0, len(items))
+	for _, representation := range items {
+		refs = append(refs, representation.toRef())
+	}
+	return idpdirectory.Page[idpdirectory.UserRef]{
+		Items: refs, Offset: page.Offset, Limit: page.Limit, HasMore: hasMore,
+	}, nil
+}
+
+// SearchRoles returns one window of the roles the installation treats as
+// authoritative: realm roles or one client's roles, per §7.3.
+func (d *Directory) SearchRoles(ctx context.Context, tenant idpdirectory.TenantID, query idpdirectory.RoleSearch) (idpdirectory.Page[idpdirectory.RoleRef], error) {
+	var empty idpdirectory.Page[idpdirectory.RoleRef]
+	if err := d.checkTenant(tenant); err != nil {
+		return empty, err
+	}
+
+	path, err := d.rolesPath(ctx)
+	if err != nil {
+		return empty, err
+	}
+
+	page := query.Page.Normalised()
+	params := url.Values{}
+	if query.Query != "" {
+		params.Set("search", query.Query)
+	}
+	applyWindow(params, page)
+
+	var found []roleRepresentation
+	if err := d.getJSON(ctx, path, params, &found); err != nil {
+		return empty, err
+	}
+
+	items, hasMore := trim(found, page.Limit)
+	refs := make([]idpdirectory.RoleRef, 0, len(items))
+	for _, representation := range items {
+		refs = append(refs, d.toRoleRef(representation))
+	}
+	return idpdirectory.Page[idpdirectory.RoleRef]{
+		Items: refs, Offset: page.Offset, Limit: page.Limit, HasMore: hasMore,
+	}, nil
+}
+
+// GetUser looks a user up by the stable identifier the authorization database
+// persists.
+func (d *Directory) GetUser(ctx context.Context, tenant idpdirectory.TenantID, externalID string) (idpdirectory.UserRef, error) {
+	if err := d.checkTenant(tenant); err != nil {
+		return idpdirectory.UserRef{}, err
+	}
+	var representation userRepresentation
+	if err := d.getJSON(ctx, d.adminPath("users", externalID), nil, &representation); err != nil {
+		return idpdirectory.UserRef{}, err
+	}
+	return representation.toRef(), nil
+}
+
+// GetRole looks a role up by name within the authoritative role source.
+func (d *Directory) GetRole(ctx context.Context, tenant idpdirectory.TenantID, externalID string) (idpdirectory.RoleRef, error) {
+	if err := d.checkTenant(tenant); err != nil {
+		return idpdirectory.RoleRef{}, err
+	}
+	path, err := d.rolesPath(ctx)
+	if err != nil {
+		return idpdirectory.RoleRef{}, err
+	}
+	var representation roleRepresentation
+	if err := d.getJSON(ctx, path+"/"+url.PathEscape(externalID), nil, &representation); err != nil {
+		return idpdirectory.RoleRef{}, err
+	}
+	return d.toRoleRef(representation), nil
+}
+
+// ResolveRuntimeRoles reports the canonical roles the verified token carries.
+//
+// It deliberately makes no directory call: the token has already been verified
+// against the issuer's keys, and querying Keycloak on every decision would put
+// the identity provider's availability and latency in front of every
+// authorization call.
+func (d *Directory) ResolveRuntimeRoles(_ context.Context, token tokenverifier.VerifiedToken, tenant idpdirectory.TenantID) ([]string, error) {
+	if err := d.checkTenant(tenant); err != nil {
+		return nil, err
+	}
+	if token.TenantID != string(tenant) {
+		return nil, fmt.Errorf("%w: the token is for tenant %q", idpdirectory.ErrUnknownTenant, token.TenantID)
+	}
+	return append([]string(nil), token.Roles...), nil
+}
+
+func (d *Directory) checkTenant(tenant idpdirectory.TenantID) error {
+	if tenant != d.cfg.TenantID {
+		return fmt.Errorf("%w: %q", idpdirectory.ErrUnknownTenant, tenant)
+	}
+	return nil
+}
+
+func (d *Directory) toRoleRef(representation roleRepresentation) idpdirectory.RoleRef {
+	canonical := tokenverifier.CanonicalRoles(tokenverifier.Config{
+		Realm:      d.cfg.Realm,
+		RoleSource: d.cfg.RoleSource,
+		ClientID:   d.cfg.ClientID,
+	}, []string{representation.Name})
+
+	ref := idpdirectory.RoleRef{
+		ExternalID:  representation.ID,
+		Name:        representation.Name,
+		Description: representation.Description,
+	}
+	if len(canonical) == 1 {
+		ref.CanonicalID = canonical[0]
+	}
+	return ref
+}
+
+// rolesPath resolves where the authoritative roles live, translating the
+// configured client id into the internal UUID the Admin API needs. The
+// translation is cached: it is realm configuration, not per-request data.
+func (d *Directory) rolesPath(ctx context.Context) (string, error) {
+	if d.cfg.RoleSource == tokenverifier.RoleSourceRealm {
+		return d.adminPath("roles"), nil
+	}
+
+	d.mu.Lock()
+	cached, ok := d.clientUUID, d.clientUUIDSet
+	d.mu.Unlock()
+	if ok {
+		return d.adminPath("clients", cached, "roles"), nil
+	}
+
+	params := url.Values{}
+	params.Set("clientId", d.cfg.ClientID)
+	var clients []struct {
+		ID string `json:"id"`
+	}
+	if err := d.getJSON(ctx, d.adminPath("clients"), params, &clients); err != nil {
+		return "", err
+	}
+	if len(clients) == 0 {
+		return "", fmt.Errorf("%w: no client %q in realm %q",
+			idpdirectory.ErrNotFound, d.cfg.ClientID, d.cfg.Realm)
+	}
+
+	d.mu.Lock()
+	d.clientUUID, d.clientUUIDSet = clients[0].ID, true
+	d.mu.Unlock()
+
+	return d.adminPath("clients", clients[0].ID, "roles"), nil
+}
+
+func (d *Directory) adminPath(segments ...string) string {
+	escaped := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		escaped = append(escaped, url.PathEscape(segment))
+	}
+	return fmt.Sprintf("%s/admin/realms/%s/%s",
+		d.cfg.BaseURL, url.PathEscape(d.cfg.Realm), strings.Join(escaped, "/"))
+}
+
+func (d *Directory) getJSON(ctx context.Context, endpoint string, params url.Values, into any) error {
+	token, err := d.serviceAccountToken(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(params) > 0 {
+		endpoint += "?" + params.Encode()
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("building a directory request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Accept", "application/json")
+
+	response, err := d.http.Do(request)
+	if err != nil {
+		return fmt.Errorf("calling the identity directory: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	switch response.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return idpdirectory.ErrNotFound
+	default:
+		// The body may echo the request, so it is not repeated here: a
+		// directory error must never become a channel for credentials.
+		return fmt.Errorf("the identity directory answered %s", response.Status)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, 8<<20))
+	if err != nil {
+		return fmt.Errorf("reading the directory response: %w", err)
+	}
+	if err := json.Unmarshal(body, into); err != nil {
+		return fmt.Errorf("decoding the directory response: %w", err)
+	}
+	return nil
+}
+
+// serviceAccountToken returns a client-credentials token, minting a new one
+// only when the cached one is about to expire.
+func (d *Directory) serviceAccountToken(ctx context.Context) (string, error) {
+	now := d.cfg.Now()
+
+	d.mu.Lock()
+	if d.token != "" && now.Add(tokenRefreshMargin).Before(d.tokenExpires) {
+		token := d.token
+		d.mu.Unlock()
+		return token, nil
+	}
+	d.mu.Unlock()
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", d.cfg.ServiceUser)
+	form.Set("client_secret", d.cfg.ClientSecret)
+
+	endpoint := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/token",
+		d.cfg.BaseURL, url.PathEscape(d.cfg.Realm))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint,
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("building the service account token request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := d.http.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("authenticating the service account: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusOK {
+		// Deliberately status only: the request carried the secret, and some
+		// providers echo the form back in the error body.
+		return "", fmt.Errorf("authenticating the service account: the identity provider answered %s",
+			response.Status)
+	}
+
+	var grant struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int64  `json:"expires_in"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&grant); err != nil {
+		return "", fmt.Errorf("decoding the service account grant: %w", err)
+	}
+	if grant.AccessToken == "" {
+		return "", errors.New("the identity provider returned no service account token")
+	}
+
+	d.mu.Lock()
+	d.token = grant.AccessToken
+	d.tokenExpires = now.Add(time.Duration(grant.ExpiresIn) * time.Second)
+	d.mu.Unlock()
+
+	return grant.AccessToken, nil
+}
+
+// applyWindow asks for one row more than the caller wants. That extra row is
+// how HasMore is answered without a second count query, which on a realm with
+// hundreds of thousands of users is the expensive one.
+func applyWindow(params url.Values, page idpdirectory.PageRequest) {
+	params.Set("first", strconv.Itoa(page.Offset))
+	params.Set("max", strconv.Itoa(page.Limit+1))
+}
+
+func trim[T any](found []T, limit int) ([]T, bool) {
+	if len(found) > limit {
+		return found[:limit], true
+	}
+	return found, false
+}
+
+type userRepresentation struct {
+	ID        string `json:"id"`
+	Username  string `json:"username"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	Email     string `json:"email"`
+	Enabled   bool   `json:"enabled"`
+}
+
+func (u userRepresentation) toRef() idpdirectory.UserRef {
+	display := strings.TrimSpace(strings.Join([]string{u.FirstName, u.LastName}, " "))
+	if display == "" {
+		display = u.Username
+	}
+	return idpdirectory.UserRef{
+		ExternalID:  u.ID,
+		Username:    u.Username,
+		DisplayName: display,
+		Email:       u.Email,
+		Enabled:     u.Enabled,
+	}
+}
+
+type roleRepresentation struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}

--- a/libs/idpdirectory/keycloak/keycloak.go
+++ b/libs/idpdirectory/keycloak/keycloak.go
@@ -139,11 +139,6 @@ func (d *Directory) SearchRoles(ctx context.Context, tenant idpdirectory.TenantI
 		return empty, err
 	}
 
-	path, err := d.rolesPath(ctx)
-	if err != nil {
-		return empty, err
-	}
-
 	page := query.Page.Normalised()
 	params := url.Values{}
 	if query.Query != "" {
@@ -152,7 +147,7 @@ func (d *Directory) SearchRoles(ctx context.Context, tenant idpdirectory.TenantI
 	applyWindow(params, page)
 
 	var found []roleRepresentation
-	if err := d.getJSON(ctx, path, params, &found); err != nil {
+	if err := d.getRoles(ctx, "", params, &found); err != nil {
 		return empty, err
 	}
 
@@ -184,12 +179,8 @@ func (d *Directory) GetRole(ctx context.Context, tenant idpdirectory.TenantID, e
 	if err := d.checkTenant(tenant); err != nil {
 		return idpdirectory.RoleRef{}, err
 	}
-	path, err := d.rolesPath(ctx)
-	if err != nil {
-		return idpdirectory.RoleRef{}, err
-	}
 	var representation roleRepresentation
-	if err := d.getJSON(ctx, path+"/"+url.PathEscape(externalID), nil, &representation); err != nil {
+	if err := d.getRoles(ctx, externalID, nil, &representation); err != nil {
 		return idpdirectory.RoleRef{}, err
 	}
 	return d.toRoleRef(representation), nil
@@ -234,6 +225,40 @@ func (d *Directory) toRoleRef(representation roleRepresentation) idpdirectory.Ro
 		ref.CanonicalID = canonical[0]
 	}
 	return ref
+}
+
+// getRoles reads from the authoritative role source, retrying once against a
+// freshly resolved client.
+//
+// The client's internal id is realm configuration, so it is cached - but a
+// realm can be rebuilt underneath a running service, and the cached id is then
+// a 404 for the rest of the process' life. Nothing about "no such identity"
+// would point an operator at a cache, so the recovery is automatic. One retry,
+// because a second failure is a real absence rather than a stale id.
+func (d *Directory) getRoles(ctx context.Context, roleName string, params url.Values, into any) error {
+	for attempt := range 2 {
+		path, err := d.rolesPath(ctx)
+		if err != nil {
+			return err
+		}
+		if roleName != "" {
+			path += "/" + url.PathEscape(roleName)
+		}
+
+		err = d.getJSON(ctx, path, params, into)
+		if err == nil || attempt == 1 || !errors.Is(err, idpdirectory.ErrNotFound) {
+			return err
+		}
+		d.forgetClient()
+	}
+	return nil
+}
+
+// forgetClient drops the cached client id so the next call resolves it again.
+func (d *Directory) forgetClient() {
+	d.mu.Lock()
+	d.clientUUID, d.clientUUIDSet = "", false
+	d.mu.Unlock()
 }
 
 // rolesPath resolves where the authoritative roles live, translating the

--- a/libs/idpdirectory/keycloak/keycloak_test.go
+++ b/libs/idpdirectory/keycloak/keycloak_test.go
@@ -121,6 +121,33 @@ func TestRoleSearchProducesTheSameCanonicalIdentifiersAsTokenNormalisation(t *te
 	}
 }
 
+// The client's internal UUID is cached as realm configuration, but a realm can
+// be rebuilt underneath a running service - `make down && make up` does exactly
+// that to the development database. The cached UUID is then a 404 forever, and
+// role search stays broken until someone restarts the ADS. Recovering has to be
+// automatic, because nothing about the symptom points at a cache.
+func TestRoleSearchRecoversWhenTheRealmIsRebuiltUnderneathIt(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.clientRoles = []role{{ID: "58d1e7c8-role", Name: "doctor"}}
+	defer fake.Close()
+
+	directory := fake.directory(t)
+	if _, err := directory.SearchRoles(context.Background(), tenant, idpdirectory.RoleSearch{}); err != nil {
+		t.Fatalf("the first SearchRoles: %v", err)
+	}
+
+	// The realm comes back with the same client under a new internal id.
+	fake.clientUUID = "client-uuid-after-rebuild"
+
+	page, err := directory.SearchRoles(context.Background(), tenant, idpdirectory.RoleSearch{})
+	if err != nil {
+		t.Fatalf("SearchRoles after the realm was rebuilt: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Errorf("returned %d roles after the rebuild, want 1", len(page.Items))
+	}
+}
+
 func TestGettingAUserThatDoesNotExistReportsNotFound(t *testing.T) {
 	fake := newFakeKeycloak(t)
 	defer fake.Close()
@@ -248,6 +275,9 @@ type fakeKeycloak struct {
 
 	users       []user
 	clientRoles []role
+	// clientUUID is the internal id the fake currently reports for the client.
+	// Changing it stands in for a realm that was rebuilt.
+	clientUUID string
 
 	tokenRequests     atomic.Int64
 	adminRequests     atomic.Int64
@@ -259,7 +289,7 @@ type fakeKeycloak struct {
 
 func newFakeKeycloak(t *testing.T) *fakeKeycloak {
 	t.Helper()
-	fake := &fakeKeycloak{t: t, queries: map[string]url.Values{}}
+	fake := &fakeKeycloak{t: t, queries: map[string]url.Values{}, clientUUID: "client-uuid"}
 	fake.Server = httptest.NewServer(http.HandlerFunc(fake.serve))
 	return fake
 }
@@ -299,17 +329,21 @@ func (f *fakeKeycloak) serve(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(http.StatusNotFound)
 	case path == "/admin/realms/"+realm+"/clients":
-		writeJSON(f.t, w, []map[string]string{{"id": "client-uuid", "clientId": clientID}})
-	case path == "/admin/realms/"+realm+"/clients/client-uuid/roles":
+		writeJSON(f.t, w, []map[string]string{{"id": f.clientUUID, "clientId": clientID}})
+	case path == "/admin/realms/"+realm+"/clients/"+f.clientUUID+"/roles":
 		writeJSON(f.t, w, window(f.clientRoles, r))
-	case strings.HasPrefix(path, "/admin/realms/"+realm+"/clients/client-uuid/roles/"):
-		name := strings.TrimPrefix(path, "/admin/realms/"+realm+"/clients/client-uuid/roles/")
+	case strings.HasPrefix(path, "/admin/realms/"+realm+"/clients/"+f.clientUUID+"/roles/"):
+		name := strings.TrimPrefix(path, "/admin/realms/"+realm+"/clients/"+f.clientUUID+"/roles/")
 		for _, candidate := range f.clientRoles {
 			if candidate.Name == name || candidate.ID == name {
 				writeJSON(f.t, w, candidate)
 				return
 			}
 		}
+		w.WriteHeader(http.StatusNotFound)
+	// A client id the realm no longer knows: what a rebuilt realm answers to a
+	// cached UUID.
+	case strings.HasPrefix(path, "/admin/realms/"+realm+"/clients/"):
 		w.WriteHeader(http.StatusNotFound)
 	default:
 		f.t.Errorf("the adapter called an endpoint the fake does not model: %s", path)

--- a/libs/idpdirectory/keycloak/keycloak_test.go
+++ b/libs/idpdirectory/keycloak/keycloak_test.go
@@ -1,0 +1,371 @@
+package keycloak_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/keycloak"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+const (
+	realm    = "cerbos-poc"
+	clientID = "patient-app"
+	tenant   = idpdirectory.TenantID("tenant-a")
+)
+
+// The Admin Console pages through a directory with hundreds of thousands of
+// users. An adapter that ignored the window would pull the whole realm into
+// memory, so the window is asserted on the wire, not only in the result.
+func TestUserSearchAsksKeycloakForTheRequestedWindowAndReportsMore(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.users = make([]user, 0, 120)
+	for index := range 120 {
+		fake.users = append(fake.users, user{
+			ID:        fmt.Sprintf("user-%03d", index),
+			Username:  fmt.Sprintf("doctor-%03d", index),
+			FirstName: "Demo",
+			LastName:  fmt.Sprintf("Doctor %03d", index),
+			Email:     fmt.Sprintf("doctor-%03d@example.test", index),
+			Enabled:   true,
+		})
+	}
+	defer fake.Close()
+
+	page, err := fake.directory(t).SearchUsers(context.Background(), tenant, idpdirectory.UserSearch{
+		Query: "doctor",
+		Page:  idpdirectory.PageRequest{Offset: 20, Limit: 10},
+	})
+	if err != nil {
+		t.Fatalf("SearchUsers: %v", err)
+	}
+
+	if len(page.Items) != 10 {
+		t.Fatalf("returned %d users, want the 10 that were asked for", len(page.Items))
+	}
+	if page.Items[0].ExternalID != "user-020" {
+		t.Errorf("first user = %q, want the one at the requested offset", page.Items[0].ExternalID)
+	}
+	if !page.HasMore {
+		t.Error("HasMore = false, want true: 90 users remain after this window")
+	}
+	if got := fake.lastQuery("/admin/realms/cerbos-poc/users"); got.Get("first") != "20" || got.Get("max") != "11" {
+		// max is one more than the window: the extra row is how HasMore is
+		// answered without a second count query on the hot path.
+		t.Errorf("user query = %v, want first=20 and max=11", got)
+	}
+	if got := fake.lastQuery("/admin/realms/cerbos-poc/users").Get("search"); got != "doctor" {
+		t.Errorf("search = %q, want the caller's query", got)
+	}
+}
+
+func TestTheLastPageReportsNoMore(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.users = []user{
+		{ID: "user-001", Username: "doctor", Enabled: true},
+		{ID: "user-002", Username: "auditor", Enabled: true},
+	}
+	defer fake.Close()
+
+	page, err := fake.directory(t).SearchUsers(context.Background(), tenant, idpdirectory.UserSearch{
+		Page: idpdirectory.PageRequest{Offset: 0, Limit: 10},
+	})
+	if err != nil {
+		t.Fatalf("SearchUsers: %v", err)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("returned %d users, want 2", len(page.Items))
+	}
+	if page.HasMore {
+		t.Error("HasMore = true on the last page")
+	}
+}
+
+// §7.5 requires the directory and token normalisation to agree byte for byte.
+// This asserts it against the verifier itself rather than against a literal, so
+// the two can only pass together.
+func TestRoleSearchProducesTheSameCanonicalIdentifiersAsTokenNormalisation(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.clientRoles = []role{
+		{ID: "58d1e7c8-role", Name: "doctor", Description: "Treating clinician"},
+		{ID: "9a2b4f11-role", Name: "auditor", Description: "Read-only auditor"},
+	}
+	defer fake.Close()
+
+	page, err := fake.directory(t).SearchRoles(context.Background(), tenant, idpdirectory.RoleSearch{})
+	if err != nil {
+		t.Fatalf("SearchRoles: %v", err)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("returned %d roles, want 2", len(page.Items))
+	}
+
+	fromDirectory := page.Items[0].CanonicalID
+	fromToken := canonicalRolesFromToken(t, "doctor")
+	if len(fromToken) != 1 || fromDirectory != fromToken[0] {
+		t.Errorf("the directory says %q and token normalisation says %v; §7.5 requires one identifier",
+			fromDirectory, fromToken)
+	}
+	if page.Items[0].ExternalID != "58d1e7c8-role" {
+		t.Errorf("ExternalID = %q, want Keycloak's stable role id", page.Items[0].ExternalID)
+	}
+}
+
+func TestGettingAUserThatDoesNotExistReportsNotFound(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	defer fake.Close()
+
+	_, err := fake.directory(t).GetUser(context.Background(), tenant, "nobody")
+	if !errors.Is(err, idpdirectory.ErrNotFound) {
+		t.Errorf("GetUser error = %v, want %v", err, idpdirectory.ErrNotFound)
+	}
+}
+
+func TestGettingAUserReturnsItsStableIdentifierAndDisplayMetadata(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.users = []user{{
+		ID: "user-doctor", Username: "doctor", FirstName: "Dana", LastName: "Doctor",
+		Email: "dana@example.test", Enabled: true,
+	}}
+	defer fake.Close()
+
+	found, err := fake.directory(t).GetUser(context.Background(), tenant, "user-doctor")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if found.ExternalID != "user-doctor" || found.Username != "doctor" {
+		t.Errorf("user = %+v, want the stable id and username", found)
+	}
+	if found.DisplayName != "Dana Doctor" {
+		t.Errorf("DisplayName = %q, want %q", found.DisplayName, "Dana Doctor")
+	}
+}
+
+// The adapter serves exactly the tenant it was configured for. Answering for
+// another tenant would mean one realm's roles could be written into another
+// tenant's matrix.
+func TestAQueryForAnotherTenantIsRefused(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	defer fake.Close()
+
+	_, err := fake.directory(t).SearchUsers(context.Background(), "tenant-b", idpdirectory.UserSearch{})
+	if !errors.Is(err, idpdirectory.ErrUnknownTenant) {
+		t.Errorf("SearchUsers error = %v, want %v", err, idpdirectory.ErrUnknownTenant)
+	}
+}
+
+// §7.3: a dedicated confidential service account, never the browser's token.
+func TestTheAdapterAuthenticatesWithItsServiceAccountAndReusesTheToken(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.users = []user{{ID: "user-001", Username: "doctor", Enabled: true}}
+	defer fake.Close()
+
+	directory := fake.directory(t)
+	for range 3 {
+		if _, err := directory.SearchUsers(context.Background(), tenant, idpdirectory.UserSearch{}); err != nil {
+			t.Fatalf("SearchUsers: %v", err)
+		}
+	}
+
+	if got := fake.tokenRequests.Load(); got != 1 {
+		t.Errorf("the service account authenticated %d times, want 1 for three calls", got)
+	}
+	if got := fake.lastAuthorization.Load(); got == nil || *got != "Bearer service-account-token" {
+		t.Errorf("admin request Authorization = %v, want the service account's token", got)
+	}
+	if fake.lastGrantType != "client_credentials" {
+		t.Errorf("grant_type = %q, want client_credentials", fake.lastGrantType)
+	}
+}
+
+// The decision path must not depend on the identity provider being up, so
+// runtime roles come from the token the caller already presented.
+func TestRuntimeRolesComeFromTheVerifiedTokenWithoutCallingKeycloak(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	defer fake.Close()
+
+	roles, err := fake.directory(t).ResolveRuntimeRoles(context.Background(), tokenverifier.VerifiedToken{
+		Subject:  "user-doctor",
+		TenantID: "tenant-a",
+		Roles:    []string{"kc:cerbos-poc:patient-app:doctor"},
+	}, tenant)
+	if err != nil {
+		t.Fatalf("ResolveRuntimeRoles: %v", err)
+	}
+	if len(roles) != 1 || roles[0] != "kc:cerbos-poc:patient-app:doctor" {
+		t.Errorf("roles = %v, want the token's canonical roles", roles)
+	}
+	if got := fake.adminRequests.Load(); got != 0 {
+		t.Errorf("the adapter made %d admin calls resolving runtime roles, want 0", got)
+	}
+}
+
+// A token minted for one tenant must never resolve roles inside another.
+func TestRuntimeRolesForATokenFromAnotherTenantAreRefused(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	defer fake.Close()
+
+	_, err := fake.directory(t).ResolveRuntimeRoles(context.Background(), tokenverifier.VerifiedToken{
+		Subject:  "user-doctor",
+		TenantID: "tenant-b",
+		Roles:    []string{"kc:cerbos-poc:patient-app:doctor"},
+	}, tenant)
+	if !errors.Is(err, idpdirectory.ErrUnknownTenant) {
+		t.Errorf("ResolveRuntimeRoles error = %v, want %v", err, idpdirectory.ErrUnknownTenant)
+	}
+}
+
+// --- a fake Keycloak admin API ---------------------------------------------
+
+type user struct {
+	ID        string `json:"id"`
+	Username  string `json:"username"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	Email     string `json:"email"`
+	Enabled   bool   `json:"enabled"`
+}
+
+type role struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type fakeKeycloak struct {
+	*httptest.Server
+	t *testing.T
+
+	users       []user
+	clientRoles []role
+
+	tokenRequests     atomic.Int64
+	adminRequests     atomic.Int64
+	lastAuthorization atomic.Pointer[string]
+	lastGrantType     string
+
+	queries map[string]url.Values
+}
+
+func newFakeKeycloak(t *testing.T) *fakeKeycloak {
+	t.Helper()
+	fake := &fakeKeycloak{t: t, queries: map[string]url.Values{}}
+	fake.Server = httptest.NewServer(http.HandlerFunc(fake.serve))
+	return fake
+}
+
+func (f *fakeKeycloak) serve(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	f.queries[path] = r.URL.Query()
+
+	if path == "/realms/"+realm+"/protocol/openid-connect/token" {
+		f.tokenRequests.Add(1)
+		if err := r.ParseForm(); err != nil {
+			f.t.Errorf("parsing the token request: %v", err)
+		}
+		f.lastGrantType = r.PostForm.Get("grant_type")
+		writeJSON(f.t, w, map[string]any{
+			"access_token": "service-account-token",
+			"expires_in":   300,
+			"token_type":   "Bearer",
+		})
+		return
+	}
+
+	f.adminRequests.Add(1)
+	authorization := r.Header.Get("Authorization")
+	f.lastAuthorization.Store(&authorization)
+
+	switch {
+	case path == "/admin/realms/"+realm+"/users":
+		writeJSON(f.t, w, window(f.users, r))
+	case strings.HasPrefix(path, "/admin/realms/"+realm+"/users/"):
+		id := strings.TrimPrefix(path, "/admin/realms/"+realm+"/users/")
+		for _, candidate := range f.users {
+			if candidate.ID == id {
+				writeJSON(f.t, w, candidate)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+	case path == "/admin/realms/"+realm+"/clients":
+		writeJSON(f.t, w, []map[string]string{{"id": "client-uuid", "clientId": clientID}})
+	case path == "/admin/realms/"+realm+"/clients/client-uuid/roles":
+		writeJSON(f.t, w, window(f.clientRoles, r))
+	case strings.HasPrefix(path, "/admin/realms/"+realm+"/clients/client-uuid/roles/"):
+		name := strings.TrimPrefix(path, "/admin/realms/"+realm+"/clients/client-uuid/roles/")
+		for _, candidate := range f.clientRoles {
+			if candidate.Name == name || candidate.ID == name {
+				writeJSON(f.t, w, candidate)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+	default:
+		f.t.Errorf("the adapter called an endpoint the fake does not model: %s", path)
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func window[T any](all []T, r *http.Request) []T {
+	first, _ := strconv.Atoi(r.URL.Query().Get("first"))
+	max, err := strconv.Atoi(r.URL.Query().Get("max"))
+	if err != nil || max <= 0 {
+		max = len(all)
+	}
+	if first > len(all) {
+		return nil
+	}
+	end := min(first+max, len(all))
+	return all[first:end]
+}
+
+func (f *fakeKeycloak) lastQuery(path string) url.Values {
+	return f.queries[path]
+}
+
+func (f *fakeKeycloak) directory(t *testing.T) idpdirectory.IdentityDirectory {
+	t.Helper()
+	directory, err := keycloak.New(keycloak.Config{
+		BaseURL:      f.URL,
+		Realm:        realm,
+		TenantID:     tenant,
+		RoleSource:   tokenverifier.RoleSourceClient,
+		ClientID:     clientID,
+		ServiceUser:  "authorization-admin-service",
+		ClientSecret: "a-secret-nobody-should-see",
+	})
+	if err != nil {
+		t.Fatalf("keycloak.New: %v", err)
+	}
+	return directory
+}
+
+func canonicalRolesFromToken(t *testing.T, roleName string) []string {
+	t.Helper()
+	// Normalisation is the verifier's, so this cannot drift from what a real
+	// token produces.
+	return tokenverifier.CanonicalRoles(tokenverifier.Config{
+		Realm:      realm,
+		RoleSource: tokenverifier.RoleSourceClient,
+		ClientID:   clientID,
+	}, []string{roleName})
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, body any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Errorf("encoding a response: %v", err)
+	}
+}

--- a/libs/idpdirectory/port.go
+++ b/libs/idpdirectory/port.go
@@ -1,0 +1,117 @@
+// Package idpdirectory is the provider-neutral identity directory port (§7.2).
+//
+// It is a library rather than a service (ADR: the IdP adapter is a shared
+// library behind dependency inversion). Consumers depend on this package only;
+// the concrete Keycloak and WSO2 adapters live below it and are reachable only
+// through the provider factory, so swapping providers is a configuration change
+// rather than a code change. An architecture test enforces that boundary.
+package idpdirectory
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+// The failures every adapter reports the same way, so a consumer can react to
+// them without knowing which provider is installed.
+var (
+	// ErrUnimplemented means the installed provider does not offer the
+	// operation. The WSO2 stub returns it for everything.
+	ErrUnimplemented = errors.New("the identity provider adapter does not implement this operation")
+	// ErrUnknownTenant means the adapter does not serve the tenant asked
+	// about. An adapter is configured for one realm or organisation, so a
+	// query for another tenant is a bug, not an empty result.
+	ErrUnknownTenant = errors.New("the identity provider adapter does not serve this tenant")
+	// ErrNotFound means the user or role does not exist.
+	ErrNotFound = errors.New("no such identity")
+)
+
+// TenantID is the authorization tenant an identity belongs to.
+type TenantID string
+
+// UserRef is a user as the directory knows it. ExternalID is the stable
+// identifier the authorization database persists (§7.3); everything else is
+// display metadata that may change.
+type UserRef struct {
+	ExternalID  string
+	Username    string
+	DisplayName string
+	Email       string
+	Enabled     bool
+}
+
+// RoleRef is a role as the directory knows it. CanonicalID is the §7.5
+// identifier the role-permission matrix is keyed by, and it is byte-identical
+// to the one token normalisation produces for the same role.
+type RoleRef struct {
+	CanonicalID string
+	ExternalID  string
+	Name        string
+	Description string
+}
+
+// PageRequest is one window over a result set. Both fields are honoured by
+// every adapter: the Admin Console pages through hundreds of thousands of
+// users, so an adapter that quietly returned everything would be unusable.
+type PageRequest struct {
+	Offset int
+	Limit  int
+}
+
+// DefaultPageLimit is used when a caller asks for no particular size.
+const DefaultPageLimit = 50
+
+// MaxPageLimit caps what a caller may ask for, so one request cannot pull the
+// whole directory into memory.
+const MaxPageLimit = 500
+
+// Normalised clamps a page request into the supported range.
+func (p PageRequest) Normalised() PageRequest {
+	normalised := p
+	if normalised.Offset < 0 {
+		normalised.Offset = 0
+	}
+	if normalised.Limit <= 0 {
+		normalised.Limit = DefaultPageLimit
+	}
+	if normalised.Limit > MaxPageLimit {
+		normalised.Limit = MaxPageLimit
+	}
+	return normalised
+}
+
+// UserSearch selects users. Query is a free-text match on username, name or
+// email, as the provider defines it.
+type UserSearch struct {
+	Query string
+	Page  PageRequest
+}
+
+// RoleSearch selects roles.
+type RoleSearch struct {
+	Query string
+	Page  PageRequest
+}
+
+// Page is one window of results plus what a caller needs to ask for the next.
+type Page[T any] struct {
+	Items   []T
+	Offset  int
+	Limit   int
+	HasMore bool
+}
+
+// IdentityDirectory is the §7.2 adapter interface.
+type IdentityDirectory interface {
+	SearchUsers(ctx context.Context, tenant TenantID, query UserSearch) (Page[UserRef], error)
+	SearchRoles(ctx context.Context, tenant TenantID, query RoleSearch) (Page[RoleRef], error)
+	GetUser(ctx context.Context, tenant TenantID, externalID string) (UserRef, error)
+	GetRole(ctx context.Context, tenant TenantID, externalID string) (RoleRef, error)
+	// ResolveRuntimeRoles reports the canonical roles a verified token grants
+	// within a tenant. It reads the token rather than the directory: a
+	// directory round trip on the decision path would put the identity
+	// provider's availability in front of every authorization call.
+	ResolveRuntimeRoles(ctx context.Context, token tokenverifier.VerifiedToken, tenant TenantID) ([]string, error)
+}

--- a/libs/idpdirectory/provider/provider.go
+++ b/libs/idpdirectory/provider/provider.go
@@ -75,8 +75,14 @@ type Config struct {
 }
 
 // JWKSURL is where the issuer publishes its signing keys.
+//
+// It is built from the base URL rather than from the issuer. The two differ
+// whenever a browser and a backend reach the identity provider by different
+// names - which is the normal case, and is exactly the deployment where using
+// the issuer here would send a backend to an address only the browser can
+// resolve.
 func (c Config) JWKSURL() string {
-	return c.Issuer + "/protocol/openid-connect/certs"
+	return fmt.Sprintf("%s/realms/%s/protocol/openid-connect/certs", c.BaseURL, c.Realm)
 }
 
 // LookupFunc mirrors os.LookupEnv so configuration stays testable.

--- a/libs/idpdirectory/provider/provider.go
+++ b/libs/idpdirectory/provider/provider.go
@@ -1,0 +1,201 @@
+// Package provider is the composition root for identity provider adapters.
+//
+// It is the only package permitted to import a concrete adapter (§7.1: "only
+// one provider adapter is active for an installation", and the domain APIs stay
+// provider-neutral). Consumers take an idpdirectory.IdentityDirectory and a
+// tokenverifier.Verifier from here and never learn which product is behind
+// them, so switching provider is an environment change. An architecture test
+// fails the build if any other package reaches past this one.
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/keycloak"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/wso2"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+// Type names an identity provider product (§7.1).
+type Type string
+
+const (
+	// TypeKeycloak selects the Keycloak Admin REST adapter.
+	TypeKeycloak Type = "KEYCLOAK"
+	// TypeWSO2 selects the WSO2 Identity Server adapter.
+	TypeWSO2 Type = "WSO2_IS"
+)
+
+// Secret holds a machine credential. It refuses to render itself so a stray
+// log line, an error body or a serialised configuration cannot become the way
+// the IdP admin credential reaches a browser (§16.1, §7.4).
+type Secret string
+
+// String reports a placeholder, never the credential.
+func (s Secret) String() string { return "REDACTED" }
+
+// MarshalJSON reports a placeholder, never the credential.
+func (s Secret) MarshalJSON() ([]byte, error) { return []byte(`"REDACTED"`), nil }
+
+// Reveal returns the credential. The name is deliberately conspicuous: every
+// call site is somewhere a reviewer should look.
+func (s Secret) Reveal() string { return string(s) }
+
+// Config is the §7.1 installation selection, resolved.
+type Config struct {
+	Type    Type
+	BaseURL string
+	Realm   string
+	// TenantID is the authorization tenant this realm or organisation maps to.
+	TenantID idpdirectory.TenantID
+	// TenantMappingMode decides whether the tenant comes from a token claim or
+	// from the realm itself.
+	TenantMappingMode tokenverifier.TenantMappingMode
+
+	RoleSource tokenverifier.RoleSource
+	// ClientID is the browser-facing client: the token audience, and the owner
+	// of the authoritative roles when RoleSource is CLIENT.
+	ClientID string
+	// ServiceClientID is the confidential service account the directory
+	// adapter authenticates as. It is separate from ClientID so the
+	// browser-facing client never needs admin permissions (§7.3).
+	ServiceClientID string
+	ClientSecret    Secret
+
+	// Issuer is what a token must claim. It is derived from the base URL and
+	// realm unless overridden, because a hand-written issuer that disagrees
+	// with the base URL rejects every token.
+	Issuer string
+	// WSO2TenantDomain is WSO2's own tenant name (§7.4).
+	WSO2TenantDomain string
+}
+
+// JWKSURL is where the issuer publishes its signing keys.
+func (c Config) JWKSURL() string {
+	return c.Issuer + "/protocol/openid-connect/certs"
+}
+
+// LookupFunc mirrors os.LookupEnv so configuration stays testable.
+type LookupFunc func(key string) (string, bool)
+
+// Environment variables, all prefixed IDP_ so one glance at a compose file
+// shows the whole identity configuration.
+const (
+	EnvType              = "IDP_TYPE"
+	EnvBaseURL           = "IDP_BASE_URL"
+	EnvRealm             = "IDP_REALM"
+	EnvTenantID          = "IDP_TENANT_ID"
+	EnvTenantMappingMode = "IDP_TENANT_MAPPING_MODE"
+	EnvRoleSource        = "IDP_ROLE_SOURCE"
+	EnvClientID          = "IDP_CLIENT_ID"
+	EnvServiceClientID   = "IDP_SERVICE_CLIENT_ID"
+	// EnvCredentialsSecretRef is §7.1's credentialsSecretRef: a path to a
+	// mounted file. A secret passed by value would be visible in
+	// `docker inspect` and inherited by every child process.
+	EnvCredentialsSecretRef = "IDP_CREDENTIALS_SECRET_REF"
+	EnvIssuer               = "IDP_ISSUER"
+	EnvWSO2TenantDomain     = "IDP_WSO2_TENANT_DOMAIN"
+)
+
+// FromEnv resolves the installation's identity configuration.
+func FromEnv(lookup LookupFunc) (Config, error) {
+	cfg := Config{
+		Type:              Type(valueOr(lookup, EnvType, string(TypeKeycloak))),
+		BaseURL:           strings.TrimRight(valueOr(lookup, EnvBaseURL, ""), "/"),
+		Realm:             valueOr(lookup, EnvRealm, ""),
+		TenantID:          idpdirectory.TenantID(valueOr(lookup, EnvTenantID, "")),
+		TenantMappingMode: tokenverifier.TenantMappingMode(valueOr(lookup, EnvTenantMappingMode, string(tokenverifier.TenantMappingClaim))),
+		RoleSource:        tokenverifier.RoleSource(valueOr(lookup, EnvRoleSource, string(tokenverifier.RoleSourceClient))),
+		ClientID:          valueOr(lookup, EnvClientID, ""),
+		ServiceClientID:   valueOr(lookup, EnvServiceClientID, ""),
+		Issuer:            strings.TrimRight(valueOr(lookup, EnvIssuer, ""), "/"),
+		WSO2TenantDomain:  valueOr(lookup, EnvWSO2TenantDomain, ""),
+	}
+
+	switch {
+	case cfg.BaseURL == "":
+		return Config{}, fmt.Errorf("%s is required", EnvBaseURL)
+	case cfg.Realm == "":
+		return Config{}, fmt.Errorf("%s is required", EnvRealm)
+	case cfg.TenantID == "":
+		return Config{}, fmt.Errorf("%s is required", EnvTenantID)
+	case cfg.ClientID == "":
+		return Config{}, fmt.Errorf("%s is required", EnvClientID)
+	}
+
+	reference, ok := lookup(EnvCredentialsSecretRef)
+	if !ok || reference == "" {
+		return Config{}, fmt.Errorf("%s is required: it names the file the service account secret is mounted at", EnvCredentialsSecretRef)
+	}
+	contents, err := os.ReadFile(reference)
+	if err != nil {
+		return Config{}, fmt.Errorf("reading the identity provider credentials from %s: %w", EnvCredentialsSecretRef, err)
+	}
+	// Trailing whitespace is what an editor or `echo` leaves behind, and a
+	// secret that fails only when written by hand is an unfindable bug.
+	cfg.ClientSecret = Secret(strings.TrimSpace(string(contents)))
+	if cfg.ClientSecret == "" {
+		return Config{}, errors.New("the identity provider credentials file is empty")
+	}
+
+	if cfg.Issuer == "" {
+		cfg.Issuer = fmt.Sprintf("%s/realms/%s", cfg.BaseURL, cfg.Realm)
+	}
+	if cfg.ServiceClientID == "" {
+		cfg.ServiceClientID = cfg.ClientID
+	}
+	return cfg, nil
+}
+
+// New builds the one identity directory this installation uses.
+func New(cfg Config) (idpdirectory.IdentityDirectory, error) {
+	switch cfg.Type {
+	case TypeKeycloak:
+		return keycloak.New(keycloak.Config{
+			BaseURL:      cfg.BaseURL,
+			Realm:        cfg.Realm,
+			TenantID:     cfg.TenantID,
+			RoleSource:   cfg.RoleSource,
+			ClientID:     cfg.ClientID,
+			ServiceUser:  cfg.ServiceClientID,
+			ClientSecret: cfg.ClientSecret.Reveal(),
+		})
+	case TypeWSO2:
+		return wso2.New(wso2.Config{
+			BaseURL:      cfg.BaseURL,
+			TenantDomain: cfg.WSO2TenantDomain,
+			TenantID:     cfg.TenantID,
+			ServiceUser:  cfg.ServiceClientID,
+			ClientSecret: cfg.ClientSecret.Reveal(),
+		})
+	default:
+		return nil, fmt.Errorf("%s=%q names no adapter; supported types are %s and %s",
+			EnvType, cfg.Type, TypeKeycloak, TypeWSO2)
+	}
+}
+
+// NewVerifier builds the token verifier from the same configuration as the
+// directory, so an installation cannot verify tokens for one realm while
+// reading roles from another.
+func NewVerifier(cfg Config) (*tokenverifier.Verifier, error) {
+	return tokenverifier.New(tokenverifier.Config{
+		Issuer:            cfg.Issuer,
+		Audience:          cfg.ClientID,
+		Realm:             cfg.Realm,
+		RoleSource:        cfg.RoleSource,
+		ClientID:          cfg.ClientID,
+		TenantMappingMode: cfg.TenantMappingMode,
+		Keys:              tokenverifier.NewJWKS(tokenverifier.JWKSConfig{URL: cfg.JWKSURL()}),
+	})
+}
+
+func valueOr(lookup LookupFunc, key, fallback string) string {
+	if value, ok := lookup(key); ok && value != "" {
+		return value
+	}
+	return fallback
+}

--- a/libs/idpdirectory/provider/provider_test.go
+++ b/libs/idpdirectory/provider/provider_test.go
@@ -1,0 +1,195 @@
+package provider_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/provider"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+const secret = "a-secret-nobody-should-see"
+
+// The seam is only real if flipping one environment variable changes the
+// provider with no consumer rebuilt and no code touched. These two cases run
+// the same construction path and differ only in IDP_TYPE.
+func TestTheProviderIsSelectedByEnvironmentAlone(t *testing.T) {
+	keycloakDirectory, err := provider.New(configFor(t, "KEYCLOAK"))
+	if err != nil {
+		t.Fatalf("New(KEYCLOAK): %v", err)
+	}
+	wso2Directory, err := provider.New(configFor(t, "WSO2_IS"))
+	if err != nil {
+		t.Fatalf("New(WSO2_IS): %v", err)
+	}
+
+	// The stub answers every operation the same way, which is how an
+	// installation learns the provider is not finished rather than seeing an
+	// empty directory.
+	_, err = wso2Directory.SearchUsers(context.Background(), "tenant-a", idpdirectory.UserSearch{})
+	if !errors.Is(err, idpdirectory.ErrUnimplemented) {
+		t.Errorf("the WSO2 stub returned %v, want %v", err, idpdirectory.ErrUnimplemented)
+	}
+
+	// The Keycloak adapter reaches its tenant check before any network call,
+	// so this distinguishes the two without a live server.
+	_, err = keycloakDirectory.SearchUsers(context.Background(), "tenant-elsewhere", idpdirectory.UserSearch{})
+	if !errors.Is(err, idpdirectory.ErrUnknownTenant) {
+		t.Errorf("the Keycloak adapter returned %v, want %v", err, idpdirectory.ErrUnknownTenant)
+	}
+}
+
+func TestAnUnknownProviderIsRefusedRatherThanDefaulted(t *testing.T) {
+	_, err := provider.New(configFor(t, "ACTIVE_DIRECTORY"))
+	if err == nil {
+		t.Fatal("New accepted a provider type nobody implements")
+	}
+	// Silently falling back to Keycloak would mean a typo in production
+	// configuration selects a directory the operator did not ask for.
+	if !strings.Contains(err.Error(), "ACTIVE_DIRECTORY") {
+		t.Errorf("error = %v, want it to name the unsupported type", err)
+	}
+}
+
+// §16.1 and §7.4: the machine credential must never reach anything a browser
+// can read. The realistic leak is a log line or an error body, so the secret
+// type has to refuse to render itself.
+func TestTheServiceAccountSecretNeverRendersItself(t *testing.T) {
+	cfg := configFor(t, "KEYCLOAK")
+
+	rendered := []string{
+		cfg.ClientSecret.String(),
+		fmt.Sprintf("%v", cfg.ClientSecret),
+		fmt.Sprintf("%s", cfg.ClientSecret),
+		fmt.Sprintf("%v", cfg),
+		fmt.Sprintf("%+v", cfg),
+		mustJSON(t, cfg),
+	}
+	for _, text := range rendered {
+		if strings.Contains(text, secret) {
+			t.Errorf("a rendering of the configuration leaked the secret: %s", text)
+		}
+	}
+
+	// Redaction is worthless if it also hides the value from the adapter.
+	if cfg.ClientSecret.Reveal() != secret {
+		t.Error("Reveal did not return the secret the adapter needs")
+	}
+}
+
+// §7.1 calls it a credentialsSecretRef: the value arrives by reference, so the
+// secret is a mounted file rather than an environment variable visible in
+// `docker inspect` and in every child process.
+func TestTheSecretIsReadFromTheReferencedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "idp-admin-credentials")
+	if err := os.WriteFile(path, []byte(secret+"\n"), 0o600); err != nil {
+		t.Fatalf("writing the secret file: %v", err)
+	}
+
+	cfg, err := provider.FromEnv(lookup(map[string]string{
+		"IDP_TYPE":                   "KEYCLOAK",
+		"IDP_BASE_URL":               "http://keycloak:8080",
+		"IDP_REALM":                  "cerbos-poc",
+		"IDP_TENANT_ID":              "tenant-a",
+		"IDP_CLIENT_ID":              "patient-app",
+		"IDP_SERVICE_CLIENT_ID":      "authorization-admin-service",
+		"IDP_CREDENTIALS_SECRET_REF": path,
+	}))
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	// Trailing newlines are what every editor and `echo` adds; a secret that
+	// works from a here-doc and fails from a file is an unfindable bug.
+	if cfg.ClientSecret.Reveal() != secret {
+		t.Errorf("the secret read from the file was %q", cfg.ClientSecret.Reveal())
+	}
+}
+
+func TestAMissingSecretReferenceIsRefused(t *testing.T) {
+	_, err := provider.FromEnv(lookup(map[string]string{
+		"IDP_TYPE":     "KEYCLOAK",
+		"IDP_BASE_URL": "http://keycloak:8080",
+		"IDP_REALM":    "cerbos-poc",
+	}))
+	if err == nil {
+		t.Fatal("FromEnv accepted a configuration with no credentials reference")
+	}
+}
+
+// The issuer a token claims is the realm URL, so deriving it removes one
+// setting that could disagree with the base URL and reject every token.
+func TestTheIssuerAndKeySetAreDerivedFromTheRealm(t *testing.T) {
+	cfg := configFor(t, "KEYCLOAK")
+
+	if want := "http://keycloak:8080/realms/cerbos-poc"; cfg.Issuer != want {
+		t.Errorf("Issuer = %q, want %q", cfg.Issuer, want)
+	}
+	if want := "http://keycloak:8080/realms/cerbos-poc/protocol/openid-connect/certs"; cfg.JWKSURL() != want {
+		t.Errorf("JWKSURL = %q, want %q", cfg.JWKSURL(), want)
+	}
+	if cfg.RoleSource != tokenverifier.RoleSourceClient {
+		t.Errorf("RoleSource = %q, want CLIENT by default", cfg.RoleSource)
+	}
+}
+
+// The verifier and the directory are built from one configuration, so an
+// installation cannot end up verifying tokens for one realm while reading roles
+// out of another.
+func TestTheVerifierIsBuiltFromTheSameConfigurationAsTheDirectory(t *testing.T) {
+	cfg := configFor(t, "KEYCLOAK")
+
+	verifier, err := provider.NewVerifier(cfg)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	if verifier == nil {
+		t.Fatal("NewVerifier returned no verifier")
+	}
+}
+
+func configFor(t *testing.T, idpType string) provider.Config {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "idp-admin-credentials")
+	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
+		t.Fatalf("writing the secret file: %v", err)
+	}
+
+	cfg, err := provider.FromEnv(lookup(map[string]string{
+		"IDP_TYPE":                   idpType,
+		"IDP_BASE_URL":               "http://keycloak:8080",
+		"IDP_REALM":                  "cerbos-poc",
+		"IDP_TENANT_ID":              "tenant-a",
+		"IDP_CLIENT_ID":              "patient-app",
+		"IDP_SERVICE_CLIENT_ID":      "authorization-admin-service",
+		"IDP_CREDENTIALS_SECRET_REF": path,
+	}))
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	return cfg
+}
+
+func lookup(values map[string]string) func(string) (string, bool) {
+	return func(key string) (string, bool) {
+		value, ok := values[key]
+		return value, ok
+	}
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		// A configuration that cannot be serialised cannot leak through a
+		// serialised response either, so this is a pass, not a failure.
+		return ""
+	}
+	return string(encoded)
+}

--- a/libs/idpdirectory/provider/provider_test.go
+++ b/libs/idpdirectory/provider/provider_test.go
@@ -139,6 +139,38 @@ func TestTheIssuerAndKeySetAreDerivedFromTheRealm(t *testing.T) {
 	}
 }
 
+// A browser and a backend reach the identity provider by different names in
+// every deployment that publishes it. The issuer is what the browser's token
+// claims; the key set has to be fetched over the backend's own route, or the
+// service goes looking for the issuer at an address only a browser can resolve.
+func TestTheKeySetIsFetchedOverTheBackendRouteEvenWhenTheIssuerIsPublished(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "idp-admin-credentials")
+	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
+		t.Fatalf("writing the secret file: %v", err)
+	}
+
+	cfg, err := provider.FromEnv(lookup(map[string]string{
+		"IDP_TYPE":                   "KEYCLOAK",
+		"IDP_BASE_URL":               "http://keycloak:8080",
+		"IDP_ISSUER":                 "http://localhost:8081/realms/cerbos-poc",
+		"IDP_REALM":                  "cerbos-poc",
+		"IDP_TENANT_ID":              "tenant-a",
+		"IDP_CLIENT_ID":              "patient-app",
+		"IDP_SERVICE_CLIENT_ID":      "authorization-admin-service",
+		"IDP_CREDENTIALS_SECRET_REF": path,
+	}))
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+
+	if cfg.Issuer != "http://localhost:8081/realms/cerbos-poc" {
+		t.Errorf("Issuer = %q, want the published address the token claims", cfg.Issuer)
+	}
+	if want := "http://keycloak:8080/realms/cerbos-poc/protocol/openid-connect/certs"; cfg.JWKSURL() != want {
+		t.Errorf("JWKSURL = %q, want %q", cfg.JWKSURL(), want)
+	}
+}
+
 // The verifier and the directory are built from one configuration, so an
 // installation cannot end up verifying tokens for one realm while reading roles
 // out of another.

--- a/libs/idpdirectory/wso2/wso2.go
+++ b/libs/idpdirectory/wso2/wso2.go
@@ -1,0 +1,78 @@
+// Package wso2 is the WSO2 Identity Server adapter (§7.4).
+//
+// It is a stub. Every operation reports idpdirectory.ErrUnimplemented with the
+// SCIM2 API it would use, so an installation that selects WSO2_IS fails loudly
+// and specifically rather than behaving as if the directory were empty.
+//
+// The stub is not scaffolding. It is the proof that the seam is real: it
+// satisfies the same interface, is selected by the same configuration, and
+// nothing in the ADS or the Admin Console had to change to make room for it.
+package wso2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+// Config describes the WSO2 installation this adapter would serve (§7.4).
+type Config struct {
+	BaseURL string
+	// TenantDomain is WSO2's tenant, mapped to an authorization tenant by
+	// installation configuration.
+	TenantDomain string
+	TenantID     idpdirectory.TenantID
+	// ServiceUser is the least-privileged machine identity. §7.4 forbids
+	// proxying administrative credentials to the browser.
+	ServiceUser  string
+	ClientSecret string
+}
+
+// Directory is the WSO2 Identity Server adapter.
+type Directory struct {
+	cfg Config
+}
+
+// New returns the adapter.
+func New(cfg Config) (*Directory, error) {
+	if cfg.BaseURL == "" {
+		return nil, errors.New("wso2: a base url is required")
+	}
+	if cfg.TenantID == "" {
+		return nil, errors.New("wso2: a tenant is required")
+	}
+	return &Directory{cfg: cfg}, nil
+}
+
+func unimplemented(operation, api string) error {
+	return fmt.Errorf("%w: %s would use the WSO2 %s API", idpdirectory.ErrUnimplemented, operation, api)
+}
+
+// SearchUsers is not implemented. It would use SCIM2 /Users.
+func (d *Directory) SearchUsers(context.Context, idpdirectory.TenantID, idpdirectory.UserSearch) (idpdirectory.Page[idpdirectory.UserRef], error) {
+	return idpdirectory.Page[idpdirectory.UserRef]{}, unimplemented("user search", "SCIM2 /Users")
+}
+
+// SearchRoles is not implemented. It would use SCIM2 /Roles.
+func (d *Directory) SearchRoles(context.Context, idpdirectory.TenantID, idpdirectory.RoleSearch) (idpdirectory.Page[idpdirectory.RoleRef], error) {
+	return idpdirectory.Page[idpdirectory.RoleRef]{}, unimplemented("role search", "SCIM2 /Roles")
+}
+
+// GetUser is not implemented. It would use SCIM2 /Users/{id}.
+func (d *Directory) GetUser(context.Context, idpdirectory.TenantID, string) (idpdirectory.UserRef, error) {
+	return idpdirectory.UserRef{}, unimplemented("user lookup", "SCIM2 /Users/{id}")
+}
+
+// GetRole is not implemented. It would use SCIM2 /Roles/{id}.
+func (d *Directory) GetRole(context.Context, idpdirectory.TenantID, string) (idpdirectory.RoleRef, error) {
+	return idpdirectory.RoleRef{}, unimplemented("role lookup", "SCIM2 /Roles/{id}")
+}
+
+// ResolveRuntimeRoles is not implemented. It would normalise WSO2 groups and
+// roles into the same canonical identifiers §7.5 defines.
+func (d *Directory) ResolveRuntimeRoles(context.Context, tokenverifier.VerifiedToken, idpdirectory.TenantID) ([]string, error) {
+	return nil, unimplemented("runtime role resolution", "SCIM2 /Roles")
+}

--- a/libs/idpdirectory/wso2/wso2_test.go
+++ b/libs/idpdirectory/wso2/wso2_test.go
@@ -1,0 +1,67 @@
+package wso2_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/wso2"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+// The stub proves the seam: it satisfies the whole port, so a second provider
+// needs no change to the interface, and it fails loudly on every operation, so
+// selecting it can never be mistaken for an empty directory.
+func TestEveryOperationReportsThatItIsNotImplemented(t *testing.T) {
+	directory, err := wso2.New(wso2.Config{
+		BaseURL:  "https://identity.internal",
+		TenantID: "tenant-a",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Typed as the port, so this fails to compile if the stub ever stops
+	// implementing the whole interface.
+	var port idpdirectory.IdentityDirectory = directory
+	ctx := context.Background()
+
+	operations := map[string]func() error{
+		"SearchUsers": func() error {
+			_, err := port.SearchUsers(ctx, "tenant-a", idpdirectory.UserSearch{})
+			return err
+		},
+		"SearchRoles": func() error {
+			_, err := port.SearchRoles(ctx, "tenant-a", idpdirectory.RoleSearch{})
+			return err
+		},
+		"GetUser": func() error {
+			_, err := port.GetUser(ctx, "tenant-a", "user-doctor")
+			return err
+		},
+		"GetRole": func() error {
+			_, err := port.GetRole(ctx, "tenant-a", "doctor")
+			return err
+		},
+		"ResolveRuntimeRoles": func() error {
+			_, err := port.ResolveRuntimeRoles(ctx, tokenverifier.VerifiedToken{}, "tenant-a")
+			return err
+		},
+	}
+
+	for name, operation := range operations {
+		t.Run(name, func(t *testing.T) {
+			err := operation()
+			if !errors.Is(err, idpdirectory.ErrUnimplemented) {
+				t.Errorf("%s error = %v, want %v", name, err, idpdirectory.ErrUnimplemented)
+			}
+			// The message has to say which SCIM2 API the work would use, so
+			// the error is a starting point rather than a dead end.
+			if err != nil && !strings.Contains(err.Error(), "SCIM2") {
+				t.Errorf("%s error = %q, want it to name the SCIM2 API", name, err)
+			}
+		})
+	}
+}

--- a/libs/tokenverifier/go.mod
+++ b/libs/tokenverifier/go.mod
@@ -1,0 +1,7 @@
+module github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier
+
+go 1.25
+
+require github.com/tishan-harischandra/cerbos-poc/libs/canonicalid v0.0.0
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/canonicalid => ../canonicalid

--- a/libs/tokenverifier/jwks.go
+++ b/libs/tokenverifier/jwks.go
@@ -1,0 +1,176 @@
+package tokenverifier
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// DefaultJWKSTTL bounds how long a cached key set may outlive a rotation. Keys
+// are fetched off the token path, so this is only the upper bound: an unknown
+// kid refetches immediately.
+const DefaultJWKSTTL = 15 * time.Minute
+
+// DefaultMinRefetchWait rate-limits rotation refetches. Without it a stream of
+// tokens naming a kid the issuer never published turns into a stream of
+// requests to the issuer, which is a denial-of-service amplifier pointed at the
+// one dependency every login needs.
+const DefaultMinRefetchWait = 30 * time.Second
+
+// DefaultJWKSTimeout bounds one fetch, so a hung issuer cannot pin a request
+// goroutine indefinitely.
+const DefaultJWKSTimeout = 5 * time.Second
+
+// ErrKeyNotPublished means the issuer's key set does not contain the kid.
+var ErrKeyNotPublished = errors.New("the issuer does not publish this key id")
+
+// JWKSConfig configures the key source.
+type JWKSConfig struct {
+	URL    string
+	Client *http.Client
+	// TTL bounds how long a cached set is served without refetching.
+	TTL time.Duration
+	// MinRefetchWait is the shortest interval between two rotation-driven
+	// refetches.
+	MinRefetchWait time.Duration
+	Now            func() time.Time
+}
+
+// JWKS is a caching key source backed by an issuer's JWKS endpoint.
+type JWKS struct {
+	cfg JWKSConfig
+
+	mu        sync.Mutex
+	keys      map[string]*rsa.PublicKey
+	fetchedAt time.Time
+	// lastRotationRefetch tracks only the refetches an unknown kid triggered.
+	// A scheduled TTL refresh must not start the rate-limit clock, or the
+	// first rotation after one would be ignored for a whole interval.
+	lastRotationRefetch time.Time
+}
+
+// NewJWKS returns a key source that reads the issuer's published keys.
+func NewJWKS(cfg JWKSConfig) *JWKS {
+	if cfg.Client == nil {
+		cfg.Client = &http.Client{Timeout: DefaultJWKSTimeout}
+	}
+	if cfg.TTL <= 0 {
+		cfg.TTL = DefaultJWKSTTL
+	}
+	if cfg.MinRefetchWait <= 0 {
+		cfg.MinRefetchWait = DefaultMinRefetchWait
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &JWKS{cfg: cfg}
+}
+
+// KeyByID returns the published key with the given id, refetching the set once
+// when the id is unknown, which is what a key rotation looks like from here.
+func (j *JWKS) KeyByID(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	now := j.cfg.Now()
+	if j.keys == nil || now.Sub(j.fetchedAt) >= j.cfg.TTL {
+		if err := j.refresh(ctx, now); err != nil {
+			return nil, err
+		}
+	}
+
+	if key, ok := j.keys[kid]; ok {
+		return key, nil
+	}
+
+	if !j.lastRotationRefetch.IsZero() && now.Sub(j.lastRotationRefetch) < j.cfg.MinRefetchWait {
+		return nil, fmt.Errorf("%w: %q", ErrKeyNotPublished, kid)
+	}
+	j.lastRotationRefetch = now
+	if err := j.refresh(ctx, now); err != nil {
+		return nil, err
+	}
+	if key, ok := j.keys[kid]; ok {
+		return key, nil
+	}
+	return nil, fmt.Errorf("%w: %q", ErrKeyNotPublished, kid)
+}
+
+func (j *JWKS) refresh(ctx context.Context, now time.Time) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, j.cfg.URL, nil)
+	if err != nil {
+		return fmt.Errorf("building the key set request: %w", err)
+	}
+	response, err := j.cfg.Client.Do(request)
+	if err != nil {
+		return fmt.Errorf("fetching the key set: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("fetching the key set: the issuer answered %s", response.Status)
+	}
+	// A malicious or misconfigured issuer must not be able to make this
+	// service read an unbounded body into memory.
+	body, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("reading the key set: %w", err)
+	}
+
+	var set struct {
+		Keys []struct {
+			Kty string `json:"kty"`
+			Use string `json:"use"`
+			Kid string `json:"kid"`
+			N   string `json:"n"`
+			E   string `json:"e"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(body, &set); err != nil {
+		return fmt.Errorf("decoding the key set: %w", err)
+	}
+
+	keys := make(map[string]*rsa.PublicKey, len(set.Keys))
+	for _, entry := range set.Keys {
+		// Encryption keys share the endpoint with signing keys. Accepting one
+		// as a signature key would widen what counts as a valid token.
+		if entry.Kty != "RSA" || (entry.Use != "" && entry.Use != "sig") {
+			continue
+		}
+		key, err := rsaKey(entry.N, entry.E)
+		if err != nil {
+			continue
+		}
+		keys[entry.Kid] = key
+	}
+
+	j.keys = keys
+	j.fetchedAt = now
+	return nil
+}
+
+func rsaKey(modulus, exponent string) (*rsa.PublicKey, error) {
+	n, err := base64.RawURLEncoding.DecodeString(modulus)
+	if err != nil {
+		return nil, fmt.Errorf("decoding the modulus: %w", err)
+	}
+	e, err := base64.RawURLEncoding.DecodeString(exponent)
+	if err != nil {
+		return nil, fmt.Errorf("decoding the exponent: %w", err)
+	}
+	if len(e) == 0 || len(e) > 8 {
+		return nil, errors.New("the exponent is not a usable size")
+	}
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(n),
+		E: int(new(big.Int).SetBytes(e).Int64()),
+	}, nil
+}

--- a/libs/tokenverifier/jwks_test.go
+++ b/libs/tokenverifier/jwks_test.go
@@ -1,0 +1,161 @@
+package tokenverifier_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+func TestTheKeySetIsFetchedFromTheIssuerAndAnswersByKeyID(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating a key: %v", err)
+	}
+	server := jwksServer(t, map[string]*rsa.PublicKey{"kid-1": &key.PublicKey})
+	defer server.Close()
+
+	keys := tokenverifier.NewJWKS(tokenverifier.JWKSConfig{URL: server.URL})
+
+	got, err := keys.KeyByID(context.Background(), "kid-1")
+	if err != nil {
+		t.Fatalf("KeyByID: %v", err)
+	}
+	if got.N.Cmp(key.PublicKey.N) != 0 || got.E != key.PublicKey.E {
+		t.Error("the fetched key is not the one the issuer published")
+	}
+}
+
+// The JWKS endpoint is on the token path, so fetching it per request would put
+// an HTTP round trip in front of every authorization call.
+func TestTheKeySetIsCachedRatherThanFetchedPerToken(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating a key: %v", err)
+	}
+	var fetches atomic.Int64
+	server := countingJWKSServer(t, &fetches, map[string]*rsa.PublicKey{"kid-1": &key.PublicKey})
+	defer server.Close()
+
+	keys := tokenverifier.NewJWKS(tokenverifier.JWKSConfig{URL: server.URL, TTL: time.Hour})
+	for range 5 {
+		if _, err := keys.KeyByID(context.Background(), "kid-1"); err != nil {
+			t.Fatalf("KeyByID: %v", err)
+		}
+	}
+
+	if got := fetches.Load(); got != 1 {
+		t.Errorf("the key set was fetched %d times, want 1", got)
+	}
+}
+
+// Keycloak rotates signing keys. A kid the cache has never seen is the signal
+// that a rotation happened, so it forces exactly one refetch - and a second
+// unknown kid must not be able to hammer the issuer.
+func TestAnUnknownKeyIDRefetchesTheKeySetOnceAndThenFails(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating a key: %v", err)
+	}
+	var fetches atomic.Int64
+	server := countingJWKSServer(t, &fetches, map[string]*rsa.PublicKey{"kid-1": &key.PublicKey})
+	defer server.Close()
+
+	keys := tokenverifier.NewJWKS(tokenverifier.JWKSConfig{
+		URL:            server.URL,
+		TTL:            time.Hour,
+		MinRefetchWait: time.Hour,
+	})
+	if _, err := keys.KeyByID(context.Background(), "kid-1"); err != nil {
+		t.Fatalf("KeyByID: %v", err)
+	}
+	if _, err := keys.KeyByID(context.Background(), "rotated-in"); err == nil {
+		t.Fatal("KeyByID for an unpublished kid returned no error")
+	}
+	if _, err := keys.KeyByID(context.Background(), "rotated-in-again"); err == nil {
+		t.Fatal("KeyByID for an unpublished kid returned no error")
+	}
+
+	if got := fetches.Load(); got != 2 {
+		t.Errorf("the key set was fetched %d times, want 2: one warm-up and one rotation refetch", got)
+	}
+}
+
+func TestATokenSignedByARotatedInKeyVerifiesOnceTheIssuerPublishesIt(t *testing.T) {
+	first, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating a key: %v", err)
+	}
+	second, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating a key: %v", err)
+	}
+
+	published := map[string]*rsa.PublicKey{"kid-1": &first.PublicKey}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJWKS(t, w, published)
+	}))
+	defer server.Close()
+
+	keys := tokenverifier.NewJWKS(tokenverifier.JWKSConfig{URL: server.URL, TTL: time.Hour})
+	if _, err := keys.KeyByID(context.Background(), "kid-1"); err != nil {
+		t.Fatalf("KeyByID: %v", err)
+	}
+
+	published["kid-2"] = &second.PublicKey
+	if _, err := keys.KeyByID(context.Background(), "kid-2"); err != nil {
+		t.Fatalf("KeyByID after rotation: %v", err)
+	}
+}
+
+func jwksServer(t *testing.T, keys map[string]*rsa.PublicKey) *httptest.Server {
+	t.Helper()
+	var ignored atomic.Int64
+	return countingJWKSServer(t, &ignored, keys)
+}
+
+func countingJWKSServer(t *testing.T, fetches *atomic.Int64, keys map[string]*rsa.PublicKey) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetches.Add(1)
+		writeJWKS(t, w, keys)
+	}))
+}
+
+func writeJWKS(t *testing.T, w http.ResponseWriter, keys map[string]*rsa.PublicKey) {
+	t.Helper()
+	type jwk struct {
+		Kty string `json:"kty"`
+		Alg string `json:"alg"`
+		Use string `json:"use"`
+		Kid string `json:"kid"`
+		N   string `json:"n"`
+		E   string `json:"e"`
+	}
+	set := struct {
+		Keys []jwk `json:"keys"`
+	}{}
+	for kid, key := range keys {
+		set.Keys = append(set.Keys, jwk{
+			Kty: "RSA",
+			Alg: "RS256",
+			Use: "sig",
+			Kid: kid,
+			N:   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+			E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(set); err != nil {
+		t.Errorf("encoding the key set: %v", err)
+	}
+}

--- a/libs/tokenverifier/tokenverifier.go
+++ b/libs/tokenverifier/tokenverifier.go
@@ -1,0 +1,400 @@
+// Package tokenverifier turns a bearer token into a verified identity.
+//
+// §16.1 makes four checks mandatory - issuer, audience, expiry and signature -
+// and requires that only *configured* role claims are normalised. This package
+// is the single place that performs them, so the ADS never has to decide
+// whether a request field can be trusted: if it did not come out of a
+// VerifiedToken, it did not come from the identity provider.
+//
+// The synthetic role is the platform's to inject (§16.1, ADR-003). A token
+// presenting one is rejected outright rather than filtered, because a caller
+// who tried it is not a caller whose remaining claims are worth honouring.
+package tokenverifier
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/canonicalid"
+)
+
+// The failures a caller may want to tell apart. They are deliberately coarse:
+// an unauthenticated caller learns only that the token was refused, while the
+// service log keeps the detail.
+var (
+	// ErrMalformedToken covers anything that is not three base64url segments
+	// carrying JSON.
+	ErrMalformedToken = errors.New("the token is malformed")
+	// ErrUnexpectedAlgorithm guards the algorithm-confusion attack: a token
+	// header naming `none`, or an HMAC algorithm verified against a public
+	// key, must never be accepted.
+	ErrUnexpectedAlgorithm = errors.New("the token is not signed with an accepted algorithm")
+	// ErrUnknownKey means the header named a key the issuer does not publish.
+	ErrUnknownKey = errors.New("the token was signed with an unknown key")
+	// ErrInvalidSignature means the signature did not verify.
+	ErrInvalidSignature = errors.New("the token signature is invalid")
+	// ErrInvalidIssuer means the token came from somewhere else.
+	ErrInvalidIssuer = errors.New("the token issuer is not the configured issuer")
+	// ErrInvalidAudience means the token was minted for another client.
+	ErrInvalidAudience = errors.New("the token audience does not include this service")
+	// ErrExpired means the token is outside its validity window.
+	ErrExpired = errors.New("the token has expired")
+	// ErrNotYetValid means the token's nbf is in the future.
+	ErrNotYetValid = errors.New("the token is not valid yet")
+	// ErrReservedRole means the token claimed a role only the platform may
+	// assign.
+	ErrReservedRole = errors.New("the token carries a role reserved for the platform")
+	// ErrMissingTenant means the token carries no tenant, so no server-side
+	// tenant context could be derived.
+	ErrMissingTenant = errors.New("the token carries no tenant")
+)
+
+// RoleSource names which Keycloak role claim is authoritative (§7.3).
+type RoleSource string
+
+const (
+	// RoleSourceClient reads resource_access.<client-id>.roles.
+	RoleSourceClient RoleSource = "CLIENT"
+	// RoleSourceRealm reads realm_access.roles.
+	RoleSourceRealm RoleSource = "REALM"
+)
+
+// TenantMappingMode names where the tenant comes from (§7.1).
+type TenantMappingMode string
+
+const (
+	// TenantMappingClaim reads the configured tenant claim from the token.
+	TenantMappingClaim TenantMappingMode = "CLAIM"
+	// TenantMappingRealm uses the realm name as the tenant identifier.
+	TenantMappingRealm TenantMappingMode = "REALM"
+)
+
+// Default claim names. Keycloak emits tenant and hospital through user
+// attribute mappers, so the names are configurable rather than fixed.
+const (
+	DefaultTenantClaim   = "tenant_id"
+	DefaultHospitalClaim = "hospital_id"
+)
+
+// DefaultLeeway absorbs clock drift between the identity provider and this
+// service. Without it a correctly issued token is intermittently rejected on
+// hosts whose clocks differ by a second, which looks like a flaky login.
+const DefaultLeeway = 30 * time.Second
+
+// KeySource supplies the issuer's signing keys, keyed by the `kid` header.
+type KeySource interface {
+	KeyByID(ctx context.Context, kid string) (*rsa.PublicKey, error)
+}
+
+// Config describes the installation's identity provider (§7.1).
+type Config struct {
+	Issuer   string
+	Audience string
+	Realm    string
+
+	RoleSource RoleSource
+	// ClientID is the client whose roles are authoritative when RoleSource is
+	// CLIENT. It is also the audience Keycloak stamps on the token.
+	ClientID string
+
+	TenantMappingMode TenantMappingMode
+	TenantClaim       string
+	HospitalClaim     string
+
+	Keys   KeySource
+	Now    func() time.Time
+	Leeway time.Duration
+}
+
+// VerifiedToken is the identity the ADS is allowed to act on.
+type VerifiedToken struct {
+	Subject    string
+	Username   string
+	Issuer     string
+	TenantID   string
+	HospitalID string
+	// Roles are canonical §7.5 identifiers, byte-identical to the ones the
+	// identity directory reports for the same roles.
+	Roles     []string
+	IssuedAt  time.Time
+	ExpiresAt time.Time
+}
+
+// Verifier performs the §16.1 identity checks.
+type Verifier struct {
+	cfg Config
+}
+
+// New validates the configuration and returns a Verifier.
+func New(cfg Config) (*Verifier, error) {
+	switch {
+	case cfg.Issuer == "":
+		return nil, errors.New("tokenverifier: an issuer is required")
+	case cfg.Audience == "":
+		return nil, errors.New("tokenverifier: an audience is required")
+	case cfg.Keys == nil:
+		return nil, errors.New("tokenverifier: a key source is required")
+	}
+
+	if cfg.RoleSource == "" {
+		cfg.RoleSource = RoleSourceClient
+	}
+	if cfg.RoleSource == RoleSourceClient && cfg.ClientID == "" {
+		return nil, errors.New("tokenverifier: a client id is required when roles come from a client")
+	}
+	if cfg.TenantMappingMode == "" {
+		cfg.TenantMappingMode = TenantMappingClaim
+	}
+	if cfg.TenantMappingMode == TenantMappingRealm && cfg.Realm == "" {
+		return nil, errors.New("tokenverifier: a realm is required when the tenant is mapped from the realm")
+	}
+	if cfg.TenantClaim == "" {
+		cfg.TenantClaim = DefaultTenantClaim
+	}
+	if cfg.HospitalClaim == "" {
+		cfg.HospitalClaim = DefaultHospitalClaim
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.Leeway <= 0 {
+		cfg.Leeway = DefaultLeeway
+	}
+
+	return &Verifier{cfg: cfg}, nil
+}
+
+type jwtHeader struct {
+	Algorithm string `json:"alg"`
+	KeyID     string `json:"kid"`
+}
+
+type jwtClaims struct {
+	Issuer    string   `json:"iss"`
+	Subject   string   `json:"sub"`
+	Audience  audience `json:"aud"`
+	Username  string   `json:"preferred_username"`
+	ExpiresAt *int64   `json:"exp"`
+	NotBefore *int64   `json:"nbf"`
+	IssuedAt  *int64   `json:"iat"`
+
+	RealmAccess struct {
+		Roles []string `json:"roles"`
+	} `json:"realm_access"`
+	ResourceAccess map[string]struct {
+		Roles []string `json:"roles"`
+	} `json:"resource_access"`
+
+	// Everything else, so a configurable tenant or hospital claim can be read
+	// without this struct having to name it.
+	rest map[string]any
+}
+
+// audience decodes the JWT `aud` claim, which RFC 7519 allows to be either a
+// string or an array of strings. Keycloak emits both shapes depending on how
+// many audiences a client mapper adds.
+type audience []string
+
+func (a *audience) UnmarshalJSON(data []byte) error {
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*a = audience{single}
+		return nil
+	}
+	var many []string
+	if err := json.Unmarshal(data, &many); err != nil {
+		return fmt.Errorf("the aud claim is neither a string nor an array: %w", err)
+	}
+	*a = many
+	return nil
+}
+
+func (a audience) contains(want string) bool {
+	for _, value := range a {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Verify performs every §16.1 identity check and returns the identity the token
+// carries. A non-nil error means nothing in the token may be trusted.
+func (v *Verifier) Verify(ctx context.Context, raw string) (VerifiedToken, error) {
+	segments := strings.Split(strings.TrimSpace(raw), ".")
+	if len(segments) != 3 {
+		return VerifiedToken{}, ErrMalformedToken
+	}
+
+	header, err := decodeSegment[jwtHeader](segments[0])
+	if err != nil {
+		return VerifiedToken{}, ErrMalformedToken
+	}
+	// Signature before claims: an unverified payload is attacker-controlled
+	// input, and reading it first invites decisions based on it.
+	if header.Algorithm != "RS256" {
+		return VerifiedToken{}, fmt.Errorf("%w: %q", ErrUnexpectedAlgorithm, header.Algorithm)
+	}
+
+	key, err := v.cfg.Keys.KeyByID(ctx, header.KeyID)
+	if err != nil {
+		return VerifiedToken{}, fmt.Errorf("%w: %v", ErrUnknownKey, err)
+	}
+	if key == nil {
+		return VerifiedToken{}, ErrUnknownKey
+	}
+
+	signature, err := base64.RawURLEncoding.DecodeString(segments[2])
+	if err != nil {
+		return VerifiedToken{}, ErrMalformedToken
+	}
+	digest := sha256.Sum256([]byte(segments[0] + "." + segments[1]))
+	if err := rsa.VerifyPKCS1v15(key, crypto.SHA256, digest[:], signature); err != nil {
+		return VerifiedToken{}, ErrInvalidSignature
+	}
+
+	claims, err := decodeSegment[jwtClaims](segments[1])
+	if err != nil {
+		return VerifiedToken{}, ErrMalformedToken
+	}
+	if err := decodeRest(segments[1], &claims); err != nil {
+		return VerifiedToken{}, ErrMalformedToken
+	}
+
+	if subtle.ConstantTimeCompare([]byte(claims.Issuer), []byte(v.cfg.Issuer)) != 1 {
+		return VerifiedToken{}, fmt.Errorf("%w: %q", ErrInvalidIssuer, claims.Issuer)
+	}
+	if !claims.Audience.contains(v.cfg.Audience) {
+		return VerifiedToken{}, fmt.Errorf("%w: %v", ErrInvalidAudience, []string(claims.Audience))
+	}
+
+	now := v.cfg.Now()
+	if claims.ExpiresAt == nil {
+		return VerifiedToken{}, fmt.Errorf("%w: the token carries no expiry", ErrExpired)
+	}
+	expiresAt := time.Unix(*claims.ExpiresAt, 0)
+	if !now.Add(-v.cfg.Leeway).Before(expiresAt) {
+		return VerifiedToken{}, ErrExpired
+	}
+	if claims.NotBefore != nil {
+		notBefore := time.Unix(*claims.NotBefore, 0)
+		if now.Add(v.cfg.Leeway).Before(notBefore) {
+			return VerifiedToken{}, ErrNotYetValid
+		}
+	}
+
+	roles, err := v.normaliseRoles(claims)
+	if err != nil {
+		return VerifiedToken{}, err
+	}
+
+	tenant, err := v.tenantOf(claims)
+	if err != nil {
+		return VerifiedToken{}, err
+	}
+
+	verified := VerifiedToken{
+		Subject:    claims.Subject,
+		Username:   claims.Username,
+		Issuer:     claims.Issuer,
+		TenantID:   tenant,
+		HospitalID: stringClaim(claims.rest, v.cfg.HospitalClaim),
+		Roles:      roles,
+		ExpiresAt:  expiresAt,
+	}
+	if claims.IssuedAt != nil {
+		verified.IssuedAt = time.Unix(*claims.IssuedAt, 0)
+	}
+	return verified, nil
+}
+
+// normaliseRoles reads only the configured role claim (§16.1) and renders each
+// role as a canonical §7.5 identifier.
+func (v *Verifier) normaliseRoles(claims jwtClaims) ([]string, error) {
+	var raw []string
+	switch v.cfg.RoleSource {
+	case RoleSourceRealm:
+		raw = claims.RealmAccess.Roles
+	default:
+		raw = claims.ResourceAccess[v.cfg.ClientID].Roles
+	}
+
+	// The reserved-role check runs over every claim the token carries, not
+	// only the configured source. A caller smuggling `sys:` into the realm
+	// claim while the installation reads client roles is still a caller
+	// attempting to impersonate the platform.
+	for _, role := range allRoles(claims) {
+		if canonicalid.IsReserved(role) {
+			return nil, fmt.Errorf("%w: %q", ErrReservedRole, role)
+		}
+	}
+
+	roles := make([]string, 0, len(raw))
+	for _, role := range raw {
+		if role == "" {
+			continue
+		}
+		if v.cfg.RoleSource == RoleSourceRealm {
+			roles = append(roles, canonicalid.KeycloakRealmRole(v.cfg.Realm, role))
+			continue
+		}
+		roles = append(roles, canonicalid.KeycloakClientRole(v.cfg.Realm, v.cfg.ClientID, role))
+	}
+	return roles, nil
+}
+
+func (v *Verifier) tenantOf(claims jwtClaims) (string, error) {
+	if v.cfg.TenantMappingMode == TenantMappingRealm {
+		return v.cfg.Realm, nil
+	}
+	tenant := stringClaim(claims.rest, v.cfg.TenantClaim)
+	if tenant == "" {
+		return "", ErrMissingTenant
+	}
+	return tenant, nil
+}
+
+func allRoles(claims jwtClaims) []string {
+	roles := append([]string(nil), claims.RealmAccess.Roles...)
+	for _, access := range claims.ResourceAccess {
+		roles = append(roles, access.Roles...)
+	}
+	return roles
+}
+
+func stringClaim(rest map[string]any, name string) string {
+	value, ok := rest[name].(string)
+	if !ok {
+		return ""
+	}
+	return value
+}
+
+func decodeSegment[T any](segment string) (T, error) {
+	var value T
+	decoded, err := base64.RawURLEncoding.DecodeString(segment)
+	if err != nil {
+		return value, err
+	}
+	if err := json.Unmarshal(decoded, &value); err != nil {
+		return value, err
+	}
+	return value, nil
+}
+
+func decodeRest(segment string, claims *jwtClaims) error {
+	decoded, err := base64.RawURLEncoding.DecodeString(segment)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(decoded, &claims.rest)
+}

--- a/libs/tokenverifier/tokenverifier.go
+++ b/libs/tokenverifier/tokenverifier.go
@@ -338,18 +338,28 @@ func (v *Verifier) normaliseRoles(claims jwtClaims) ([]string, error) {
 		}
 	}
 
-	roles := make([]string, 0, len(raw))
-	for _, role := range raw {
+	return CanonicalRoles(v.cfg, raw), nil
+}
+
+// CanonicalRoles renders provider role names as canonical §7.5 identifiers.
+//
+// It is exported because the identity directory adapter has to produce exactly
+// the same strings for the same roles, and §7.5 makes that agreement a
+// requirement rather than a coincidence. Sharing this function is what makes it
+// structural: there is no second implementation to drift.
+func CanonicalRoles(cfg Config, names []string) []string {
+	roles := make([]string, 0, len(names))
+	for _, role := range names {
 		if role == "" {
 			continue
 		}
-		if v.cfg.RoleSource == RoleSourceRealm {
-			roles = append(roles, canonicalid.KeycloakRealmRole(v.cfg.Realm, role))
+		if cfg.RoleSource == RoleSourceRealm {
+			roles = append(roles, canonicalid.KeycloakRealmRole(cfg.Realm, role))
 			continue
 		}
-		roles = append(roles, canonicalid.KeycloakClientRole(v.cfg.Realm, v.cfg.ClientID, role))
+		roles = append(roles, canonicalid.KeycloakClientRole(cfg.Realm, cfg.ClientID, role))
 	}
-	return roles, nil
+	return roles
 }
 
 func (v *Verifier) tenantOf(claims jwtClaims) (string, error) {

--- a/libs/tokenverifier/tokenverifier_test.go
+++ b/libs/tokenverifier/tokenverifier_test.go
@@ -1,0 +1,347 @@
+package tokenverifier_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+const (
+	issuer   = "http://keycloak:8080/realms/cerbos-poc"
+	audience = "patient-app"
+	realm    = "cerbos-poc"
+)
+
+// A token minted by the realm, for this audience, still inside its lifetime is
+// the only shape that yields an identity. Everything the ADS later trusts -
+// principal, tenant, hospital, roles - comes from here and from nowhere the
+// browser can reach.
+func TestAWellFormedTokenYieldsTheIdentityItCarries(t *testing.T) {
+	fixture := newFixture(t)
+
+	verified, err := fixture.verifier(t).Verify(context.Background(), fixture.sign(t, fixture.valid(nil)))
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	if verified.Subject != "user-doctor" {
+		t.Errorf("Subject = %q, want %q", verified.Subject, "user-doctor")
+	}
+	if verified.Username != "doctor" {
+		t.Errorf("Username = %q, want %q", verified.Username, "doctor")
+	}
+	if verified.TenantID != "tenant-a" {
+		t.Errorf("TenantID = %q, want %q", verified.TenantID, "tenant-a")
+	}
+	if verified.HospitalID != "hospital-1" {
+		t.Errorf("HospitalID = %q, want %q", verified.HospitalID, "hospital-1")
+	}
+	if len(verified.Roles) != 1 || verified.Roles[0] != "kc:cerbos-poc:patient-app:doctor" {
+		t.Errorf("Roles = %v, want [kc:cerbos-poc:patient-app:doctor]", verified.Roles)
+	}
+}
+
+// The four mandatory §16.1 checks, each proven by the token that fails only it.
+// The valid token above is the control: every case below differs from it in one
+// respect, so a pass here cannot come from some unrelated rejection.
+func TestTheMandatoryIdentityChecksEachRejectATokenThatFailsThem(t *testing.T) {
+	fixture := newFixture(t)
+	otherKey := newFixture(t)
+
+	tests := []struct {
+		name  string
+		token func() string
+		want  error
+	}{
+		{
+			name: "another issuer",
+			token: func() string {
+				return fixture.sign(t, fixture.valid(claims{"iss": "http://evil.example/realms/cerbos-poc"}))
+			},
+			want: tokenverifier.ErrInvalidIssuer,
+		},
+		{
+			name: "another audience",
+			token: func() string {
+				return fixture.sign(t, fixture.valid(claims{"aud": "some-other-client"}))
+			},
+			want: tokenverifier.ErrInvalidAudience,
+		},
+		{
+			name: "an expiry in the past",
+			token: func() string {
+				return fixture.sign(t, fixture.valid(claims{
+					"exp": fixture.now.Add(-time.Hour).Unix(),
+				}))
+			},
+			want: tokenverifier.ErrExpired,
+		},
+		{
+			name: "a signature from a key the issuer does not publish",
+			token: func() string {
+				// Same kid, different key: the verifier finds a key and has
+				// to reject on the signature rather than on the lookup.
+				return signWith(t, otherKey.key, "test-key", "RS256", fixture.valid(nil))
+			},
+			want: tokenverifier.ErrInvalidSignature,
+		},
+		{
+			name: "a key id the issuer does not publish",
+			token: func() string {
+				return signWith(t, fixture.key, "rotated-away", "RS256", fixture.valid(nil))
+			},
+			want: tokenverifier.ErrUnknownKey,
+		},
+		{
+			name: "an algorithm nobody agreed to",
+			token: func() string {
+				return signWith(t, fixture.key, "test-key", "none", fixture.valid(nil))
+			},
+			want: tokenverifier.ErrUnexpectedAlgorithm,
+		},
+		{
+			name:  "something that is not a token at all",
+			token: func() string { return "not-a-token" },
+			want:  tokenverifier.ErrMalformedToken,
+		},
+		{
+			name: "no tenant to derive a server-side context from",
+			token: func() string {
+				payload := fixture.valid(nil)
+				delete(payload, "tenant_id")
+				return fixture.sign(t, payload)
+			},
+			want: tokenverifier.ErrMissingTenant,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := fixture.verifier(t).Verify(context.Background(), test.token())
+			if !errors.Is(err, test.want) {
+				t.Errorf("Verify error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+// The synthetic role is added only by the trusted ADS (§16.1). A token
+// presenting one is refused outright - not filtered, because the rest of a
+// forged claim set is not worth honouring.
+func TestATokenCarryingAReservedRoleIsRejectedOutright(t *testing.T) {
+	fixture := newFixture(t)
+
+	smuggled := []struct {
+		name    string
+		payload claims
+	}{
+		{
+			name: "in the configured client role claim",
+			payload: claims{"resource_access": map[string]any{
+				"patient-app": map[string]any{"roles": []string{"doctor", "sys:permission-evaluator"}},
+			}},
+		},
+		{
+			// The installation reads client roles, so this claim is not even
+			// normalised. It is still an impersonation attempt.
+			name:    "in a claim this installation does not read",
+			payload: claims{"realm_access": map[string]any{"roles": []string{"sys:permission-evaluator"}}},
+		},
+		{
+			name: "spelled in a different case",
+			payload: claims{"resource_access": map[string]any{
+				"patient-app": map[string]any{"roles": []string{"SYS:Permission-Evaluator"}},
+			}},
+		},
+		{
+			name: "under another client entirely",
+			payload: claims{"resource_access": map[string]any{
+				"patient-app": map[string]any{"roles": []string{"doctor"}},
+				"another-app": map[string]any{"roles": []string{"sys:anything"}},
+			}},
+		},
+	}
+
+	for _, test := range smuggled {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := fixture.verifier(t).Verify(context.Background(),
+				fixture.sign(t, fixture.valid(test.payload)))
+			if !errors.Is(err, tokenverifier.ErrReservedRole) {
+				t.Errorf("Verify error = %v, want %v", err, tokenverifier.ErrReservedRole)
+			}
+		})
+	}
+}
+
+// §16.1 says normalise *only* the configured role claims. An installation
+// reading client roles must not silently pick up realm roles as well, or a role
+// granted for an unrelated application becomes an authorization input.
+func TestOnlyTheConfiguredRoleClaimIsNormalised(t *testing.T) {
+	fixture := newFixture(t)
+
+	payload := fixture.valid(claims{
+		"realm_access": map[string]any{"roles": []string{"offline_access", "auditor"}},
+		"resource_access": map[string]any{
+			"patient-app": map[string]any{"roles": []string{"doctor"}},
+			"another-app": map[string]any{"roles": []string{"administrator"}},
+		},
+	})
+
+	verified, err := fixture.verifier(t).Verify(context.Background(), fixture.sign(t, payload))
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if len(verified.Roles) != 1 || verified.Roles[0] != "kc:cerbos-poc:patient-app:doctor" {
+		t.Fatalf("Roles = %v, want only the configured client's roles", verified.Roles)
+	}
+}
+
+func TestARealmRoleSourceNormalisesRealmRoles(t *testing.T) {
+	fixture := newFixture(t)
+
+	verifier, err := tokenverifier.New(tokenverifier.Config{
+		Issuer:     issuer,
+		Audience:   audience,
+		Realm:      realm,
+		RoleSource: tokenverifier.RoleSourceRealm,
+		ClientID:   "patient-app",
+		Keys:       staticKeys{"test-key": &fixture.key.PublicKey},
+		Now:        func() time.Time { return fixture.now },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	payload := fixture.valid(claims{
+		"realm_access": map[string]any{"roles": []string{"auditor"}},
+	})
+	verified, err := verifier.Verify(context.Background(), fixture.sign(t, payload))
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if len(verified.Roles) != 1 || verified.Roles[0] != "kc:cerbos-poc:realm:auditor" {
+		t.Errorf("Roles = %v, want [kc:cerbos-poc:realm:auditor]", verified.Roles)
+	}
+}
+
+// Keycloak emits `aud` as a bare string for a single audience and as an array
+// once a mapper adds a second one. Both have to verify, or enabling an
+// unrelated mapper starts rejecting every token.
+func TestAnAudienceArrayContainingTheClientIsAccepted(t *testing.T) {
+	fixture := newFixture(t)
+
+	payload := fixture.valid(claims{"aud": []string{"account", audience}})
+	if _, err := fixture.verifier(t).Verify(context.Background(), fixture.sign(t, payload)); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+}
+
+// --- fixture ---------------------------------------------------------------
+
+type claims map[string]any
+
+type fixture struct {
+	key *rsa.PrivateKey
+	now time.Time
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating a signing key: %v", err)
+	}
+	return &fixture{key: key, now: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)}
+}
+
+// valid is the token Keycloak would mint for the demo doctor. Every rejection
+// case starts from it and changes exactly one thing, so a rejection can only be
+// attributed to that change.
+func (f *fixture) valid(overrides claims) claims {
+	payload := claims{
+		"iss":                issuer,
+		"aud":                audience,
+		"sub":                "user-doctor",
+		"preferred_username": "doctor",
+		"exp":                f.now.Add(time.Hour).Unix(),
+		"iat":                f.now.Unix(),
+		"tenant_id":          "tenant-a",
+		"hospital_id":        "hospital-1",
+		"resource_access": map[string]any{
+			"patient-app": map[string]any{"roles": []string{"doctor"}},
+		},
+	}
+	for name, value := range overrides {
+		payload[name] = value
+	}
+	return payload
+}
+
+func (f *fixture) verifier(t *testing.T) *tokenverifier.Verifier {
+	t.Helper()
+	verifier, err := tokenverifier.New(tokenverifier.Config{
+		Issuer:     issuer,
+		Audience:   audience,
+		Realm:      realm,
+		RoleSource: tokenverifier.RoleSourceClient,
+		ClientID:   "patient-app",
+		Keys:       staticKeys{"test-key": &f.key.PublicKey},
+		Now:        func() time.Time { return f.now },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return verifier
+}
+
+// sign mints a token the way Keycloak would: RS256, a kid in the header, and
+// the claims under test.
+func (f *fixture) sign(t *testing.T, payload claims) string {
+	t.Helper()
+	return signWith(t, f.key, "test-key", "RS256", payload)
+}
+
+func signWith(t *testing.T, key *rsa.PrivateKey, kid, alg string, payload claims) string {
+	t.Helper()
+	header := map[string]any{"alg": alg, "typ": "JWT", "kid": kid}
+	signing := encodeSegment(t, header) + "." + encodeSegment(t, payload)
+
+	signature, err := signRS256(key, signing)
+	if err != nil {
+		t.Fatalf("signing: %v", err)
+	}
+	return signing + "." + base64.RawURLEncoding.EncodeToString(signature)
+}
+
+func encodeSegment(t *testing.T, value any) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("encoding a token segment: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(encoded)
+}
+
+type staticKeys map[string]*rsa.PublicKey
+
+func (s staticKeys) KeyByID(_ context.Context, kid string) (*rsa.PublicKey, error) {
+	key, ok := s[kid]
+	if !ok {
+		return nil, errors.New("no such key")
+	}
+	return key, nil
+}
+
+func signRS256(key *rsa.PrivateKey, signingInput string) ([]byte, error) {
+	digest := sha256.Sum256([]byte(signingInput))
+	return rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+}

--- a/scripts/tests/compose-contract.py
+++ b/scripts/tests/compose-contract.py
@@ -7,6 +7,7 @@ reachable only from inside the compose network.
 """
 from __future__ import annotations
 
+import json
 import pathlib
 import sys
 
@@ -67,6 +68,60 @@ def check_images_carry_no_native_clients() -> None:
         )
         if offenders:
             print(f"     found: {', '.join(sorted(set(offenders)))}")
+
+
+def check_identity_provider(services: dict) -> None:
+    """The §7.1 installation selection, as the running stack expresses it."""
+    check("service 'keycloak' is defined", "keycloak" in services)
+    if "keycloak" not in services:
+        return
+
+    keycloak = services["keycloak"]
+    # Unlike the PDP and the database, Keycloak has to be reachable from the
+    # browser: an OIDC redirect the user cannot follow is not a login.
+    check("keycloak is published to the host so a browser can log in",
+          bool(keycloak.get("ports")))
+    check("keycloak imports a realm rather than being configured by hand",
+          "--import-realm" in (keycloak.get("command") or []))
+
+    realm_import = REPO_ROOT / "deploy" / "keycloak" / "realm-cerbos-poc.json"
+    check("the realm import exists", realm_import.exists())
+    if realm_import.exists():
+        realm = json.loads(realm_import.read_text())
+        clients = {client["clientId"]: client for client in realm.get("clients", [])}
+        check("the realm defines the browser-facing client", "patient-app" in clients)
+        check("the realm defines the confidential service account",
+              "authorization-admin-service" in clients)
+        if "patient-app" in clients:
+            # §7.3: the client a browser holds must not be able to read the
+            # directory. A public client with a service account would hand
+            # every browser session an administrative identity.
+            check("the browser-facing client is public and has no service account",
+                  clients["patient-app"].get("publicClient") is True
+                  and not clients["patient-app"].get("serviceAccountsEnabled"))
+        if "authorization-admin-service" in clients:
+            service = clients["authorization-admin-service"]
+            check("the service account client is confidential and browserless",
+                  service.get("publicClient") is False
+                  and service.get("serviceAccountsEnabled") is True
+                  and not service.get("redirectUris"))
+
+    ads = services.get("ads", {})
+    environment = ads.get("environment") or {}
+    check("the ads waits for a healthy keycloak",
+          (ads.get("depends_on") or {}).get("keycloak", {}).get("condition") == "service_healthy")
+    check("the ads is told which identity provider to use", "IDP_TYPE" in environment)
+
+    # §7.1's credentialsSecretRef. A secret passed by value would be readable
+    # through `docker inspect` and inherited by every child process.
+    check("the ads reads the service account secret by reference, not by value",
+          "IDP_CREDENTIALS_SECRET_REF" in environment
+          and not any(key.endswith("CLIENT_SECRET") for key in environment))
+
+    console_environment = services.get("admin-console", {}).get("environment") or {}
+    check("no identity provider credential reaches the browser-facing service",
+          not any("SECRET" in key.upper() or "PASSWORD" in key.upper()
+                  for key in console_environment))
 
 
 def main() -> int:
@@ -144,6 +199,7 @@ def main() -> int:
         check(f"service '{name}' is built from a Dockerfile in this repo", bool(build))
 
     check_images_carry_no_native_clients()
+    check_identity_provider(services)
 
     if failures:
         print(f"\n{len(failures)} contract failure(s)")

--- a/scripts/tests/decision-e2e.sh
+++ b/scripts/tests/decision-e2e.sh
@@ -52,8 +52,8 @@ wait_for_decisions || exit 1
 # Canonical §7.5 role identifiers, matching the seeded role matrix exactly.
 # Token-to-role normalisation has to produce the same identifiers the matrix is
 # keyed by, so a second spelling here would resolve to no permissions at all.
-DOCTOR_ROLE="kc:realm:patient-app:doctor"
-AUDITOR_ROLE="kc:realm:patient-app:auditor"
+DOCTOR_ROLE="kc:cerbos-poc:patient-app:doctor"
+AUDITOR_ROLE="kc:cerbos-poc:patient-app:auditor"
 
 # Which roles each principal presents. Role grants now come from the database,
 # so a principal's roles are what decides its grants: giving every principal the

--- a/scripts/tests/decision-e2e.sh
+++ b/scripts/tests/decision-e2e.sh
@@ -8,11 +8,29 @@
 # up here.
 set -uo pipefail
 
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+# shellcheck source=scripts/tests/lib-token.sh
+source scripts/tests/lib-token.sh
+
 PORT="${ADMIN_CONSOLE_PORT:-4200}"
 CHECK_URL="http://127.0.0.1:${PORT}/api/ads/internal/authz/check"
 failures=0
 
 command -v jq >/dev/null 2>&1 || { echo "decision-e2e: jq is required" >&2; exit 1; }
+wait_for_keycloak || exit 1
+
+# Every principal below is a real Keycloak user, and every request carries the
+# token that user logged in with. Roles are therefore whatever the realm grants
+# them, which is the point: the identifiers in the seeded matrix have to be the
+# ones token normalisation produces, and a mismatch shows up here as a denial.
+declare -A TOKENS
+token_of() {
+  local principal="$1"
+  if [[ -z "${TOKENS[${principal}]:-}" ]]; then
+    TOKENS[${principal}]="$(token_for "${principal}")" || exit 1
+  fi
+  printf '%s' "${TOKENS[${principal}]}"
+}
 
 wait_for_decisions() {
   # Gate on the decision path itself rather than on /readyz. Readiness probes the
@@ -22,15 +40,16 @@ wait_for_decisions() {
   # is the only signal that means what this suite needs.
   #
   # Consecutive successes, because one success during a restart proves nothing.
-  local required=3 streak=0 code
-  local probe='{"tenantId":"tenant-a","hospitalId":"hospital-1","principalId":"user-unassigned",
-    "idpRoles":[],"resources":[{"kind":"patient_record","id":"patient-000",
+  local required=3 streak=0 code token
+  token="$(token_of user-unassigned)"
+  local probe='{"resources":[{"kind":"patient_record","id":"patient-000",
     "attributes":{"tenantId":"tenant-a","hospitalId":"hospital-1","status":"ACTIVE"},
     "actions":["read"]}]}'
 
   for _ in $(seq 1 60); do
     code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 \
-      -H 'Content-Type: application/json' --data "${probe}" "${CHECK_URL}" 2>/dev/null)"
+      -H 'Content-Type: application/json' -H "Authorization: Bearer ${token}" \
+      --data "${probe}" "${CHECK_URL}" 2>/dev/null)"
     if [[ "${code}" == "200" ]]; then
       streak=$((streak + 1))
       if (( streak >= required )); then
@@ -49,44 +68,18 @@ wait_for_decisions() {
 
 wait_for_decisions || exit 1
 
-# Canonical §7.5 role identifiers, matching the seeded role matrix exactly.
-# Token-to-role normalisation has to produce the same identifiers the matrix is
-# keyed by, so a second spelling here would resolve to no permissions at all.
-DOCTOR_ROLE="kc:cerbos-poc:patient-app:doctor"
-AUDITOR_ROLE="kc:cerbos-poc:patient-app:auditor"
-
-# Which roles each principal presents. Role grants now come from the database,
-# so a principal's roles are what decides its grants: giving every principal the
-# doctor role would make "a principal with no assignments is denied" untestable.
-roles_for() {
-  case "$1" in
-    user-doctor|user-doctor-revoked) jq -cn --arg r "${DOCTOR_ROLE}" '[$r]' ;;
-    user-auditor)                    jq -cn --arg r "${AUDITOR_ROLE}" '[$r]' ;;
-    *)                               echo '[]' ;;
-  esac
-}
-
-# decide <principal> <status> <resource-tenant> <actions-json> [extra-idp-role]
-# Echoes the decision response body.
+# decide <principal> <status> <resource-tenant> <actions-json>
+# Echoes the HTTP status, leaving the response body in /tmp/decision-body.
 decide() {
-  local principal="$1" status="$2" resource_tenant="$3" actions="$4" extra_role="${5:-}"
-  local roles
-  roles="$(roles_for "${principal}")"
-  if [[ -n "${extra_role}" ]]; then
-    roles="$(jq -cn --argjson base "${roles}" --arg extra "${extra_role}" '$base + [$extra]')"
-  fi
+  local principal="$1" status="$2" resource_tenant="$3" actions="$4"
+  local token
+  token="$(token_of "${principal}")"
 
   jq -cn \
-    --arg principal "${principal}" \
     --arg status "${status}" \
     --arg resourceTenant "${resource_tenant}" \
     --argjson actions "${actions}" \
-    --argjson idpRoles "${roles}" \
     '{
-      tenantId: "tenant-a",
-      hospitalId: "hospital-1",
-      principalId: $principal,
-      idpRoles: $idpRoles,
       resources: [{
         kind: "patient_record",
         id: "patient-456",
@@ -96,6 +89,7 @@ decide() {
     }' \
   | curl -sS -o /tmp/decision-body -w '%{http_code}' \
       -H 'Content-Type: application/json' \
+      -H "Authorization: Bearer ${token}" \
       -H 'X-Correlation-Id: decision-e2e' \
       --data @- "${CHECK_URL}"
 }
@@ -222,8 +216,9 @@ else
 fi
 
 # The synthetic role is the platform's to inject. A token claiming it must be
-# refused before a decision is attempted.
-code="$(decide user-doctor ACTIVE tenant-a '["read"]' "sys:permission-evaluator")"
+# refused before a decision is attempted; the realm carries a hostile fixture
+# user so this is a token Keycloak really minted.
+code="$(decide user-forger ACTIVE tenant-a '["read"]')"
 if [[ "${code}" == "403" ]]; then
   echo "ok   a token presenting the synthetic role is refused"
 else
@@ -237,7 +232,8 @@ fi
 # ADS refuses a structurally invalid request instead of forwarding it.
 code="$(curl -sS -o /tmp/decision-body -w '%{http_code}' \
   -H 'Content-Type: application/json' \
-  --data '{"tenantId":"tenant-a","hospitalId":"hospital-1","principalId":"user-doctor","resources":[]}' \
+  -H "Authorization: Bearer $(token_of user-doctor)" \
+  --data '{"resources":[]}' \
   "${CHECK_URL}")"
 if [[ "${code}" == "400" ]]; then
   echo "ok   a request with no resources is rejected"

--- a/scripts/tests/identity-e2e.sh
+++ b/scripts/tests/identity-e2e.sh
@@ -90,13 +90,11 @@ other_audience_token="$(token_for user-doctor reporting-app)" || exit 1
 expect_status "a token minted for another client is refused" 401 \
   "$(decide_with "${other_audience_token}")"
 
-# The master realm is a different issuer with a different key set.
-master_token="$(token_for "${KEYCLOAK_ADMIN:-admin}" admin-cli master)" || master_token=""
-if [[ -n "${master_token}" ]]; then
-  expect_status "a token from another issuer is refused" 401 "$(decide_with "${master_token}")"
-else
-  fail "a token from another issuer is refused (could not obtain a master realm token)"
-fi
+# A second realm mints a token that is genuine in every respect - real user,
+# valid signature, right audience - and signed by a key set this ADS does not
+# trust. Only the issuer check stands between it and a decision.
+other_issuer_token="$(token_for user-doctor patient-app other-issuer)" || exit 1
+expect_status "a token from another issuer is refused" 401 "$(decide_with "${other_issuer_token}")"
 
 # §16.1: the synthetic role prefix is the platform's. The realm carries a
 # hostile fixture role so this is a token Keycloak really issued.

--- a/scripts/tests/identity-e2e.sh
+++ b/scripts/tests/identity-e2e.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Identity end to end against a running `make up` stack.
+#
+# The unit suites prove each check in isolation. This proves the whole identity
+# path: an OIDC login against a real Keycloak, a real signature over a real key
+# set, and an ADS that accepts exactly the tokens it should and refuses the
+# rest. Token expiry is left to the unit suite - waiting out a real token's
+# lifetime would make this suite slow for no extra evidence.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+# shellcheck source=scripts/tests/lib-token.sh
+source scripts/tests/lib-token.sh
+
+PORT="${ADMIN_CONSOLE_PORT:-4200}"
+ADS_URL="http://127.0.0.1:${PORT}/api/ads"
+failures=0
+
+command -v jq >/dev/null 2>&1 || { echo "identity-e2e: jq is required" >&2; exit 1; }
+wait_for_keycloak || exit 1
+
+pass() { echo "ok   $1"; }
+fail() { echo "FAIL $1"; failures=$((failures + 1)); }
+
+expect_status() {
+  local description="$1" expected="$2" actual="$3" body="${4:-}"
+  if [[ "${actual}" == "${expected}" ]]; then
+    pass "${description}"
+  else
+    fail "${description} (HTTP ${actual}, want ${expected}${body:+: ${body}})"
+  fi
+}
+
+READ_REQUEST='{"resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-a","hospitalId":"hospital-1","status":"ACTIVE"},"actions":["read"]}]}'
+
+# decide_with <token> [body]
+# Echoes the HTTP status of a decision call, leaving the body in /tmp/identity-body.
+decide_with() {
+  local token="$1" body="${2:-${READ_REQUEST}}"
+  local auth=()
+  [[ -n "${token}" ]] && auth=(-H "Authorization: Bearer ${token}")
+
+  curl -sS -o /tmp/identity-body -w '%{http_code}' \
+    -H 'Content-Type: application/json' \
+    "${auth[@]}" \
+    --data "${body}" \
+    "${ADS_URL}/internal/authz/check"
+}
+
+echo "--- a real OIDC login ---"
+
+doctor_token="$(token_for user-doctor)" || exit 1
+pass "a user can log in against Keycloak and receive a token"
+
+roles="$(claim_of "${doctor_token}" '.resource_access["patient-app"].roles | join(",")')"
+if [[ "${roles}" == *"doctor"* ]]; then
+  pass "the token carries the user's roles"
+else
+  fail "the token carries the user's roles (roles were '${roles}')"
+fi
+
+subject="$(claim_of "${doctor_token}" '.sub')"
+if [[ "${subject}" == "user-doctor" ]]; then
+  pass "the token's subject is the identifier the authorization database keys on"
+else
+  fail "the token's subject is the identifier the authorization database keys on (was '${subject}')"
+fi
+
+tenant="$(claim_of "${doctor_token}" '.tenant_id')"
+if [[ "${tenant}" == "tenant-a" ]]; then
+  pass "the token carries the tenant the ADS will derive its context from"
+else
+  fail "the token carries the tenant (was '${tenant}')"
+fi
+
+echo
+echo "--- what the ADS accepts ---"
+
+expect_status "a valid token is accepted" 200 "$(decide_with "${doctor_token}")" "$(cat /tmp/identity-body)"
+
+echo
+echo "--- what the ADS refuses ---"
+
+expect_status "no token at all is refused" 401 "$(decide_with "")"
+expect_status "a tampered signature is refused" 401 "$(decide_with "$(tamper_with "${doctor_token}")")"
+
+# Signed by Keycloak, for a real user, and still not for this service: the
+# audience check is the only thing standing between the two.
+other_audience_token="$(token_for user-doctor reporting-app)" || exit 1
+expect_status "a token minted for another client is refused" 401 \
+  "$(decide_with "${other_audience_token}")"
+
+# The master realm is a different issuer with a different key set.
+master_token="$(token_for "${KEYCLOAK_ADMIN:-admin}" admin-cli master)" || master_token=""
+if [[ -n "${master_token}" ]]; then
+  expect_status "a token from another issuer is refused" 401 "$(decide_with "${master_token}")"
+else
+  fail "a token from another issuer is refused (could not obtain a master realm token)"
+fi
+
+# §16.1: the synthetic role prefix is the platform's. The realm carries a
+# hostile fixture role so this is a token Keycloak really issued.
+forger_token="$(token_for user-forger)" || exit 1
+expect_status "a token carrying a sys: role is refused outright" 403 "$(decide_with "${forger_token}")"
+
+echo
+echo "--- the browser cannot name itself ---"
+
+smuggled='{"tenantId":"tenant-b","resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-b","hospitalId":"hospital-1","status":"ACTIVE"},"actions":["read"]}]}'
+expect_status "a request naming its own tenant is refused" 400 \
+  "$(decide_with "${doctor_token}" "${smuggled}")"
+
+echo
+echo "--- the identity directory ---"
+
+admin_token="$(token_for user-admin)" || exit 1
+status="$(curl -sS -o /tmp/identity-body -w '%{http_code}' \
+  -H "Authorization: Bearer ${admin_token}" \
+  "${ADS_URL}/internal/directory/users?limit=2")"
+expect_status "user search answers" 200 "${status}" "$(cat /tmp/identity-body)"
+
+if [[ "${status}" == "200" ]]; then
+  count="$(jq -r '.items | length' /tmp/identity-body)"
+  has_more="$(jq -r '.hasMore' /tmp/identity-body)"
+  if [[ "${count}" == "2" && "${has_more}" == "true" ]]; then
+    pass "user search returns a page and reports that another follows"
+  else
+    fail "user search returns a page and reports that another follows (${count} items, hasMore=${has_more})"
+  fi
+
+  second="$(curl -sS "${ADS_URL}/internal/directory/users?limit=2&offset=2" \
+    -H "Authorization: Bearer ${admin_token}" | jq -r '.items[0].externalId')"
+  first="$(jq -r '.items[0].externalId' /tmp/identity-body)"
+  if [[ -n "${second}" && "${second}" != "${first}" ]]; then
+    pass "the next page is a different window over the directory"
+  else
+    fail "the next page is a different window over the directory (both started at '${first}')"
+  fi
+fi
+
+status="$(curl -sS -o /tmp/identity-body -w '%{http_code}' \
+  -H "Authorization: Bearer ${admin_token}" \
+  "${ADS_URL}/internal/directory/roles?limit=10")"
+expect_status "role search answers" 200 "${status}" "$(cat /tmp/identity-body)"
+
+if [[ "${status}" == "200" ]]; then
+  # §7.5: the identifier the directory reports has to be the one a token
+  # normalises to, or the console would write matrix rows nothing matches.
+  canonical="$(jq -r '.items[] | select(.name == "doctor") | .canonicalId' /tmp/identity-body)"
+  if [[ "${canonical}" == "kc:cerbos-poc:patient-app:doctor" ]]; then
+    pass "the directory's canonical identifier matches token normalisation byte for byte"
+  else
+    fail "the directory's canonical identifier matches token normalisation (was '${canonical}')"
+  fi
+fi
+
+expect_status "a directory query naming its own tenant is refused" 400 \
+  "$(curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${admin_token}" \
+    "${ADS_URL}/internal/directory/users?tenantId=tenant-b")"
+expect_status "the directory is not readable without a token" 401 \
+  "$(curl -sS -o /dev/null -w '%{http_code}' "${ADS_URL}/internal/directory/users")"
+
+echo
+echo "--- the admin credential stays server side ---"
+
+# Everything a browser can reach, checked for the one string that must never
+# appear in any of it.
+secret="$(tr -d '[:space:]' < deploy/secrets/idp-admin-credentials)"
+leaked=0
+for path in "/internal/directory/users?limit=5" "/internal/directory/roles?limit=5" "/readyz" "/healthz"; do
+  body="$(curl -sS -H "Authorization: Bearer ${admin_token}" "${ADS_URL}${path}")"
+  if grep -qF "${secret}" <<<"${body}"; then
+    fail "the IdP admin credential appeared in ${path}"
+    leaked=1
+  fi
+done
+if (( leaked == 0 )); then
+  pass "no browser-reachable ADS response carries the IdP admin credential"
+fi
+
+rm -f /tmp/identity-body
+
+if (( failures > 0 )); then
+  echo
+  echo "${failures} identity failure(s)"
+  exit 1
+fi
+
+echo
+echo "identity end to end passed"

--- a/scripts/tests/lib-token.sh
+++ b/scripts/tests/lib-token.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Shared helpers for obtaining real tokens from the running Keycloak.
+#
+# Everything the end-to-end suites send is a token the identity provider
+# actually minted. A hand-rolled JWT would prove only that the tests can build
+# one; these prove that a login, a signature, an audience and a role claim line
+# up all the way from Keycloak to a Cerbos decision.
+#
+# Source this file; it defines KEYCLOAK_URL, REALM and the helpers below.
+
+KEYCLOAK_URL="${KEYCLOAK_URL:-http://127.0.0.1:${KEYCLOAK_PORT:-8081}}"
+REALM="${IDP_REALM:-cerbos-poc}"
+DEMO_PASSWORD="${KEYCLOAK_DEMO_PASSWORD:-demo-password}"
+
+# token_for <username> [client-id] [realm]
+# Echoes an access token, or exits non-zero with the provider's message.
+token_for() {
+  local username="$1" client="${2:-patient-app}" realm="${3:-${REALM}}"
+  local response
+  response="$(curl -sS --max-time 10 \
+    -d "grant_type=password" \
+    -d "client_id=${client}" \
+    -d "username=${username}" \
+    -d "password=${DEMO_PASSWORD}" \
+    "${KEYCLOAK_URL}/realms/${realm}/protocol/openid-connect/token")" || return 1
+
+  local token
+  token="$(jq -r '.access_token // empty' <<<"${response}")"
+  if [[ -z "${token}" ]]; then
+    echo "token_for: ${username}@${client} did not receive a token: ${response}" >&2
+    return 1
+  fi
+  printf '%s' "${token}"
+}
+
+# claim_of <token> <jq-expression>
+# Reads a claim out of the payload segment without verifying anything: this is
+# for asserting what the identity provider put in the token, never for deciding
+# whether to trust it.
+claim_of() {
+  local token="$1" expression="$2" payload
+  payload="$(cut -d. -f2 <<<"${token}")"
+  # JWT uses base64url with the padding stripped; base64 wants both back.
+  payload="${payload//-/+}"
+  payload="${payload//_/\/}"
+  while (( ${#payload} % 4 )); do payload+="="; done
+  base64 -d <<<"${payload}" 2>/dev/null | jq -r "${expression}"
+}
+
+# tamper_with <token>
+# Returns the same token with one signature byte changed, which is the cheapest
+# possible forgery and must be refused.
+tamper_with() {
+  local token="$1" header payload signature
+  header="$(cut -d. -f1 <<<"${token}")"
+  payload="$(cut -d. -f2 <<<"${token}")"
+  signature="$(cut -d. -f3 <<<"${token}")"
+  local last="${signature: -1}"
+  local replacement="A"
+  [[ "${last}" == "A" ]] && replacement="B"
+  printf '%s.%s.%s%s' "${header}" "${payload}" "${signature%?}" "${replacement}"
+}
+
+# wait_for_keycloak waits until the realm's discovery document is served.
+wait_for_keycloak() {
+  for _ in $(seq 1 60); do
+    if curl -sS --max-time 5 -o /dev/null \
+      "${KEYCLOAK_URL}/realms/${REALM}/.well-known/openid-configuration"; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "keycloak never served the ${REALM} realm at ${KEYCLOAK_URL}" >&2
+  return 1
+}

--- a/scripts/tests/stack-smoke.sh
+++ b/scripts/tests/stack-smoke.sh
@@ -30,6 +30,16 @@ check "the ADS readiness endpoint answers" "$?"
 check "the ADS reaches Cerbos over gRPC from inside the network" "$?"
 [[ "${ready}" == *'"postgres":"ok"'* ]]
 check "the ADS reaches PostgreSQL from inside the network" "$?"
+[[ "${ready}" == *'"idp":"ok"'* ]]
+check "the ADS reaches the identity provider from inside the network" "$?"
+
+# Unlike the PDP, Keycloak has to be reachable from the host: a login is a
+# browser redirect, and a redirect nobody can follow is not a login.
+discovery="$(curl -fsS --max-time 5 \
+  "http://127.0.0.1:${KEYCLOAK_PORT:-8081}/realms/${IDP_REALM:-cerbos-poc}/.well-known/openid-configuration" 2>/dev/null)"
+check "the identity provider is reachable from the browser's side" "$?"
+grep -q 'authorization_endpoint' <<<"${discovery}"
+check "the realm publishes an authorization endpoint to log in against" "$?"
 
 ! curl -fsS --max-time 3 "http://127.0.0.1:3592/_cerbos/health" >/dev/null 2>&1
 check "the Cerbos PDP is not published to the host" "$?"

--- a/tests/architecture/adapterimports.go
+++ b/tests/architecture/adapterimports.go
@@ -1,0 +1,78 @@
+package architecture
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+)
+
+// ConcreteAdapterPackages are the identity provider implementations. Importing
+// one binds a consumer to a product: the type it returns, the errors it reports
+// and the configuration it needs all become part of that consumer's contract,
+// and the "swap the provider by changing IDP_TYPE" promise quietly stops being
+// true.
+var ConcreteAdapterPackages = []string{
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/keycloak",
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/wso2",
+}
+
+// CompositionRoots are the only places allowed to name an adapter: the provider
+// factory that selects one, and each adapter's own package.
+var CompositionRoots = []string{
+	"libs/idpdirectory/provider/",
+	"libs/idpdirectory/keycloak/",
+	"libs/idpdirectory/wso2/",
+}
+
+// ScanAdapterImports reports every import of a concrete adapter from a file
+// that is not a composition root.
+func ScanAdapterImports(filename, relativePath, src string) ([]Finding, error) {
+	if IsCompositionRoot(relativePath) {
+		return nil, nil
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, src, parser.ImportsOnly|parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", filename, err)
+	}
+
+	var findings []Finding
+	for _, imported := range file.Imports {
+		path, err := strconv.Unquote(imported.Path.Value)
+		if err != nil {
+			continue
+		}
+		for _, adapter := range ConcreteAdapterPackages {
+			if path != adapter {
+				continue
+			}
+			findings = append(findings, Finding{
+				File:   filename,
+				Line:   fset.Position(imported.Pos()).Line,
+				Symbol: path,
+				Message: "only the provider factory may name a concrete identity provider " +
+					"adapter; depend on idpdirectory.IdentityDirectory instead",
+			})
+		}
+	}
+	return findings, nil
+}
+
+// IsCompositionRoot reports whether a path is allowed to name an adapter. Test
+// files are included: a test asserting an adapter's own behaviour has to
+// construct it.
+func IsCompositionRoot(relativePath string) bool {
+	normalised := strings.ReplaceAll(relativePath, "\\", "/")
+	if strings.HasSuffix(normalised, "_test.go") {
+		return true
+	}
+	for _, root := range CompositionRoots {
+		if strings.HasPrefix(normalised, root) {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/architecture/adapterimports_test.go
+++ b/tests/architecture/adapterimports_test.go
@@ -1,0 +1,119 @@
+package architecture_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/tests/architecture"
+)
+
+// The constraint: the identity provider adapter is a library behind dependency
+// inversion, so no consumer may name a concrete adapter. If one did, "set
+// IDP_TYPE=WSO2_IS and rebuild nothing" would stop being true the moment that
+// consumer needed a Keycloak-shaped type.
+func TestNoConsumerImportsAConcreteIdentityProviderAdapter(t *testing.T) {
+	root := repoRoot(t)
+
+	var findings []architecture.Finding
+	for _, path := range goFiles(t, root) {
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatalf("relativising %s: %v", path, err)
+		}
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+
+		fileFindings, err := architecture.ScanAdapterImports(relative, relative, string(source))
+		if err != nil {
+			t.Fatalf("scanning %s: %v", relative, err)
+		}
+		findings = append(findings, fileFindings...)
+	}
+
+	if len(findings) > 0 {
+		var report strings.Builder
+		report.WriteString("a concrete identity provider adapter is imported outside the provider factory:\n")
+		for _, finding := range findings {
+			report.WriteString("  " + finding.String() + "\n")
+		}
+		t.Fatal(report.String())
+	}
+}
+
+// An architecture test that cannot fail is decoration.
+func TestTheCheckerCatchesAConsumerReachingForAnAdapter(t *testing.T) {
+	const violation = `package assignments
+
+import (
+	"context"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/keycloak"
+)
+
+// The defect: a consumer that has to know which product is installed.
+func lookup(ctx context.Context, directory *keycloak.Directory) error {
+	_, err := directory.GetUser(ctx, "tenant-a", "user-doctor")
+	return err
+}
+`
+
+	findings, err := architecture.ScanAdapterImports(
+		"apps/ads/internal/assignments/lookup.go",
+		"apps/ads/internal/assignments/lookup.go",
+		violation)
+	if err != nil {
+		t.Fatalf("ScanAdapterImports: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1; got %v", len(findings), findings)
+	}
+	if !strings.HasSuffix(findings[0].Symbol, "/keycloak") {
+		t.Errorf("finding names %q, want the Keycloak adapter", findings[0].Symbol)
+	}
+}
+
+func TestTheProviderFactoryMayNameEveryAdapter(t *testing.T) {
+	const factory = `package provider
+
+import (
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/keycloak"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/wso2"
+)
+
+var _ = keycloak.New
+var _ = wso2.New
+`
+
+	findings, err := architecture.ScanAdapterImports(
+		"libs/idpdirectory/provider/provider.go",
+		"libs/idpdirectory/provider/provider.go",
+		factory)
+	if err != nil {
+		t.Fatalf("ScanAdapterImports: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("the composition root was flagged: %v", findings)
+	}
+}
+
+func TestCompositionRootRules(t *testing.T) {
+	cases := map[string]bool{
+		"libs/idpdirectory/provider/provider.go":   true,
+		"libs/idpdirectory/keycloak/keycloak.go":   true,
+		"libs/idpdirectory/wso2/wso2.go":           true,
+		"apps/ads/internal/authz/authz_test.go":    true,
+		"apps/ads/cmd/ads/main.go":                 false,
+		"apps/ads/internal/tokenauth/tokenauth.go": false,
+		"libs/idpdirectory/port.go":                false,
+	}
+
+	for path, want := range cases {
+		if got := architecture.IsCompositionRoot(path); got != want {
+			t.Errorf("IsCompositionRoot(%q) = %t, want %t", path, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

- Added Keycloak as a compose service with an imported realm (`deploy/keycloak/realm-cerbos-poc.json`) defining the demo client, roles and users, plus a second realm (`realm-other-issuer.json`) used to prove issuer rejection.
- `libs/tokenverifier`: validates issuer, audience, expiry and signature against JWKS (`jwks.go`), normalises configured role claims into canonical identifiers, and rejects any token carrying a `sys:`-prefixed role.
- `libs/idpdirectory`: the §7.2 `IdentityDirectory` port (`port.go`), a Keycloak Admin REST implementation (`keycloak/keycloak.go`) using a least-privileged confidential service account, a `WSO2_IS` stub (`wso2/wso2.go`) returning a clear unimplemented error, and a `provider` package that selects the adapter from `IDP_TYPE`, `IDP_BASE_URL`, `IDP_ROLE_SOURCE`, `IDP_CLIENT_ID` and a credentials secret reference at the composition root.
- `libs/canonicalid`: shared canonical identifier formats (§7.5) used by both the token verifier and the directory adapter so normalisation is byte-identical.
- `tests/architecture/adapterimports.go` (+ test): forbids any consumer outside the composition root from importing a concrete adapter type (`keycloak` or `wso2` packages directly).
- ADS now derives principal, tenant, hospital and canonical roles from the verified token (`apps/ads/internal/tokenauth`, `internal/server`) instead of trusting request fields.
- `scripts/tests/identity-e2e.sh` + `scripts/tests/lib-token.sh`: end-to-end suite that drives real Keycloak password-grant tokens against the running stack.
- `scripts/tests/compose-contract.py`: new checks that Keycloak is defined, published, imports a realm, defines both clients correctly, the ADS waits on it and is told which IdP to use, and that no IdP credential is reachable from the browser-facing service.
- `deploy/secrets/idp-admin-credentials`: secret reference file for the confidential service account, read by reference and never embedded in a browser-reachable response.

## Acceptance criteria

- [x] A user can complete an OIDC login against Keycloak and receive a token carrying their roles — `scripts/tests/identity-e2e.sh` performs a password grant and inspects the resulting claims.
- [x] Tokens with a wrong issuer, wrong audience, expired claim or bad signature are all rejected — `libs/tokenverifier/tokenverifier_test.go` and the second realm (`realm-other-issuer.json`) exercise each case.
- [x] A token carrying any `sys:`-prefixed role is rejected outright — covered in `libs/tokenverifier/tokenverifier_test.go`.
- [x] Canonical identifiers from token normalisation are byte-identical to those from the directory adapter — both consume `libs/canonicalid`; covered by `libs/canonicalid/canonicalid_test.go` and cross-checked in `libs/idpdirectory/keycloak/keycloak_test.go`.
- [x] User and role search returns paginated results — `libs/idpdirectory/keycloak/keycloak.go` + tests.
- [x] Setting `IDP_TYPE=WSO2_IS` selects the stub with no code change and no rebuild of any consumer — `libs/idpdirectory/provider/provider_test.go`.
- [x] The architecture test fails if any consumer imports a concrete adapter type — `tests/architecture/adapterimports_test.go`.
- [x] IdP admin credentials never appear in any browser-reachable response — enforced by the credentials-by-reference secret and checked in `scripts/tests/compose-contract.py`.
- [x] Tenant and hospital are derived server-side; browser-supplied values are ignored — ADS derives these from the verified token, not request fields.

## Verification

- `make test` (Nx run-many across all 9 projects including `tokenverifier`, `idpdirectory`, `canonicalid`, `architecture`, `ads`, `admin-console`, plus the Cerbos policy suite and the compose contract) — all green.
- `scripts/tests/identity-e2e.sh` against the running compose stack with real Keycloak tokens.

Closes #6


Closes #6
