### PR TITLE
Capability evaluator and the capability snapshot endpoint (#11)

### DIFF
--- a/apps/ads/Dockerfile
+++ b/apps/ads/Dockerfile
@@ -14,6 +14,10 @@ COPY libs/permissioncontext/go.mod ./libs/permissioncontext/
 COPY libs/canonicalid/go.mod ./libs/canonicalid/
 COPY libs/tokenverifier/go.mod ./libs/tokenverifier/
 COPY libs/idpdirectory/go.mod ./libs/idpdirectory/
+COPY libs/authzcache/go.mod ./libs/authzcache/
+COPY libs/capabilitycatalog/go.mod libs/capabilitycatalog/go.sum ./libs/capabilitycatalog/
+COPY libs/capabilityeval/go.mod libs/capabilityeval/go.sum ./libs/capabilityeval/
+COPY libs/cataloggen/go.mod libs/cataloggen/go.sum ./libs/cataloggen/
 WORKDIR /src/apps/ads
 RUN go mod download
 

--- a/apps/ads/cmd/ads/main.go
+++ b/apps/ads/cmd/ads/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/assignments"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/capability"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/cerbos"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/config"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/directoryapi"
@@ -100,6 +101,20 @@ func main() {
 		DirectoryRolesHandler: authenticated(directoryapi.NewRolesHandler(directoryapi.Config{
 			Directory: directory,
 			Logger:    logger,
+		})),
+		CapabilityHandler: authenticated(capability.NewHandler(capability.Config{
+			PDP:               pdp,
+			CapabilityCatalog: capability.NewFSCatalog(cfg.CapabilityCatalogDir, cfg.CapabilityCatalogRevision, nil),
+			TargetResolver:    capability.DefaultTargetResolver{},
+			Assignments: assignments.NewResolver(assignments.ResolverConfig{
+				Matrix: assignments.NewCachingRoleMatrix(assignments.CacheConfig{
+					Matrix: store,
+					TTL:    cfg.RoleMatrixCacheTTL,
+				}),
+				Overrides: assignments.NewDBOverrides(store, nil),
+			}),
+			RootPolicyRevision: cfg.RootPolicyRevision,
+			Logger:             logger,
 		})),
 	})
 

--- a/apps/ads/go.mod
+++ b/apps/ads/go.mod
@@ -3,6 +3,7 @@ module github.com/tishan-harischandra/cerbos-poc/apps/ads
 go 1.25.11
 
 require (
+	github.com/tishan-harischandra/cerbos-poc/libs/authzcache v0.0.0-00010101000000-000000000000
 	github.com/tishan-harischandra/cerbos-poc/libs/canonicalid v0.0.0
 	google.golang.org/grpc v1.82.1
 )

--- a/apps/ads/go.mod
+++ b/apps/ads/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
+	github.com/tishan-harischandra/cerbos-poc/libs/cataloggen v0.0.0 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/zalando/go-keyring v0.2.8 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
@@ -73,6 +74,8 @@ require (
 
 require (
 	github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore v0.0.0
+	github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog v0.0.0
+	github.com/tishan-harischandra/cerbos-poc/libs/capabilityeval v0.0.0
 	github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient v0.0.0
 	github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory v0.0.0
 	github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext v0.0.0
@@ -85,6 +88,14 @@ require (
 )
 
 replace github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore => ../../libs/assignmentstore
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/authzcache => ../../libs/authzcache
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog => ../../libs/capabilitycatalog
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/capabilityeval => ../../libs/capabilityeval
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/cataloggen => ../../libs/cataloggen
 
 replace github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient => ../../libs/cerbosclient
 

--- a/apps/ads/internal/authz/authz.go
+++ b/apps/ads/internal/authz/authz.go
@@ -199,7 +199,7 @@ func NewHandler(cfg Config) http.Handler {
 				decision := result.Decisions[cerbosclient.Leaf{Resource: ref, Action: action}]
 				actions[action] = Decision{
 					Allowed: decision.Allowed,
-					Source:  decisionSource(action, decision.Allowed, result.FiredRules[ref]),
+					Source:  DecisionSource(action, decision.Allowed, result.FiredRules[ref]),
 				}
 			}
 			response.Resources = append(response.Resources, ResourceDecision{

--- a/apps/ads/internal/authz/decisionsource.go
+++ b/apps/ads/internal/authz/decisionsource.go
@@ -15,7 +15,7 @@ const (
 	SourceMandatory  Source = "MANDATORY_RULE"
 )
 
-// decisionSource labels one leaf's decision from the rule names that fired
+// DecisionSource labels one leaf's decision from the rule names that fired
 // for its resource. allowed is the PDP's own verdict for this action; the
 // fired rule names only say which named rule produced it.
 //
@@ -23,7 +23,10 @@ const (
 // tenant_and_hospital_isolation, locked_record_restriction, revoke_<action>,
 // grant_<action>_to_user and grant_<action>_to_role (§6.5/ADR-006), so the
 // rule name alone identifies the category without reading any action set.
-func decisionSource(action string, allowed bool, firedRules []string) Source {
+//
+// Exported so the capability endpoint (issue #11) can label the same
+// leaf-level facts without a second implementation of this mapping.
+func DecisionSource(action string, allowed bool, firedRules []string) Source {
 	fired := make(map[string]bool, len(firedRules))
 	for _, name := range firedRules {
 		fired[name] = true

--- a/apps/ads/internal/authz/decisionsource_test.go
+++ b/apps/ads/internal/authz/decisionsource_test.go
@@ -63,8 +63,8 @@ func TestDecisionSourceLabelsEveryCategory(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := decisionSource(c.action, c.allowed, c.firedRules); got != c.want {
-				t.Errorf("decisionSource(%q, %v, %v) = %q, want %q",
+			if got := DecisionSource(c.action, c.allowed, c.firedRules); got != c.want {
+				t.Errorf("DecisionSource(%q, %v, %v) = %q, want %q",
 					c.action, c.allowed, c.firedRules, got, c.want)
 			}
 		})

--- a/apps/ads/internal/capability/algorithm.go
+++ b/apps/ads/internal/capability/algorithm.go
@@ -31,7 +31,7 @@ func evaluate(ctx context.Context, cfg Config, maxResources int, identity tokena
 	}
 
 	// Step 2: resolve every targetRef into a concrete resource, server-side.
-	targets, targetOrder, err := resolveTargets(ctx, cfg, identity, req, defs)
+	targets, targetOrder, resourceAttrs, err := resolveTargets(ctx, cfg, identity, req, defs)
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("resolving targets: %w", err)
 	}
@@ -48,7 +48,7 @@ func evaluate(ctx context.Context, cfg Config, maxResources int, identity tokena
 	resourceActions, resourceOrder := groupLeavesByResource(leaves)
 
 	// Step 5: resolve assignments once per resource for this subject.
-	revision, resourceChecks, err := buildResourceChecks(ctx, cfg, identity, resourceOrder, resourceActions)
+	revision, resourceChecks, err := buildResourceChecks(ctx, cfg, identity, resourceOrder, resourceActions, resourceAttrs)
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("resolving assignments: %w", err)
 	}
@@ -128,7 +128,11 @@ func selectRequested(defs []capabilitycatalog.UiCapabilityDefinition, keys []str
 // resolveTargets resolves every distinct targetRef referenced by defs into
 // a concrete resource, server-side, exactly once per targetRef (§12.3 step
 // 2). targetOrder is returned purely for a deterministic fingerprint.
-func resolveTargets(ctx context.Context, cfg Config, identity tokenauth.Identity, req Request, defs []capabilitycatalog.UiCapabilityDefinition) (map[string]capabilityeval.ResourceRef, []string, error) {
+// resourceAttrs carries each resolved resource's trusted, server-loaded
+// attributes, keyed by the same ResourceRef the leaves and Cerbos batch
+// will use, so a resource resolved through two different targetRefs still
+// contributes its attributes once.
+func resolveTargets(ctx context.Context, cfg Config, identity tokenauth.Identity, req Request, defs []capabilitycatalog.UiCapabilityDefinition) (map[string]capabilityeval.ResourceRef, []string, map[capabilityeval.ResourceRef]map[string]any, error) {
 	kindByTargetRef := make(map[string]string)
 	collectTargetRefs(defs, kindByTargetRef)
 
@@ -139,6 +143,7 @@ func resolveTargets(ctx context.Context, cfg Config, identity tokenauth.Identity
 	sort.Strings(targetRefs)
 
 	targets := make(map[string]capabilityeval.ResourceRef, len(targetRefs))
+	resourceAttrs := make(map[capabilityeval.ResourceRef]map[string]any, len(targetRefs))
 	for _, targetRef := range targetRefs {
 		resolved, err := cfg.TargetResolver.Resolve(ctx, TargetQuery{
 			TenantID:     identity.TenantID,
@@ -148,11 +153,14 @@ func resolveTargets(ctx context.Context, cfg Config, identity tokenauth.Identity
 			RouteContext: req.Context,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("resolving targetRef %q: %w", targetRef, err)
+			return nil, nil, nil, fmt.Errorf("resolving targetRef %q: %w", targetRef, err)
 		}
 		targets[targetRef] = resolved.Resource
+		if resolved.Attributes != nil {
+			resourceAttrs[resolved.Resource] = resolved.Attributes
+		}
 	}
-	return targets, targetRefs, nil
+	return targets, targetRefs, resourceAttrs, nil
 }
 
 func collectTargetRefs(defs []capabilitycatalog.UiCapabilityDefinition, out map[string]string) {
@@ -203,7 +211,7 @@ func groupLeavesByResource(leaves []capabilityeval.Leaf) (map[capabilityeval.Res
 // buildResourceChecks resolves assignments once per resource for this
 // principal (§12.3 step 5) and assembles each resource's permissionContext,
 // returning the authorization revision they were resolved at.
-func buildResourceChecks(ctx context.Context, cfg Config, identity tokenauth.Identity, order []capabilityeval.ResourceRef, actionsByResource map[capabilityeval.ResourceRef][]string) (int64, []cerbosclient.ResourceCheck, error) {
+func buildResourceChecks(ctx context.Context, cfg Config, identity tokenauth.Identity, order []capabilityeval.ResourceRef, actionsByResource map[capabilityeval.ResourceRef][]string, resourceAttrs map[capabilityeval.ResourceRef]map[string]any) (int64, []cerbosclient.ResourceCheck, error) {
 	var revision int64
 	checks := make([]cerbosclient.ResourceCheck, 0, len(order))
 
@@ -225,14 +233,22 @@ func buildResourceChecks(ctx context.Context, cfg Config, identity tokenauth.Ide
 			revision = assembled.PermissionRevision
 		}
 
+		// The resolver's own trusted attributes come first so
+		// tenantId/hospitalId/permissionContext, which every resource must
+		// carry regardless of what the resolver returned, can never be
+		// shadowed by it.
+		attr := make(map[string]any, len(resourceAttrs[ref])+3)
+		for name, value := range resourceAttrs[ref] {
+			attr[name] = value
+		}
+		attr["tenantId"] = identity.TenantID
+		attr["hospitalId"] = identity.HospitalID
+		attr["permissionContext"] = assembled.AsMap()
+
 		checks = append(checks, cerbosclient.ResourceCheck{
 			Resource: cerbosclient.ResourceRef{Kind: ref.Kind, ID: ref.ID},
-			Attr: map[string]any{
-				"tenantId":          identity.TenantID,
-				"hospitalId":        identity.HospitalID,
-				"permissionContext": assembled.AsMap(),
-			},
-			Actions: actionsByResource[ref],
+			Attr:     attr,
+			Actions:  actionsByResource[ref],
 		})
 	}
 

--- a/apps/ads/internal/capability/algorithm.go
+++ b/apps/ads/internal/capability/algorithm.go
@@ -1,0 +1,325 @@
+package capability
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilityeval"
+	"github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient"
+	"github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext"
+)
+
+// evaluate implements the §12.3 backend evaluation algorithm end to end.
+func evaluate(ctx context.Context, cfg Config, maxResources int, identity tokenauth.Identity, req Request) (Snapshot, error) {
+	// Step 1: load definitions for the active capability-catalog revision.
+	allDefs, catalogRevision, err := cfg.CapabilityCatalog.Definitions(ctx, req.Module)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("loading capability definitions: %w", err)
+	}
+
+	defs, err := selectRequested(allDefs, req.CapabilityKeys)
+	if err != nil {
+		return Snapshot{}, err
+	}
+
+	// Step 2: resolve every targetRef into a concrete resource, server-side.
+	targets, targetOrder, err := resolveTargets(ctx, cfg, identity, req, defs)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("resolving targets: %w", err)
+	}
+
+	// Steps 3-4: flatten and deduplicate every permission leaf.
+	leaves, err := capabilityeval.Flatten(defs, targets)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("flattening capabilities: %w", err)
+	}
+
+	// Group deduplicated leaves by resource, so assignments and Cerbos are
+	// each asked about one resource once, regardless of how many
+	// capabilities or actions touch it (§12.3 steps 4-5).
+	resourceActions, resourceOrder := groupLeavesByResource(leaves)
+
+	// Step 5: resolve assignments once per resource for this subject.
+	revision, resourceChecks, err := buildResourceChecks(ctx, cfg, identity, resourceOrder, resourceActions)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("resolving assignments: %w", err)
+	}
+
+	// Steps 6-7: issue a bounded number of Cerbos calls and merge results.
+	decisions, firedRules, err := checkInChunks(ctx, cfg, maxResources, identity, resourceChecks)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("checking resources: %w", err)
+	}
+
+	leafOutcomes := make(map[capabilityeval.Leaf]capabilityeval.LeafOutcome, len(leaves))
+	for _, leaf := range leaves {
+		ref := cerbosclient.ResourceRef{Kind: leaf.Resource.Kind, ID: leaf.Resource.ID}
+		decision := decisions[cerbosclient.Leaf{Resource: ref, Action: leaf.Action}]
+		leafOutcomes[leaf] = capabilityeval.LeafOutcome{
+			Allowed: decision.Allowed,
+			Reason:  string(authz.DecisionSource(leaf.Action, decision.Allowed, firedRules[ref])),
+		}
+	}
+
+	// Step 8: evaluate every capability expression in memory.
+	outcomes, err := capabilityeval.Evaluate(defs, targets, leafOutcomes)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("evaluating capabilities: %w", err)
+	}
+
+	// Step 9: assemble the snapshot.
+	capabilities := make(map[string]CapabilityResult, len(outcomes))
+	for key, outcome := range outcomes {
+		result := CapabilityResult{Allowed: outcome.Allowed, Reason: outcome.Reason}
+		// §12.4: end-user responses carry a stable reason code only. The
+		// full requirement tree is administration-audience evidence and
+		// must never reach an end-user path (issue #11 acceptance
+		// criteria), so it is only attached for AudienceAdmin.
+		if cfg.Audience == AudienceAdmin {
+			for _, f := range outcome.FailedRequirements {
+				result.FailedRequirements = append(result.FailedRequirements, FailedRequirement{
+					Resource: f.Resource, Action: f.Action, Target: f.Target, Reason: f.Reason,
+				})
+			}
+		}
+		capabilities[key] = result
+	}
+
+	return Snapshot{
+		AuthorizationRevision:     revision,
+		RootPolicyRevision:        cfg.RootPolicyRevision,
+		CapabilityCatalogRevision: catalogRevision,
+		TenantID:                  identity.TenantID,
+		HospitalID:                identity.HospitalID,
+		Module:                    req.Module,
+		ContextFingerprint:        contextFingerprint(identity, req, targetOrder, targets),
+		Capabilities:              capabilities,
+	}, nil
+}
+
+// selectRequested filters defs down to exactly the requested capability
+// keys, in request order, failing with a client error if a key names a
+// capability the module does not have.
+func selectRequested(defs []capabilitycatalog.UiCapabilityDefinition, keys []string) ([]capabilitycatalog.UiCapabilityDefinition, error) {
+	byKey := make(map[string]capabilitycatalog.UiCapabilityDefinition, len(defs))
+	for _, d := range defs {
+		byKey[d.Key] = d
+	}
+
+	selected := make([]capabilitycatalog.UiCapabilityDefinition, 0, len(keys))
+	for _, key := range keys {
+		def, ok := byKey[key]
+		if !ok {
+			return nil, &badRequestError{msg: fmt.Sprintf("unknown capability key %q", key)}
+		}
+		selected = append(selected, def)
+	}
+	return selected, nil
+}
+
+// resolveTargets resolves every distinct targetRef referenced by defs into
+// a concrete resource, server-side, exactly once per targetRef (§12.3 step
+// 2). targetOrder is returned purely for a deterministic fingerprint.
+func resolveTargets(ctx context.Context, cfg Config, identity tokenauth.Identity, req Request, defs []capabilitycatalog.UiCapabilityDefinition) (map[string]capabilityeval.ResourceRef, []string, error) {
+	kindByTargetRef := make(map[string]string)
+	collectTargetRefs(defs, kindByTargetRef)
+
+	targetRefs := make([]string, 0, len(kindByTargetRef))
+	for ref := range kindByTargetRef {
+		targetRefs = append(targetRefs, ref)
+	}
+	sort.Strings(targetRefs)
+
+	targets := make(map[string]capabilityeval.ResourceRef, len(targetRefs))
+	for _, targetRef := range targetRefs {
+		resolved, err := cfg.TargetResolver.Resolve(ctx, TargetQuery{
+			TenantID:     identity.TenantID,
+			HospitalID:   identity.HospitalID,
+			ResourceKind: kindByTargetRef[targetRef],
+			TargetRef:    targetRef,
+			RouteContext: req.Context,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving targetRef %q: %w", targetRef, err)
+		}
+		targets[targetRef] = resolved.Resource
+	}
+	return targets, targetRefs, nil
+}
+
+func collectTargetRefs(defs []capabilitycatalog.UiCapabilityDefinition, out map[string]string) {
+	var walk func(e capabilitycatalog.Expression)
+	walk = func(e capabilitycatalog.Expression) {
+		switch {
+		case e.Permission != nil:
+			out[e.Permission.TargetRef] = e.Permission.Resource
+		case e.AllOf != nil:
+			for _, c := range e.AllOf {
+				walk(c)
+			}
+		case e.AnyOf != nil:
+			for _, c := range e.AnyOf {
+				walk(c)
+			}
+		}
+	}
+	for _, def := range defs {
+		walk(def.Expression)
+	}
+}
+
+// groupLeavesByResource collapses the deduplicated leaf list into one
+// action set per resource, so a resource with several required actions is
+// still asked about once (§12.3 step 6). resourceOrder is sorted so the
+// resulting Cerbos batches - and therefore which chunk a resource lands in
+// - are deterministic.
+func groupLeavesByResource(leaves []capabilityeval.Leaf) (map[capabilityeval.ResourceRef][]string, []capabilityeval.ResourceRef) {
+	actionsByResource := make(map[capabilityeval.ResourceRef][]string)
+	for _, leaf := range leaves {
+		actionsByResource[leaf.Resource] = append(actionsByResource[leaf.Resource], leaf.Action)
+	}
+
+	order := make([]capabilityeval.ResourceRef, 0, len(actionsByResource))
+	for ref := range actionsByResource {
+		order = append(order, ref)
+	}
+	sort.Slice(order, func(i, j int) bool {
+		if order[i].Kind != order[j].Kind {
+			return order[i].Kind < order[j].Kind
+		}
+		return order[i].ID < order[j].ID
+	})
+	return actionsByResource, order
+}
+
+// buildResourceChecks resolves assignments once per resource for this
+// principal (§12.3 step 5) and assembles each resource's permissionContext,
+// returning the authorization revision they were resolved at.
+func buildResourceChecks(ctx context.Context, cfg Config, identity tokenauth.Identity, order []capabilityeval.ResourceRef, actionsByResource map[capabilityeval.ResourceRef][]string) (int64, []cerbosclient.ResourceCheck, error) {
+	var revision int64
+	checks := make([]cerbosclient.ResourceCheck, 0, len(order))
+
+	for _, ref := range order {
+		input, err := cfg.Assignments.For(ctx, authz.AssignmentQuery{
+			TenantID:     identity.TenantID,
+			HospitalID:   identity.HospitalID,
+			PrincipalID:  identity.PrincipalID,
+			ResourceKind: ref.Kind,
+			ResourceID:   ref.ID,
+			IdPRoles:     identity.Roles,
+		})
+		if err != nil {
+			return 0, nil, fmt.Errorf("resolving assignments for %s/%s: %w", ref.Kind, ref.ID, err)
+		}
+
+		assembled := permissioncontext.Assemble(input)
+		if assembled.PermissionRevision > revision {
+			revision = assembled.PermissionRevision
+		}
+
+		checks = append(checks, cerbosclient.ResourceCheck{
+			Resource: cerbosclient.ResourceRef{Kind: ref.Kind, ID: ref.ID},
+			Attr: map[string]any{
+				"tenantId":          identity.TenantID,
+				"hospitalId":        identity.HospitalID,
+				"permissionContext": assembled.AsMap(),
+			},
+			Actions: actionsByResource[ref],
+		})
+	}
+
+	return revision, checks, nil
+}
+
+// checkInChunks issues a bounded number of Cerbos CheckResources calls -
+// never one per capability, and automatically split if the resource count
+// would exceed maxResources - and merges every chunk's decisions and fired
+// rules (§12.3 steps 6-7, §15.2).
+func checkInChunks(ctx context.Context, cfg Config, maxResources int, identity tokenauth.Identity, checks []cerbosclient.ResourceCheck) (map[cerbosclient.Leaf]cerbosclient.Decision, map[cerbosclient.ResourceRef][]string, error) {
+	decisions := make(map[cerbosclient.Leaf]cerbosclient.Decision)
+	firedRules := make(map[cerbosclient.ResourceRef][]string)
+
+	if len(checks) == 0 {
+		return decisions, firedRules, nil
+	}
+
+	for start := 0; start < len(checks); start += maxResources {
+		end := start + maxResources
+		if end > len(checks) {
+			end = len(checks)
+		}
+
+		result, err := cfg.PDP.Check(ctx, cerbosclient.Request{
+			Principal: cerbosclient.Principal{
+				ID: identity.PrincipalID,
+				Attr: map[string]any{
+					"tenantId":   identity.TenantID,
+					"hospitalId": identity.HospitalID,
+					"idpRoles":   identity.Roles,
+				},
+			},
+			Resources: checks[start:end],
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		for leaf, decision := range result.Decisions {
+			decisions[leaf] = decision
+		}
+		for ref, rules := range result.FiredRules {
+			firedRules[ref] = rules
+		}
+	}
+
+	return decisions, firedRules, nil
+}
+
+// contextFingerprint hashes everything the resolved snapshot depends on
+// beyond the two revisions: the module, the exact capability keys asked
+// for, and the routing context that drove targetRef resolution. Two
+// requests that resolve to the same fingerprint are asking the identical
+// question, which is what makes it safe for the frontend to cache a
+// snapshot by fingerprint (§12.6).
+func contextFingerprint(identity tokenauth.Identity, req Request, targetOrder []string, targets map[string]capabilityeval.ResourceRef) string {
+	var b strings.Builder
+	b.WriteString(identity.TenantID)
+	b.WriteString("|")
+	b.WriteString(identity.HospitalID)
+	b.WriteString("|")
+	b.WriteString(req.Module)
+
+	keys := append([]string(nil), req.CapabilityKeys...)
+	sort.Strings(keys)
+	for _, key := range keys {
+		b.WriteString("|k:")
+		b.WriteString(key)
+	}
+
+	for _, targetRef := range targetOrder {
+		ref := targets[targetRef]
+		b.WriteString("|t:")
+		b.WriteString(targetRef)
+		b.WriteString("=")
+		b.WriteString(ref.Kind)
+		b.WriteString(":")
+		b.WriteString(ref.ID)
+	}
+
+	sum := sha256.Sum256([]byte(b.String()))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// formatCatalogRevision renders an int64 catalog revision into the string
+// shape §12.4 shows ("ui-capabilities-v12"). Exported for adapters that
+// store the revision as a bare number.
+func formatCatalogRevision(revision int64) string {
+	return "ui-capabilities-v" + strconv.FormatInt(revision, 10)
+}

--- a/apps/ads/internal/capability/capability.go
+++ b/apps/ads/internal/capability/capability.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"sort"
 
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
@@ -231,15 +230,4 @@ func writeJSON(w http.ResponseWriter, status int, body any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(body)
-}
-
-// sortedKeys is a small determinism helper used by the fingerprint and by
-// tests.
-func sortedKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/apps/ads/internal/capability/capability.go
+++ b/apps/ads/internal/capability/capability.go
@@ -1,0 +1,245 @@
+// Package capability serves the ADS's capability snapshot endpoint: the
+// §12.3 backend evaluation algorithm end to end (issue #11, ADR-005).
+//
+// It resolves every requested capability's targetRefs server-side, batches
+// the resulting permission leaves into a bounded number of Cerbos calls,
+// and composes the results with libs/capabilityeval - the same pure
+// evaluator, unit-tested on its own without any of this package's
+// collaborators. This package's own job is assembling trusted data and
+// calling the PDP; it never ranks a grant against a revoke itself (§6.3,
+// ADR-003), and it never trusts a browser-supplied resource attribute -
+// only routing identifiers travel in the request body, exactly like the
+// existing decision endpoint (apps/ads/internal/authz).
+package capability
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilityeval"
+	"github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient"
+	"github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext"
+)
+
+// DefaultMaxResourcesPerCheck bounds how many resources one Cerbos
+// CheckResources call carries (§15.2: "batch...within Cerbos request
+// limits"). Chosen well under Cerbos's own default request-size limits so
+// a large module snapshot chunks automatically instead of ever depending
+// on the PDP's own rejection behaviour.
+const DefaultMaxResourcesPerCheck = 500
+
+// PDP is the policy decision point the handler asks.
+type PDP interface {
+	Check(ctx context.Context, req cerbosclient.Request) (cerbosclient.Result, error)
+}
+
+// CapabilityCatalog supplies the UiCapabilityDefinitions for one module at
+// the active capability-catalog revision (§12.3 step 1).
+type CapabilityCatalog interface {
+	Definitions(ctx context.Context, module string) (defs []capabilitycatalog.UiCapabilityDefinition, catalogRevision string, err error)
+}
+
+// TargetQuery identifies one symbolic targetRef that needs resolving into a
+// concrete resource (§12.3 step 2).
+type TargetQuery struct {
+	TenantID     string
+	HospitalID   string
+	ResourceKind string
+	TargetRef    string
+	// RouteContext is the browser-supplied routing context (e.g.
+	// {"patientId": "patient-456"}). It carries identifiers only, never
+	// trust attributes: the resolver loads the resource itself and derives
+	// its authorization attributes from the authoritative source (§12.3).
+	RouteContext map[string]string
+}
+
+// ResolvedTarget is a targetRef resolved to a concrete resource and its
+// trusted, server-loaded attributes.
+type ResolvedTarget struct {
+	Resource   capabilityeval.ResourceRef
+	Attributes map[string]any
+}
+
+// TargetResolver resolves symbolic targetRefs into concrete resources
+// server-side. The browser cannot supply a resource's authorization
+// attributes directly; it can only name which instance it is looking at.
+type TargetResolver interface {
+	Resolve(ctx context.Context, query TargetQuery) (ResolvedTarget, error)
+}
+
+// Assignments resolves the role permissions and user overrides that apply
+// to one principal and one resource (reuses the decision endpoint's port).
+type Assignments interface {
+	For(ctx context.Context, query authz.AssignmentQuery) (permissioncontext.Input, error)
+}
+
+// Audience selects how much failure evidence a snapshot carries.
+//
+// §12.4: "Failure evidence is optional and should be filtered for the
+// audience. End-user responses normally contain a stable reason code,
+// while the administration simulator may expose the complete requirement
+// tree." The zero value is AudienceEndUser, so a Config that forgets to
+// set this field fails safe rather than leaking the requirement tree.
+type Audience int
+
+const (
+	// AudienceEndUser carries a stable reason code only. Full requirement
+	// trees must never appear on this path (issue #11 acceptance criteria).
+	AudienceEndUser Audience = iota
+	// AudienceAdmin additionally carries FailedRequirements, for the
+	// administration simulator.
+	AudienceAdmin
+)
+
+// Config holds the handler's collaborators.
+type Config struct {
+	PDP               PDP
+	CapabilityCatalog CapabilityCatalog
+	TargetResolver    TargetResolver
+	Assignments       Assignments
+	// RootPolicyRevision is the immutable root-policy tag currently served
+	// (§12.4, §13.1), e.g. "root-v1.4.0". Static per deployment.
+	RootPolicyRevision string
+	// MaxResourcesPerCheck bounds resources per Cerbos call. Zero means
+	// DefaultMaxResourcesPerCheck.
+	MaxResourcesPerCheck int
+	// Audience controls failure-evidence detail. Zero value is
+	// AudienceEndUser.
+	Audience Audience
+	Logger   *slog.Logger
+}
+
+// Request is the §12.3 capability-evaluation request. Only routing
+// identifiers travel here - tenant, hospital and principal come from the
+// verified token, never the body, exactly like the decision endpoint's
+// Request (§12.3: "The browser must not provide trusted permission
+// decisions, tenant ownership or user overrides").
+type Request struct {
+	Module         string            `json:"module"`
+	CapabilityKeys []string          `json:"capabilityKeys"`
+	Context        map[string]string `json:"context"`
+}
+
+func (r Request) validate() error {
+	if r.Module == "" {
+		return errors.New("module is required")
+	}
+	if len(r.CapabilityKeys) == 0 {
+		return errors.New("capabilityKeys must not be empty")
+	}
+	return nil
+}
+
+// Snapshot is the §12.4 capability snapshot.
+type Snapshot struct {
+	AuthorizationRevision     int64                       `json:"authorizationRevision"`
+	RootPolicyRevision        string                      `json:"rootPolicyRevision"`
+	CapabilityCatalogRevision string                      `json:"capabilityCatalogRevision"`
+	TenantID                  string                      `json:"tenantId"`
+	HospitalID                string                      `json:"hospitalId"`
+	Module                    string                      `json:"module"`
+	ContextFingerprint        string                      `json:"contextFingerprint"`
+	Capabilities              map[string]CapabilityResult `json:"capabilities"`
+}
+
+// CapabilityResult is one capability's decision in the administration
+// shape. Handlers serving end-user audiences must call ForEndUser instead
+// of encoding this type directly (issue #11 acceptance criteria: "full
+// requirement trees never appear on end-user paths").
+type CapabilityResult struct {
+	Allowed            bool                `json:"allowed"`
+	Reason             string              `json:"reason,omitempty"`
+	FailedRequirements []FailedRequirement `json:"failedRequirements,omitempty"`
+}
+
+// FailedRequirement is one denied leaf that explains a capability's denial,
+// administration-audience evidence only (§12.4).
+type FailedRequirement struct {
+	Resource string `json:"resource"`
+	Action   string `json:"action"`
+	Target   string `json:"target"`
+	Reason   string `json:"reason"`
+}
+
+// NewHandler builds the POST /internal/capabilities/evaluate handler.
+func NewHandler(cfg Config) http.Handler {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	maxResources := cfg.MaxResourcesPerCheck
+	if maxResources <= 0 {
+		maxResources = DefaultMaxResourcesPerCheck
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity, ok := tokenauth.From(r.Context())
+		if !ok {
+			logger.ErrorContext(r.Context(), "the capability endpoint was reached without a verified identity")
+			writeError(w, http.StatusUnauthorized, "a bearer token is required")
+			return
+		}
+
+		var req Request
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("malformed request: %v", err))
+			return
+		}
+		if err := req.validate(); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		snapshot, err := evaluate(r.Context(), cfg, maxResources, identity, req)
+		if err != nil {
+			var badRequest *badRequestError
+			if errors.As(err, &badRequest) {
+				writeError(w, http.StatusBadRequest, badRequest.Error())
+				return
+			}
+			logger.ErrorContext(r.Context(), "evaluating capabilities failed",
+				slog.String("principalId", identity.PrincipalID),
+				slog.String("module", req.Module),
+				slog.Any("error", err))
+			writeError(w, http.StatusServiceUnavailable, "could not evaluate capabilities")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, snapshot)
+	})
+}
+
+type badRequestError struct{ msg string }
+
+func (e *badRequestError) Error() string { return e.msg }
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// sortedKeys is a small determinism helper used by the fingerprint and by
+// tests.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/apps/ads/internal/capability/capability_test.go
+++ b/apps/ads/internal/capability/capability_test.go
@@ -1,0 +1,391 @@
+package capability_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/capability"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilityeval"
+	"github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient"
+	"github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext"
+)
+
+func permission(resource, action, targetRef string) capabilitycatalog.Expression {
+	return capabilitycatalog.Expression{Permission: &capabilitycatalog.PermissionRequirement{
+		Resource: resource, Action: action, TargetRef: targetRef,
+	}}
+}
+
+// identity is the demo doctor, the way the token middleware would have
+// left it.
+func identity() tokenauth.Identity {
+	return tokenauth.Identity{
+		PrincipalID: "user-doctor",
+		TenantID:    "tenant-a",
+		HospitalID:  "hospital-1",
+		Roles:       []string{"kc:cerbos-poc:patient-app:doctor"},
+	}
+}
+
+func post(t *testing.T, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/internal/capabilities/evaluate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req.WithContext(tokenauth.WithIdentity(req.Context(), identity()))
+}
+
+// fakeCatalog serves a fixed, in-memory capability catalog for one module.
+type fakeCatalog struct {
+	revision string
+	defs     []capabilitycatalog.UiCapabilityDefinition
+}
+
+func (c fakeCatalog) Definitions(context.Context, string) ([]capabilitycatalog.UiCapabilityDefinition, string, error) {
+	return c.defs, c.revision, nil
+}
+
+// fakeResolver resolves every targetRef to resourceKind/hospitalId, i.e.
+// hospital-scoped by default, unless the browser context supplies an
+// instance ID keyed by "<targetRef>Id" - the same convention §12.3's own
+// example request/definition pair uses (targetRef "patient", context key
+// "patientId").
+type fakeResolver struct {
+	resolved []capability.TargetQuery // records every call, in order
+}
+
+func (r *fakeResolver) Resolve(_ context.Context, query capability.TargetQuery) (capability.ResolvedTarget, error) {
+	r.resolved = append(r.resolved, query)
+	id := query.HospitalID
+	if v, ok := query.RouteContext[query.TargetRef+"Id"]; ok {
+		id = v
+	}
+	return capability.ResolvedTarget{
+		Resource: capabilityeval.ResourceRef{Kind: query.ResourceKind, ID: id},
+	}, nil
+}
+
+type emptyAssignments struct{}
+
+func (emptyAssignments) For(context.Context, authz.AssignmentQuery) (permissioncontext.Input, error) {
+	return permissioncontext.Input{}, nil
+}
+
+// recordingPDP answers every leaf as allowed unless told otherwise, and
+// counts calls and resources seen across every call so batching and
+// chunking behaviour can be asserted on.
+type recordingPDP struct {
+	calls           int
+	resourcesSeen   int
+	denied          map[cerbosclient.Leaf]bool
+	maxResourcesArg int // largest single-call resource count observed
+}
+
+func (p *recordingPDP) Check(_ context.Context, req cerbosclient.Request) (cerbosclient.Result, error) {
+	p.calls++
+	p.resourcesSeen += len(req.Resources)
+	if len(req.Resources) > p.maxResourcesArg {
+		p.maxResourcesArg = len(req.Resources)
+	}
+
+	decisions := make(map[cerbosclient.Leaf]cerbosclient.Decision)
+	for _, resource := range req.Resources {
+		for _, action := range resource.Actions {
+			l := cerbosclient.Leaf{Resource: resource.Resource, Action: action}
+			decisions[l] = cerbosclient.Decision{Allowed: !p.denied[l]}
+		}
+	}
+	return cerbosclient.Result{CallID: "call-1", Decisions: decisions}, nil
+}
+
+func baseConfig(catalog fakeCatalog, pdp *recordingPDP, resolver *fakeResolver) capability.Config {
+	return capability.Config{
+		PDP:                pdp,
+		CapabilityCatalog:  catalog,
+		TargetResolver:     resolver,
+		Assignments:        emptyAssignments{},
+		RootPolicyRevision: "root-v1.4.0",
+	}
+}
+
+func TestAnUnverifiedRequestIsRefusedWithoutCallingThePDP(t *testing.T) {
+	pdp := &recordingPDP{}
+	handler := capability.NewHandler(baseConfig(fakeCatalog{}, pdp, &fakeResolver{}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/capabilities/evaluate", strings.NewReader(`{}`)))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if pdp.calls != 0 {
+		t.Error("the PDP was called for an unauthenticated request")
+	}
+}
+
+// §12.3: "The browser must not provide trusted permission decisions,
+// tenant ownership or user overrides." A request that tries to name its
+// own tenant, hospital or principal is refused outright, just like the
+// decision endpoint.
+func TestIdentityFieldsInTheRequestBodyAreRefused(t *testing.T) {
+	smuggled := map[string]string{
+		"a tenant":   `{"tenantId": "tenant-b", "module": "clinical", "capabilityKeys": ["x"]}`,
+		"a hospital": `{"hospitalId": "hospital-9", "module": "clinical", "capabilityKeys": ["x"]}`,
+	}
+	for name, body := range smuggled {
+		t.Run(name, func(t *testing.T) {
+			pdp := &recordingPDP{}
+			handler := capability.NewHandler(baseConfig(fakeCatalog{}, pdp, &fakeResolver{}))
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, post(t, body))
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+			}
+			if pdp.calls != 0 {
+				t.Error("the PDP was called for a request that named its own identity")
+			}
+		})
+	}
+}
+
+func TestAnAllOfCapabilityIsAllowedOnlyWhenEveryLeafIsAllowed(t *testing.T) {
+	catalog := fakeCatalog{
+		revision: "1",
+		defs: []capabilitycatalog.UiCapabilityDefinition{
+			{Key: "patient.route.edit", Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+				permission("patient_record", "read", "patient"),
+				permission("patient_record", "update", "patient"),
+			}}},
+		},
+	}
+	pdp := &recordingPDP{denied: map[cerbosclient.Leaf]bool{
+		{Resource: cerbosclient.ResourceRef{Kind: "patient_record", ID: "patient-456"}, Action: "update"}: true,
+	}}
+	handler := capability.NewHandler(baseConfig(catalog, pdp, &fakeResolver{}))
+
+	body := `{"module":"clinical","capabilityKeys":["patient.route.edit"],"context":{"patientId":"patient-456"}}`
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, post(t, body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+	var snapshot capability.Snapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &snapshot); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if snapshot.Capabilities["patient.route.edit"].Allowed {
+		t.Error("expected patient.route.edit to be denied: update was denied")
+	}
+}
+
+// targetRef is resolved server-side; browser-supplied "attributes" outside
+// the routing-id shape must be refused rather than silently accepted, just
+// like the decision endpoint's unknown-field rejection.
+func TestUnknownRequestFieldsAreRefused(t *testing.T) {
+	pdp := &recordingPDP{}
+	handler := capability.NewHandler(baseConfig(fakeCatalog{}, pdp, &fakeResolver{}))
+
+	body := `{"module":"clinical","capabilityKeys":["x"],"attributes":{"status":"ACTIVE"}}`
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, post(t, body))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+// A leaf shared by several requested capabilities must be checked exactly
+// once (issue #11 acceptance criteria), which this asserts indirectly by
+// counting the total resources the PDP saw across all calls: two
+// capabilities sharing the same resource+action must not double it.
+func TestASharedLeafIsCheckedExactlyOnceAcrossCapabilities(t *testing.T) {
+	catalog := fakeCatalog{
+		revision: "1",
+		defs: []capabilitycatalog.UiCapabilityDefinition{
+			{Key: "patient.route.details", Expression: permission("patient_record", "read", "patient")},
+			{Key: "patient.route.edit", Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+				permission("patient_record", "read", "patient"),
+				permission("patient_record", "update", "patient"),
+			}}},
+		},
+	}
+	pdp := &recordingPDP{}
+	handler := capability.NewHandler(baseConfig(catalog, pdp, &fakeResolver{}))
+
+	body := `{"module":"clinical","capabilityKeys":["patient.route.details","patient.route.edit"],"context":{"patientId":"patient-456"}}`
+	handler.ServeHTTP(httptest.NewRecorder(), post(t, body))
+
+	// One resource (patient_record/patient-456) with two actions
+	// (read, update): the PDP must see it as one resource entry, not two.
+	if pdp.resourcesSeen != 1 {
+		t.Errorf("resources seen by the PDP = %d, want 1 (the shared resource checked once)", pdp.resourcesSeen)
+	}
+}
+
+// Requesting many capabilities must issue a bounded number of Cerbos
+// calls, not one per capability, and calls exceeding the configured
+// resource limit must be chunked automatically.
+func TestManyCapabilitiesAreBatchedAndChunkedWithinResourceLimits(t *testing.T) {
+	const capabilityCount = 250
+	var defs []capabilitycatalog.UiCapabilityDefinition
+	for i := 0; i < capabilityCount; i++ {
+		key := fmt.Sprintf("resource-%d.route.details", i)
+		defs = append(defs, capabilitycatalog.UiCapabilityDefinition{
+			Key:        key,
+			Expression: permission(fmt.Sprintf("resource-%d", i), "read", fmt.Sprintf("target-%d", i)),
+		})
+	}
+	catalog := fakeCatalog{revision: "1", defs: defs}
+
+	keys := make([]string, capabilityCount)
+	for i := range keys {
+		keys[i] = defs[i].Key
+	}
+	bodyBytes, err := json.Marshal(capability.Request{Module: "clinical", CapabilityKeys: keys})
+	if err != nil {
+		t.Fatalf("marshalling request: %v", err)
+	}
+
+	pdp := &recordingPDP{}
+	cfg := baseConfig(catalog, pdp, &fakeResolver{})
+	cfg.MaxResourcesPerCheck = 50
+	handler := capability.NewHandler(cfg)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, post(t, string(bodyBytes)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+
+	// 250 distinct resources at a limit of 50 per call must take exactly 5
+	// calls: bounded, and neither 1 (unbatched) nor 250 (one per capability).
+	if pdp.calls != 5 {
+		t.Errorf("PDP calls = %d, want 5 (250 resources chunked at 50 per call)", pdp.calls)
+	}
+	if pdp.maxResourcesArg > 50 {
+		t.Errorf("a single Cerbos call carried %d resources, want at most 50", pdp.maxResourcesArg)
+	}
+	if pdp.resourcesSeen != capabilityCount {
+		t.Errorf("total resources seen = %d, want %d", pdp.resourcesSeen, capabilityCount)
+	}
+}
+
+// The snapshot must carry both revisions and a stable, deterministic
+// context fingerprint.
+func TestTheSnapshotCarriesBothRevisionsAndAStableFingerprint(t *testing.T) {
+	catalog := fakeCatalog{
+		revision: "ui-capabilities-v12",
+		defs: []capabilitycatalog.UiCapabilityDefinition{
+			{Key: "patient.route.details", Expression: permission("patient_record", "read", "patient")},
+		},
+	}
+	body := `{"module":"clinical","capabilityKeys":["patient.route.details"],"context":{"patientId":"patient-456"}}`
+
+	fingerprints := make([]string, 2)
+	for i := range fingerprints {
+		pdp := &recordingPDP{}
+		handler := capability.NewHandler(baseConfig(catalog, pdp, &fakeResolver{}))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, post(t, body))
+
+		var snapshot capability.Snapshot
+		if err := json.Unmarshal(rec.Body.Bytes(), &snapshot); err != nil {
+			t.Fatalf("response is not JSON: %v", err)
+		}
+		if snapshot.CapabilityCatalogRevision != "ui-capabilities-v12" {
+			t.Errorf("capabilityCatalogRevision = %q, want %q", snapshot.CapabilityCatalogRevision, "ui-capabilities-v12")
+		}
+		if snapshot.RootPolicyRevision != "root-v1.4.0" {
+			t.Errorf("rootPolicyRevision = %q, want %q", snapshot.RootPolicyRevision, "root-v1.4.0")
+		}
+		if snapshot.ContextFingerprint == "" {
+			t.Error("expected a non-empty contextFingerprint")
+		}
+		fingerprints[i] = snapshot.ContextFingerprint
+	}
+	if fingerprints[0] != fingerprints[1] {
+		t.Errorf("the same request produced two different fingerprints: %q vs %q", fingerprints[0], fingerprints[1])
+	}
+}
+
+// End-user responses must carry a stable reason code only; the full
+// requirement tree must never appear on that path.
+func TestEndUserResponsesCarryNoFailedRequirementsTree(t *testing.T) {
+	catalog := fakeCatalog{
+		revision: "1",
+		defs: []capabilitycatalog.UiCapabilityDefinition{
+			{Key: "patient.route.edit", Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+				permission("patient_record", "read", "patient"),
+				permission("patient_record", "update", "patient"),
+			}}},
+		},
+	}
+	pdp := &recordingPDP{denied: map[cerbosclient.Leaf]bool{
+		{Resource: cerbosclient.ResourceRef{Kind: "patient_record", ID: "hospital-1"}, Action: "update"}: true,
+	}}
+	handler := capability.NewHandler(baseConfig(catalog, pdp, &fakeResolver{}))
+
+	body := `{"module":"clinical","capabilityKeys":["patient.route.edit"]}`
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, post(t, body))
+
+	var raw map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	capabilities := raw["capabilities"].(map[string]any)
+	result := capabilities["patient.route.edit"].(map[string]any)
+
+	if result["allowed"] != false {
+		t.Fatalf("expected patient.route.edit to be denied, got %+v", result)
+	}
+	if result["reason"] != capabilityeval.ReasonRequiredPermissionDenied {
+		t.Errorf("reason = %v, want %q", result["reason"], capabilityeval.ReasonRequiredPermissionDenied)
+	}
+	if _, present := result["failedRequirements"]; present {
+		t.Errorf("end-user response must not carry failedRequirements, got %+v", result["failedRequirements"])
+	}
+}
+
+// The administration audience may see the complete requirement tree.
+func TestAdminAudienceResponsesCarryTheFailedRequirementsTree(t *testing.T) {
+	catalog := fakeCatalog{
+		revision: "1",
+		defs: []capabilitycatalog.UiCapabilityDefinition{
+			{Key: "patient.route.edit", Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+				permission("patient_record", "read", "patient"),
+				permission("patient_record", "update", "patient"),
+			}}},
+		},
+	}
+	pdp := &recordingPDP{denied: map[cerbosclient.Leaf]bool{
+		{Resource: cerbosclient.ResourceRef{Kind: "patient_record", ID: "hospital-1"}, Action: "update"}: true,
+	}}
+	cfg := baseConfig(catalog, pdp, &fakeResolver{})
+	cfg.Audience = capability.AudienceAdmin
+	handler := capability.NewHandler(cfg)
+
+	body := `{"module":"clinical","capabilityKeys":["patient.route.edit"]}`
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, post(t, body))
+
+	var snapshot capability.Snapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &snapshot); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	result := snapshot.Capabilities["patient.route.edit"]
+	if len(result.FailedRequirements) == 0 {
+		t.Error("expected the admin audience to carry failed requirement evidence")
+	}
+}

--- a/apps/ads/internal/capability/capability_test.go
+++ b/apps/ads/internal/capability/capability_test.go
@@ -68,7 +68,8 @@ func (r *fakeResolver) Resolve(_ context.Context, query capability.TargetQuery) 
 		id = v
 	}
 	return capability.ResolvedTarget{
-		Resource: capabilityeval.ResourceRef{Kind: query.ResourceKind, ID: id},
+		Resource:   capabilityeval.ResourceRef{Kind: query.ResourceKind, ID: id},
+		Attributes: map[string]any{"status": "ACTIVE"},
 	}, nil
 }
 
@@ -86,11 +87,13 @@ type recordingPDP struct {
 	resourcesSeen   int
 	denied          map[cerbosclient.Leaf]bool
 	maxResourcesArg int // largest single-call resource count observed
+	lastRequest     cerbosclient.Request
 }
 
 func (p *recordingPDP) Check(_ context.Context, req cerbosclient.Request) (cerbosclient.Result, error) {
 	p.calls++
 	p.resourcesSeen += len(req.Resources)
+	p.lastRequest = req
 	if len(req.Resources) > p.maxResourcesArg {
 		p.maxResourcesArg = len(req.Resources)
 	}
@@ -355,6 +358,29 @@ func TestEndUserResponsesCarryNoFailedRequirementsTree(t *testing.T) {
 	}
 	if _, present := result["failedRequirements"]; present {
 		t.Errorf("end-user response must not carry failedRequirements, got %+v", result["failedRequirements"])
+	}
+}
+
+// The TargetResolver's own trusted attributes must reach the PDP alongside
+// tenantId/hospitalId/permissionContext, not be dropped on the floor.
+func TestResolvedTargetAttributesReachThePDP(t *testing.T) {
+	catalog := fakeCatalog{
+		revision: "1",
+		defs: []capabilitycatalog.UiCapabilityDefinition{
+			{Key: "patient.route.details", Expression: permission("patient_record", "read", "patient")},
+		},
+	}
+	pdp := &recordingPDP{}
+	handler := capability.NewHandler(baseConfig(catalog, pdp, &fakeResolver{}))
+
+	body := `{"module":"clinical","capabilityKeys":["patient.route.details"],"context":{"patientId":"patient-456"}}`
+	handler.ServeHTTP(httptest.NewRecorder(), post(t, body))
+
+	if len(pdp.lastRequest.Resources) != 1 {
+		t.Fatalf("resources sent to the PDP = %d, want 1", len(pdp.lastRequest.Resources))
+	}
+	if got := pdp.lastRequest.Resources[0].Attr["status"]; got != "ACTIVE" {
+		t.Errorf("status attribute = %v, want %q", got, "ACTIVE")
 	}
 }
 

--- a/apps/ads/internal/capability/fscatalog.go
+++ b/apps/ads/internal/capability/fscatalog.go
@@ -3,7 +3,6 @@ package capability
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/tishan-harischandra/cerbos-poc/libs/authzcache"
 	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
@@ -59,14 +58,4 @@ func (c *FSCatalog) Definitions(_ context.Context, module string) ([]capabilityc
 	}
 
 	return byModule[module], revision, nil
-}
-
-// parseCatalogRevision is a small helper for callers that read the
-// revision from the environment as a string.
-func parseCatalogRevision(raw string) (int64, error) {
-	revision, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parsing catalog revision %q: %w", raw, err)
-	}
-	return revision, nil
 }

--- a/apps/ads/internal/capability/fscatalog.go
+++ b/apps/ads/internal/capability/fscatalog.go
@@ -1,0 +1,72 @@
+package capability
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/authzcache"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+)
+
+// DefaultCatalogCacheSize bounds how many modules' definitions FSCatalog
+// keeps warm at once. The installation's module count is small and known
+// ahead of time (§9.1 lists eight admin console modules plus the business
+// UI), so this is generous headroom rather than a tight tuning knob.
+const DefaultCatalogCacheSize = 64
+
+// FSCatalog serves UiCapabilityDefinitions from the same local directory
+// tree Cerbos itself reads its policies from (§13: an immutable root-policy
+// release is installed to a local path by a per-pod agent; this reads the
+// capability catalog committed alongside it in
+// deploy/cerbos/catalog/ui-capabilities). It caches per module through
+// authzcache so a warm request never touches disk (§11.2, §15.1).
+type FSCatalog struct {
+	dir             string
+	catalogRevision int64
+	cache           *authzcache.Cache[string, []capabilitycatalog.UiCapabilityDefinition]
+}
+
+// NewFSCatalog builds an FSCatalog reading definitions from dir.
+// catalogRevision is the release's numeric revision, formatted into the
+// §12.4 snapshot shape ("ui-capabilities-v12").
+func NewFSCatalog(dir string, catalogRevision int64, cache *authzcache.Cache[string, []capabilitycatalog.UiCapabilityDefinition]) *FSCatalog {
+	if cache == nil {
+		cache = authzcache.New[string, []capabilitycatalog.UiCapabilityDefinition](DefaultCatalogCacheSize, 0)
+	}
+	return &FSCatalog{dir: dir, catalogRevision: catalogRevision, cache: cache}
+}
+
+// Definitions returns every UiCapabilityDefinition belonging to module.
+func (c *FSCatalog) Definitions(_ context.Context, module string) ([]capabilitycatalog.UiCapabilityDefinition, string, error) {
+	revision := formatCatalogRevision(c.catalogRevision)
+
+	if cached, ok := c.cache.Get(module); ok {
+		return cached, revision, nil
+	}
+
+	all, err := capabilitycatalog.LoadDefinitionsDir(c.dir)
+	if err != nil {
+		return nil, "", fmt.Errorf("loading the capability catalog from %s: %w", c.dir, err)
+	}
+
+	byModule := make(map[string][]capabilitycatalog.UiCapabilityDefinition)
+	for _, def := range all {
+		byModule[def.Module] = append(byModule[def.Module], def)
+	}
+	for m, defs := range byModule {
+		c.cache.Set(m, defs)
+	}
+
+	return byModule[module], revision, nil
+}
+
+// parseCatalogRevision is a small helper for callers that read the
+// revision from the environment as a string.
+func parseCatalogRevision(raw string) (int64, error) {
+	revision, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing catalog revision %q: %w", raw, err)
+	}
+	return revision, nil
+}

--- a/apps/ads/internal/capability/fscatalog_test.go
+++ b/apps/ads/internal/capability/fscatalog_test.go
@@ -1,0 +1,78 @@
+package capability_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/capability"
+)
+
+const fixtureDefinitions = `
+catalogRevision: 1
+capabilities:
+  - key: patient.route.details
+    module: clinical
+    context: INSTANCE
+    expression:
+      permission:
+        resource: patient_record
+        action: read
+        targetRef: patient
+  - key: account.route.list
+    module: financial
+    context: COLLECTION
+    expression:
+      permission:
+        resource: account
+        action: list
+        targetRef: accountCollection
+`
+
+func writeFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "definitions.yaml"), []byte(fixtureDefinitions), 0o644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	return dir
+}
+
+func TestFSCatalogReturnsOnlyTheRequestedModulesDefinitions(t *testing.T) {
+	catalog := capability.NewFSCatalog(writeFixture(t), 12, nil)
+
+	defs, revision, err := catalog.Definitions(context.Background(), "clinical")
+	if err != nil {
+		t.Fatalf("Definitions: %v", err)
+	}
+	if revision != "ui-capabilities-v12" {
+		t.Errorf("revision = %q, want %q", revision, "ui-capabilities-v12")
+	}
+	if len(defs) != 1 || defs[0].Key != "patient.route.details" {
+		t.Errorf("defs = %+v, want exactly patient.route.details", defs)
+	}
+}
+
+func TestFSCatalogServesFromCacheOnASecondCall(t *testing.T) {
+	dir := writeFixture(t)
+	catalog := capability.NewFSCatalog(dir, 1, nil)
+
+	if _, _, err := catalog.Definitions(context.Background(), "financial"); err != nil {
+		t.Fatalf("Definitions: %v", err)
+	}
+
+	// Remove the source directory: a second call must still succeed,
+	// proving it was served from the cache rather than reading disk again.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("removing fixture dir: %v", err)
+	}
+
+	defs, _, err := catalog.Definitions(context.Background(), "financial")
+	if err != nil {
+		t.Fatalf("Definitions after removing the source directory: %v", err)
+	}
+	if len(defs) != 1 || defs[0].Key != "account.route.list" {
+		t.Errorf("defs = %+v, want exactly account.route.list", defs)
+	}
+}

--- a/apps/ads/internal/capability/targetresolver.go
+++ b/apps/ads/internal/capability/targetresolver.go
@@ -1,0 +1,42 @@
+package capability
+
+import (
+	"context"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilityeval"
+)
+
+// DefaultTargetResolver resolves a symbolic targetRef into a concrete
+// resource using one convention: an instance-level targetRef's concrete ID
+// travels in the request's routing context, keyed by "<targetRef>Id" -
+// exactly the convention §12.3's own example uses (targetRef "patient",
+// context key "patientId"). A targetRef with no matching context entry is
+// module- or collection-scoped and resolves to the hospital itself, the
+// same tenant/hospital-scoped identity hospital_context and every
+// COLLECTION-context leaf already carry in the committed policies
+// (deploy/cerbos/policies/resources/hospital_context.yaml).
+//
+// It loads no resource attributes of its own beyond tenant and hospital:
+// this prototype has no FHIR resource data store yet (issue #11 is the
+// evaluator and endpoint, not a clinical data layer), so a real
+// installation with per-resource attributes (e.g. a patient record's own
+// status) replaces this with a resolver that loads them from the
+// authoritative service. TargetResolver is a narrow port for exactly that
+// reason.
+type DefaultTargetResolver struct{}
+
+// Resolve implements TargetResolver.
+func (DefaultTargetResolver) Resolve(_ context.Context, query TargetQuery) (ResolvedTarget, error) {
+	id := query.HospitalID
+	if value, ok := query.RouteContext[query.TargetRef+"Id"]; ok {
+		id = value
+	}
+
+	return ResolvedTarget{
+		Resource: capabilityeval.ResourceRef{Kind: query.ResourceKind, ID: id},
+		Attributes: map[string]any{
+			"tenantId":   query.TenantID,
+			"hospitalId": query.HospitalID,
+		},
+	}, nil
+}

--- a/apps/ads/internal/config/config.go
+++ b/apps/ads/internal/config/config.go
@@ -1,7 +1,10 @@
 // Package config resolves the ADS runtime configuration from the environment.
 package config
 
-import "time"
+import (
+	"strconv"
+	"time"
+)
 
 // DefaultRoleMatrixCacheTTL bounds how long the in-process role matrix cache may
 // outlive a change to the underlying row (§11.2). It is short because expiry is
@@ -23,6 +26,17 @@ type Config struct {
 	// IdPAddr is the host:port the readiness probe dials. Like PostgresAddr it
 	// carries no credential, because a readiness probe must not need one.
 	IdPAddr string
+	// CapabilityCatalogDir is the local path the capability snapshot
+	// endpoint reads UiCapabilityDefinitions from - the same
+	// per-pod-mounted release tree Cerbos itself reads policies from
+	// (§13.1, issue #11).
+	CapabilityCatalogDir string
+	// CapabilityCatalogRevision is the release's numeric catalog revision,
+	// formatted into the §12.4 snapshot shape.
+	CapabilityCatalogRevision int64
+	// RootPolicyRevision is the immutable root-policy tag currently served
+	// (§12.4, §13.1), e.g. "root-v1.4.0".
+	RootPolicyRevision string
 }
 
 // LookupFunc mirrors os.LookupEnv so configuration stays testable.
@@ -38,7 +52,26 @@ func FromEnv(lookup LookupFunc) Config {
 		PostgresDSN:        valueOr(lookup, "ASSIGNMENTSTORE_POSTGRES_DSN", ""),
 		RoleMatrixCacheTTL: durationOr(lookup, "ADS_ROLE_MATRIX_CACHE_TTL", DefaultRoleMatrixCacheTTL),
 		IdPAddr:            valueOr(lookup, "IDP_ADDR", "keycloak:8080"),
+
+		CapabilityCatalogDir:      valueOr(lookup, "CAPABILITY_CATALOG_DIR", "/etc/cerbos-catalog/ui-capabilities"),
+		CapabilityCatalogRevision: int64Or(lookup, "CAPABILITY_CATALOG_REVISION", 1),
+		RootPolicyRevision:        valueOr(lookup, "ROOT_POLICY_REVISION", "root-v1.4.0"),
 	}
+}
+
+// int64Or falls back on an unreadable value, for the same reason
+// durationOr does: a silent zero would be indistinguishable from a real
+// revision zero rather than a misconfiguration.
+func int64Or(lookup LookupFunc, key string, fallback int64) int64 {
+	value, ok := lookup(key)
+	if !ok || value == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return fallback
+	}
+	return parsed
 }
 
 // durationOr falls back on an unreadable value rather than on zero. A zero

--- a/apps/ads/internal/config/config_test.go
+++ b/apps/ads/internal/config/config_test.go
@@ -67,6 +67,35 @@ func TestFromEnvFallsBackToTheComposeDefaults(t *testing.T) {
 	}
 }
 
+func TestCapabilityCatalogSettingsFallBackToTheComposeDefaults(t *testing.T) {
+	cfg := config.FromEnv(func(string) (string, bool) { return "", false })
+
+	if cfg.CapabilityCatalogDir != "/etc/cerbos-catalog/ui-capabilities" {
+		t.Errorf("CapabilityCatalogDir = %q, want the compose default", cfg.CapabilityCatalogDir)
+	}
+	if cfg.CapabilityCatalogRevision != 1 {
+		t.Errorf("CapabilityCatalogRevision = %d, want 1", cfg.CapabilityCatalogRevision)
+	}
+	if cfg.RootPolicyRevision != "root-v1.4.0" {
+		t.Errorf("RootPolicyRevision = %q, want %q", cfg.RootPolicyRevision, "root-v1.4.0")
+	}
+}
+
+// An unparseable revision must not silently become zero, which would be
+// indistinguishable from a real revision zero.
+func TestAnUnreadableCapabilityCatalogRevisionFallsBackToTheDefault(t *testing.T) {
+	cfg := config.FromEnv(func(key string) (string, bool) {
+		if key == "CAPABILITY_CATALOG_REVISION" {
+			return "not-a-number", true
+		}
+		return "", false
+	})
+
+	if cfg.CapabilityCatalogRevision != 1 {
+		t.Errorf("CapabilityCatalogRevision = %d, want the default 1", cfg.CapabilityCatalogRevision)
+	}
+}
+
 func TestFromEnvPrefersExplicitEnvironmentValues(t *testing.T) {
 	env := map[string]string{
 		"ADS_HTTP_ADDR":    ":9999",

--- a/apps/ads/internal/server/server.go
+++ b/apps/ads/internal/server/server.go
@@ -41,6 +41,11 @@ type Config struct {
 	// configured, in which case the routes do not exist.
 	DirectoryUsersHandler http.Handler
 	DirectoryRolesHandler http.Handler
+
+	// CapabilityHandler serves POST /internal/capabilities/evaluate, the
+	// §12.3 capability snapshot endpoint (issue #11). Nil means the route
+	// does not exist.
+	CapabilityHandler http.Handler
 }
 
 // New builds the ADS HTTP handler.
@@ -57,6 +62,9 @@ func New(cfg Config) http.Handler {
 	}
 	if cfg.DirectoryRolesHandler != nil {
 		mux.Handle("GET /internal/directory/roles", cfg.DirectoryRolesHandler)
+	}
+	if cfg.CapabilityHandler != nil {
+		mux.Handle("POST /internal/capabilities/evaluate", cfg.CapabilityHandler)
 	}
 
 	timeout := cfg.ReadinessTimeout

--- a/apps/ads/internal/server/server_test.go
+++ b/apps/ads/internal/server/server_test.go
@@ -91,6 +91,34 @@ func TestTheDecisionEndpointIsAbsentWhenNoHandlerIsConfigured(t *testing.T) {
 	}
 }
 
+func TestTheCapabilityEndpointIsMountedWhenAHandlerIsConfigured(t *testing.T) {
+	handler := server.New(server.Config{
+		CapabilityHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		}),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/capabilities/evaluate", nil))
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("POST /internal/capabilities/evaluate status = %d, want the configured handler to answer", rec.Code)
+	}
+}
+
+// Without a capability handler the route must not exist at all, for the
+// same reason the decision endpoint's absence is 404 rather than a stub.
+func TestTheCapabilityEndpointIsAbsentWhenNoHandlerIsConfigured(t *testing.T) {
+	handler := server.New(server.Config{})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/capabilities/evaluate", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("POST /internal/capabilities/evaluate status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
 func TestReadyzGivesUpOnADependencyThatNeverAnswers(t *testing.T) {
 	handler := server.New(server.Config{
 		ReadinessTimeout: 50 * time.Millisecond,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,8 +122,14 @@ services:
       # By reference, never by value: a secret in an environment variable is
       # visible in `docker inspect` and inherited by every child process.
       IDP_CREDENTIALS_SECRET_REF: "/run/secrets/idp-admin-credentials"
+      # The capability snapshot endpoint (§12.3, issue #11) reads the same
+      # committed capability catalog Cerbos itself reads its policies from.
+      CAPABILITY_CATALOG_DIR: "/capability-catalog"
+      CAPABILITY_CATALOG_REVISION: "${CAPABILITY_CATALOG_REVISION:-1}"
+      ROOT_POLICY_REVISION: "${ROOT_POLICY_REVISION:-root-v1.4.0}"
     volumes:
       - ./deploy/secrets/idp-admin-credentials:/run/secrets/idp-admin-credentials:ro
+      - ./deploy/cerbos/catalog/ui-capabilities:/capability-catalog:ro
     depends_on:
       cerbos:
         condition: service_healthy

--- a/go.work
+++ b/go.work
@@ -4,6 +4,7 @@ use (
 ./apps/ads
 ./apps/resource-service
 ./libs/assignmentstore
+./libs/authzcache
 ./libs/canonicalid
 ./libs/capabilitycatalog
 ./libs/capabilityeval

--- a/go.work
+++ b/go.work
@@ -6,6 +6,7 @@ use (
 ./libs/assignmentstore
 ./libs/canonicalid
 ./libs/capabilitycatalog
+./libs/capabilityeval
 ./libs/cataloggen
 ./libs/cerbosclient
 ./libs/idpdirectory

--- a/libs/authzcache/cache.go
+++ b/libs/authzcache/cache.go
@@ -1,0 +1,133 @@
+// Package authzcache is the bounded, in-process read-through cache shape
+// used across the ADS's hot decision path: role permissions, user
+// overrides, the capability catalog and IdP metadata (issue #11, §11.2,
+// §15.1). It generalizes the pattern the assignment-matrix cache already
+// proved out (apps/ads/internal/assignments.CachingRoleMatrix) into one
+// reusable, generic type so every cache on the hot path shares the same
+// bound rather than each growing its own ad hoc map.
+//
+// Every entry is a fact resolved from an authoritative source, never a
+// verdict, so a stale or evicted entry can only be wrong about data, never
+// about precedence (§6.3, ADR-003).
+package authzcache
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// Cache is a bounded, TTL-aged, least-recently-used cache safe for
+// concurrent use.
+//
+// It is bounded on two independent axes, both required under high user
+// cardinality (issue #11 acceptance criteria): TTL bounds how long a
+// cached fact may outlive a change to its source, and maxEntries bounds
+// how much memory the cache can ever hold regardless of how many distinct
+// keys - tenants, users, roles, capability revisions - are ever seen.
+// Without the second bound, a system with many tenants and users would
+// grow the cache forever even though every individual entry keeps
+// expiring on time.
+type Cache[K comparable, V any] struct {
+	mu         sync.Mutex
+	ttl        time.Duration
+	maxEntries int
+	now        func() time.Time
+
+	order   *list.List
+	entries map[K]*list.Element
+}
+
+type cacheEntry[K comparable, V any] struct {
+	key    K
+	value  V
+	readAt time.Time
+}
+
+// New builds a Cache bounded to maxEntries, aging entries out after ttl.
+// maxEntries <= 0 means unbounded by count (TTL alone still applies);
+// ttl <= 0 means entries never expire on their own (size alone still
+// applies). Passing neither bound defeats the purpose of this package, but
+// nothing here refuses it - a caller reaching for an unbounded cache is a
+// design decision to be caught in review, not a runtime panic.
+func New[K comparable, V any](maxEntries int, ttl time.Duration) *Cache[K, V] {
+	return NewWithClock[K, V](maxEntries, ttl, time.Now)
+}
+
+// NewWithClock is New with an injectable clock, so a test can advance time
+// without sleeping.
+func NewWithClock[K comparable, V any](maxEntries int, ttl time.Duration, now func() time.Time) *Cache[K, V] {
+	return &Cache[K, V]{
+		ttl:        ttl,
+		maxEntries: maxEntries,
+		now:        now,
+		order:      list.New(),
+		entries:    make(map[K]*list.Element),
+	}
+}
+
+// Get reads a value, treating an expired entry as a miss and evicting it.
+func (c *Cache[K, V]) Get(key K) (V, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	elem, ok := c.entries[key]
+	if !ok {
+		var zero V
+		return zero, false
+	}
+
+	entry := elem.Value.(*cacheEntry[K, V])
+	if c.ttl > 0 && c.now().Sub(entry.readAt) >= c.ttl {
+		c.removeElement(elem)
+		var zero V
+		return zero, false
+	}
+
+	c.order.MoveToFront(elem)
+	return entry.value, true
+}
+
+// Set stores a value, evicting the least-recently-used entry first if the
+// cache is already at capacity and key is not already present.
+func (c *Cache[K, V]) Set(key K, value V) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	if elem, ok := c.entries[key]; ok {
+		elem.Value.(*cacheEntry[K, V]).value = value
+		elem.Value.(*cacheEntry[K, V]).readAt = now
+		c.order.MoveToFront(elem)
+		return
+	}
+
+	if c.maxEntries > 0 && len(c.entries) >= c.maxEntries {
+		c.evictOldest()
+	}
+
+	elem := c.order.PushFront(&cacheEntry[K, V]{key: key, value: value, readAt: now})
+	c.entries[key] = elem
+}
+
+// Len reports the current number of live entries, expired or not. It exists
+// for tests proving the size bound holds; production callers have no need
+// for it.
+func (c *Cache[K, V]) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+func (c *Cache[K, V]) evictOldest() {
+	oldest := c.order.Back()
+	if oldest != nil {
+		c.removeElement(oldest)
+	}
+}
+
+func (c *Cache[K, V]) removeElement(elem *list.Element) {
+	entry := elem.Value.(*cacheEntry[K, V])
+	delete(c.entries, entry.key)
+	c.order.Remove(elem)
+}

--- a/libs/authzcache/cache_test.go
+++ b/libs/authzcache/cache_test.go
@@ -1,0 +1,80 @@
+package authzcache_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/authzcache"
+)
+
+func TestGetMissesOnAnAbsentKey(t *testing.T) {
+	c := authzcache.New[string, int](10, time.Minute)
+	if _, ok := c.Get("missing"); ok {
+		t.Error("expected a miss for a key that was never set")
+	}
+}
+
+func TestSetThenGetReturnsTheStoredValue(t *testing.T) {
+	c := authzcache.New[string, int](10, time.Minute)
+	c.Set("a", 1)
+	got, ok := c.Get("a")
+	if !ok || got != 1 {
+		t.Errorf("got (%v, %v), want (1, true)", got, ok)
+	}
+}
+
+func TestGetIsAMissAfterTheTTLElapses(t *testing.T) {
+	now := time.Now()
+	c := authzcache.NewWithClock[string, int](10, time.Minute, func() time.Time { return now })
+	c.Set("a", 1)
+
+	now = now.Add(2 * time.Minute)
+	if _, ok := c.Get("a"); ok {
+		t.Error("expected a miss once the entry's TTL has elapsed")
+	}
+}
+
+// TestSizeNeverExceedsMaxEntriesUnderHighCardinality is the issue #11
+// acceptance criterion "Caches are bounded and cannot grow without limit
+// under high user cardinality": inserting far more distinct keys than the
+// configured bound - simulating many distinct users, tenants or roles -
+// must never grow the cache past that bound, with or without a TTL.
+func TestSizeNeverExceedsMaxEntriesUnderHighCardinality(t *testing.T) {
+	const maxEntries = 100
+	c := authzcache.New[int, int](maxEntries, time.Hour)
+
+	for i := 0; i < 100_000; i++ {
+		c.Set(i, i)
+		if got := c.Len(); got > maxEntries {
+			t.Fatalf("after inserting key %d, cache holds %d entries, want at most %d", i, got, maxEntries)
+		}
+	}
+	if got := c.Len(); got != maxEntries {
+		t.Errorf("expected the cache to settle at exactly %d entries, got %d", maxEntries, got)
+	}
+}
+
+// TestLeastRecentlyUsedEntryIsEvictedFirst proves the eviction the bound
+// relies on is not just "some entry, any entry" but genuinely
+// least-recently-used: a key kept warm by repeated Get calls survives
+// while a cold one is evicted first.
+func TestLeastRecentlyUsedEntryIsEvictedFirst(t *testing.T) {
+	c := authzcache.New[string, int](2, time.Hour)
+	c.Set("cold", 1)
+	c.Set("warm", 2)
+
+	// Touch "warm" so "cold" becomes the least-recently-used entry.
+	c.Get("warm")
+
+	c.Set("new", 3)
+
+	if _, ok := c.Get("cold"); ok {
+		t.Error("expected the least-recently-used entry to have been evicted")
+	}
+	if _, ok := c.Get("warm"); !ok {
+		t.Error("expected the recently touched entry to survive eviction")
+	}
+	if _, ok := c.Get("new"); !ok {
+		t.Error("expected the newly inserted entry to be present")
+	}
+}

--- a/libs/authzcache/go.mod
+++ b/libs/authzcache/go.mod
@@ -1,0 +1,3 @@
+module github.com/tishan-harischandra/cerbos-poc/libs/authzcache
+
+go 1.25

--- a/libs/capabilityeval/evaluate.go
+++ b/libs/capabilityeval/evaluate.go
@@ -1,0 +1,137 @@
+package capabilityeval
+
+import (
+	"fmt"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+)
+
+// LeafOutcome is what the caller already learned about one leaf: the PDP's
+// decision, plus why (Appendix A's ROLE/USER_GRANT/USER_REVOKE/
+// MANDATORY_RULE vocabulary, or any other reason code the caller supplies -
+// this package treats it as an opaque string).
+type LeafOutcome struct {
+	Allowed bool
+	Reason  string
+}
+
+// ReasonRequiredPermissionDenied is the stable, audience-safe top-level
+// reason code for a denied capability (§12.4's snapshot example). It says
+// only that composition failed, never which leaf or why - that detail lives
+// in FailedRequirements, which is filtered out of end-user responses.
+const ReasonRequiredPermissionDenied = "REQUIRED_PERMISSION_DENIED"
+
+// FailedRequirement is one denied leaf that caused a capability to fail,
+// the administration-audience evidence from §12.4.
+type FailedRequirement struct {
+	Resource string
+	Action   string
+	Target   string
+	Reason   string
+}
+
+// Outcome is one capability's evaluated decision, in the full
+// administration shape. ForEndUser strips it to the audience-safe shape.
+type Outcome struct {
+	Allowed            bool
+	Reason             string
+	FailedRequirements []FailedRequirement
+}
+
+// EndUserOutcome is the audience-filtered shape §12.4 requires for
+// end-user paths: a stable reason code only, never the requirement tree.
+type EndUserOutcome struct {
+	Allowed bool
+	Reason  string
+}
+
+// ForEndUser strips an Outcome down to what an end-user response may
+// carry. Full requirement trees must never appear on end-user paths
+// (issue #11 acceptance criteria); this is the one place that boundary is
+// enforced structurally rather than by caller discipline.
+func (o Outcome) ForEndUser() EndUserOutcome {
+	return EndUserOutcome{Allowed: o.Allowed, Reason: o.Reason}
+}
+
+// Evaluate composes every definition's expression over decisions, the
+// leaf-decision map the caller already obtained from Cerbos (§12.3 steps
+// 7-8). A leaf with no entry in decisions is treated as denied: a leaf the
+// caller never checked must never be silently allowed.
+func Evaluate(defs []capabilitycatalog.UiCapabilityDefinition, targets map[string]ResourceRef, decisions map[Leaf]LeafOutcome) (map[string]Outcome, error) {
+	outcomes := make(map[string]Outcome, len(defs))
+	for _, def := range defs {
+		allowed, failed, err := evaluateExpression(def.Expression, targets, decisions)
+		if err != nil {
+			return nil, fmt.Errorf("capability %q: %w", def.Key, err)
+		}
+		outcome := Outcome{Allowed: allowed}
+		if !allowed {
+			outcome.Reason = ReasonRequiredPermissionDenied
+			outcome.FailedRequirements = failed
+		}
+		outcomes[def.Key] = outcome
+	}
+	return outcomes, nil
+}
+
+// evaluateExpression returns whether the expression is satisfied and, when
+// it is not, the leaves whose denial explains why. A branch that itself
+// evaluates to allowed contributes no evidence, even if nested inside a
+// failing parent, and even if some of its own children were individually
+// denied (§12.4: evidence should explain the failure, not list irrelevant
+// detail from branches that passed).
+func evaluateExpression(e capabilitycatalog.Expression, targets map[string]ResourceRef, decisions map[Leaf]LeafOutcome) (bool, []FailedRequirement, error) {
+	switch {
+	case e.Permission != nil:
+		ref, ok := targets[e.Permission.TargetRef]
+		if !ok {
+			return false, nil, fmt.Errorf("targetRef %q has no resolved resource", e.Permission.TargetRef)
+		}
+		leaf := Leaf{Resource: ref, Action: e.Permission.Action}
+		decision := decisions[leaf] // zero value: Allowed=false, unchecked leaves stay denied.
+		if decision.Allowed {
+			return true, nil, nil
+		}
+		return false, []FailedRequirement{{
+			Resource: ref.Kind,
+			Action:   e.Permission.Action,
+			Target:   ref.ID,
+			Reason:   decision.Reason,
+		}}, nil
+
+	case e.AllOf != nil:
+		allowed := true
+		var failed []FailedRequirement
+		for _, child := range e.AllOf {
+			childAllowed, childFailed, err := evaluateExpression(child, targets, decisions)
+			if err != nil {
+				return false, nil, err
+			}
+			if !childAllowed {
+				allowed = false
+				failed = append(failed, childFailed...)
+			}
+		}
+		if allowed {
+			return true, nil, nil
+		}
+		return false, failed, nil
+
+	case e.AnyOf != nil:
+		var failed []FailedRequirement
+		for _, child := range e.AnyOf {
+			childAllowed, childFailed, err := evaluateExpression(child, targets, decisions)
+			if err != nil {
+				return false, nil, err
+			}
+			if childAllowed {
+				return true, nil, nil
+			}
+			failed = append(failed, childFailed...)
+		}
+		return false, failed, nil
+
+	default:
+		return false, nil, fmt.Errorf("expression has no populated field")
+	}
+}

--- a/libs/capabilityeval/evaluate_test.go
+++ b/libs/capabilityeval/evaluate_test.go
@@ -1,0 +1,158 @@
+package capabilityeval_test
+
+import (
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilityeval"
+)
+
+func leaf(kind, id, action string) capabilityeval.Leaf {
+	return capabilityeval.Leaf{Resource: capabilityeval.ResourceRef{Kind: kind, ID: id}, Action: action}
+}
+
+func TestEvaluateAllOfIsAllowedOnlyWhenEveryLeafIsAllowed(t *testing.T) {
+	defs := []capabilitycatalog.UiCapabilityDefinition{
+		{Key: "patient.route.edit", Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+			permission("patient_record", "read", "patient"),
+			permission("patient_record", "update", "patient"),
+		}}},
+	}
+	targets := map[string]capabilityeval.ResourceRef{"patient": {Kind: "patient_record", ID: "p-1"}}
+
+	allAllowed := map[capabilityeval.Leaf]capabilityeval.LeafOutcome{
+		leaf("patient_record", "p-1", "read"):   {Allowed: true},
+		leaf("patient_record", "p-1", "update"): {Allowed: true},
+	}
+	outcomes, err := capabilityeval.Evaluate(defs, targets, allAllowed)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !outcomes["patient.route.edit"].Allowed {
+		t.Error("expected the capability to be allowed when every leaf is allowed")
+	}
+
+	oneRevoked := map[capabilityeval.Leaf]capabilityeval.LeafOutcome{
+		leaf("patient_record", "p-1", "read"):   {Allowed: true},
+		leaf("patient_record", "p-1", "update"): {Allowed: false, Reason: "USER_REVOKE"},
+	}
+	outcomes, err = capabilityeval.Evaluate(defs, targets, oneRevoked)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if outcomes["patient.route.edit"].Allowed {
+		t.Error("expected the capability to be denied when one required leaf is denied")
+	}
+}
+
+func TestEvaluateAnyOfIsAllowedWhenAtLeastOneLeafIsAllowed(t *testing.T) {
+	defs := []capabilitycatalog.UiCapabilityDefinition{
+		{Key: "patient.button.create-order", Expression: capabilitycatalog.Expression{AnyOf: []capabilitycatalog.Expression{
+			permission("medication_request", "create", "meds"),
+			permission("service_request", "create", "labs"),
+		}}},
+	}
+	targets := map[string]capabilityeval.ResourceRef{
+		"meds": {Kind: "medication_request", ID: "h-1"},
+		"labs": {Kind: "service_request", ID: "h-1"},
+	}
+
+	decisions := map[capabilityeval.Leaf]capabilityeval.LeafOutcome{
+		leaf("medication_request", "h-1", "create"): {Allowed: false, Reason: "USER_REVOKE"},
+		leaf("service_request", "h-1", "create"):    {Allowed: true},
+	}
+	outcomes, err := capabilityeval.Evaluate(defs, targets, decisions)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !outcomes["patient.button.create-order"].Allowed {
+		t.Error("expected anyOf to be allowed when at least one leaf is allowed")
+	}
+
+	noneAllowed := map[capabilityeval.Leaf]capabilityeval.LeafOutcome{
+		leaf("medication_request", "h-1", "create"): {Allowed: false, Reason: "USER_REVOKE"},
+		leaf("service_request", "h-1", "create"):    {Allowed: false, Reason: "MANDATORY_RULE"},
+	}
+	outcomes, err = capabilityeval.Evaluate(defs, targets, noneAllowed)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if outcomes["patient.button.create-order"].Allowed {
+		t.Error("expected anyOf to be denied when every leaf is denied")
+	}
+}
+
+func TestEvaluateNestedAnyOfInsideAllOf(t *testing.T) {
+	defs := []capabilitycatalog.UiCapabilityDefinition{
+		{Key: "patient.button.create-order", Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+			permission("patient_record", "read", "patient"),
+			{AnyOf: []capabilitycatalog.Expression{
+				permission("medication_request", "create", "meds"),
+				permission("service_request", "create", "labs"),
+			}},
+		}}},
+	}
+	targets := map[string]capabilityeval.ResourceRef{
+		"patient": {Kind: "patient_record", ID: "p-1"},
+		"meds":    {Kind: "medication_request", ID: "h-1"},
+		"labs":    {Kind: "service_request", ID: "h-1"},
+	}
+
+	// Read is allowed, and one of the two anyOf branches is allowed: the
+	// whole allOf must be allowed.
+	decisions := map[capabilityeval.Leaf]capabilityeval.LeafOutcome{
+		leaf("patient_record", "p-1", "read"):       {Allowed: true},
+		leaf("medication_request", "h-1", "create"): {Allowed: false, Reason: "USER_REVOKE"},
+		leaf("service_request", "h-1", "create"):    {Allowed: true},
+	}
+	outcomes, err := capabilityeval.Evaluate(defs, targets, decisions)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !outcomes["patient.button.create-order"].Allowed {
+		t.Error("expected the allOf to be allowed: read passed and the nested anyOf had one allowed branch")
+	}
+
+	// Read is allowed but both anyOf branches are denied: the allOf must
+	// fail, and only the anyOf's leaves belong in the failure evidence
+	// since the read leaf did not cause the failure.
+	bothOrdersDenied := map[capabilityeval.Leaf]capabilityeval.LeafOutcome{
+		leaf("patient_record", "p-1", "read"):       {Allowed: true},
+		leaf("medication_request", "h-1", "create"): {Allowed: false, Reason: "USER_REVOKE"},
+		leaf("service_request", "h-1", "create"):    {Allowed: false, Reason: "MANDATORY_RULE"},
+	}
+	outcomes, err = capabilityeval.Evaluate(defs, targets, bothOrdersDenied)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	outcome := outcomes["patient.button.create-order"]
+	if outcome.Allowed {
+		t.Fatal("expected the capability to be denied")
+	}
+	if len(outcome.FailedRequirements) != 2 {
+		t.Fatalf("expected exactly the 2 denied anyOf leaves as evidence, got %d: %+v",
+			len(outcome.FailedRequirements), outcome.FailedRequirements)
+	}
+	for _, req := range outcome.FailedRequirements {
+		if req.Resource == "patient_record" {
+			t.Errorf("the passing read leaf must not appear in failure evidence: %+v", req)
+		}
+	}
+}
+
+func TestEvaluateFailsOnAnUncheckedLeaf(t *testing.T) {
+	defs := []capabilitycatalog.UiCapabilityDefinition{
+		{Key: "patient.route.details", Expression: permission("patient_record", "read", "patient")},
+	}
+	targets := map[string]capabilityeval.ResourceRef{"patient": {Kind: "patient_record", ID: "p-1"}}
+
+	// No decisions supplied at all: a leaf the caller never checked must
+	// never silently evaluate to allowed.
+	outcomes, err := capabilityeval.Evaluate(defs, targets, map[capabilityeval.Leaf]capabilityeval.LeafOutcome{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if outcomes["patient.route.details"].Allowed {
+		t.Error("a leaf with no decision must never be treated as allowed")
+	}
+}

--- a/libs/capabilityeval/flatten.go
+++ b/libs/capabilityeval/flatten.go
@@ -1,0 +1,88 @@
+// Package capabilityeval is the pure, zero-I/O half of the §12.3 backend
+// evaluation algorithm (issue #11): flattening capability expressions into
+// permission leaves, deduplicating them, and composing allOf/anyOf over a
+// leaf-decision map the caller already obtained from Cerbos.
+//
+// Nothing here calls Cerbos, a database or the network. Resolving a
+// targetRef into a concrete resource, calling the PDP and caching are all
+// the ADS's job (apps/ads/internal/capability); this package only takes
+// already-resolved, plain Go values and computes with them, which is what
+// makes it unit-testable without any infrastructure test double.
+//
+// It depends on libs/capabilitycatalog for the UiCapabilityDefinition and
+// Expression shapes rather than duplicating them. That package's own type
+// definitions do no I/O either; only its separate loader functions (which
+// capabilityeval never calls) touch the filesystem.
+package capabilityeval
+
+import (
+	"fmt"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+)
+
+// ResourceRef identifies one concrete resource instance, already resolved
+// server-side from a symbolic targetRef (§12.2, §12.3 step 2).
+type ResourceRef struct {
+	Kind string
+	ID   string
+}
+
+// Leaf is one resource-action pair - the unit a Cerbos decision answers for
+// and the unit this package deduplicates by (§12.3 step 4).
+type Leaf struct {
+	Resource ResourceRef
+	Action   string
+}
+
+// Flatten walks every definition's expression tree and returns the unique
+// set of leaves that must be checked, resolving each permission's symbolic
+// targetRef through targets.
+//
+// targets is the already-resolved server-side mapping from targetRef to a
+// concrete resource (§12.2: "targetRef must be resolved server-side");
+// resolving it is I/O and happens before this function is called.
+func Flatten(defs []capabilitycatalog.UiCapabilityDefinition, targets map[string]ResourceRef) ([]Leaf, error) {
+	seen := make(map[Leaf]struct{})
+	var leaves []Leaf
+
+	for _, def := range defs {
+		if err := flattenExpression(def.Expression, targets, seen, &leaves); err != nil {
+			return nil, fmt.Errorf("capability %q: %w", def.Key, err)
+		}
+	}
+
+	return leaves, nil
+}
+
+func flattenExpression(e capabilitycatalog.Expression, targets map[string]ResourceRef, seen map[Leaf]struct{}, leaves *[]Leaf) error {
+	switch {
+	case e.Permission != nil:
+		ref, ok := targets[e.Permission.TargetRef]
+		if !ok {
+			return fmt.Errorf("targetRef %q has no resolved resource", e.Permission.TargetRef)
+		}
+		leaf := Leaf{Resource: ref, Action: e.Permission.Action}
+		if _, dup := seen[leaf]; !dup {
+			seen[leaf] = struct{}{}
+			*leaves = append(*leaves, leaf)
+		}
+		return nil
+	case e.AllOf != nil:
+		for _, child := range e.AllOf {
+			if err := flattenExpression(child, targets, seen, leaves); err != nil {
+				return err
+			}
+		}
+		return nil
+	case e.AnyOf != nil:
+		for _, child := range e.AnyOf {
+			if err := flattenExpression(child, targets, seen, leaves); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("expression has no populated field")
+	}
+}

--- a/libs/capabilityeval/flatten_test.go
+++ b/libs/capabilityeval/flatten_test.go
@@ -1,0 +1,96 @@
+package capabilityeval_test
+
+import (
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilityeval"
+)
+
+func permission(resource, action, targetRef string) capabilitycatalog.Expression {
+	return capabilitycatalog.Expression{Permission: &capabilitycatalog.PermissionRequirement{
+		Resource: resource, Action: action, TargetRef: targetRef,
+	}}
+}
+
+func TestFlattenReturnsOneLeafPerPermission(t *testing.T) {
+	defs := []capabilitycatalog.UiCapabilityDefinition{
+		{Key: "patient.route.details", Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+			permission("patient_record", "read", "patient"),
+		}}},
+	}
+	targets := map[string]capabilityeval.ResourceRef{
+		"patient": {Kind: "patient_record", ID: "patient-456"},
+	}
+
+	leaves, err := capabilityeval.Flatten(defs, targets)
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	if len(leaves) != 1 {
+		t.Fatalf("expected 1 leaf, got %d", len(leaves))
+	}
+	want := capabilityeval.Leaf{Resource: capabilityeval.ResourceRef{Kind: "patient_record", ID: "patient-456"}, Action: "read"}
+	if leaves[0] != want {
+		t.Errorf("got %+v, want %+v", leaves[0], want)
+	}
+}
+
+func TestFlattenDeduplicatesALeafSharedAcrossCapabilities(t *testing.T) {
+	defs := []capabilitycatalog.UiCapabilityDefinition{
+		{Key: "patient.route.details", Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+			permission("patient_record", "read", "patient"),
+		}}},
+		{Key: "patient.route.edit", Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+			permission("patient_record", "read", "patient"),
+			permission("patient_record", "update", "patient"),
+		}}},
+	}
+	targets := map[string]capabilityeval.ResourceRef{
+		"patient": {Kind: "patient_record", ID: "patient-456"},
+	}
+
+	leaves, err := capabilityeval.Flatten(defs, targets)
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	if len(leaves) != 2 {
+		t.Fatalf("expected the shared read leaf to be checked exactly once (2 unique leaves total), got %d: %+v", len(leaves), leaves)
+	}
+}
+
+func TestFlattenWalksNestedAnyOfInsideAllOf(t *testing.T) {
+	defs := []capabilitycatalog.UiCapabilityDefinition{
+		{Key: "patient.button.create-order", Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+			permission("patient_record", "read", "patient"),
+			{AnyOf: []capabilitycatalog.Expression{
+				permission("medication_request", "create", "medicationOrders"),
+				permission("service_request", "create", "laboratoryOrders"),
+			}},
+		}}},
+	}
+	targets := map[string]capabilityeval.ResourceRef{
+		"patient":          {Kind: "patient_record", ID: "patient-456"},
+		"medicationOrders": {Kind: "medication_request", ID: "hospital-1"},
+		"laboratoryOrders": {Kind: "service_request", ID: "hospital-1"},
+	}
+
+	leaves, err := capabilityeval.Flatten(defs, targets)
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	if len(leaves) != 3 {
+		t.Fatalf("expected 3 unique leaves, got %d: %+v", len(leaves), leaves)
+	}
+}
+
+func TestFlattenFailsOnAnUnresolvedTargetRef(t *testing.T) {
+	defs := []capabilitycatalog.UiCapabilityDefinition{
+		{Key: "patient.route.details", Expression: permission("patient_record", "read", "patient")},
+	}
+
+	_, err := capabilityeval.Flatten(defs, map[string]capabilityeval.ResourceRef{})
+	if err == nil {
+		t.Fatal("expected an error for an unresolved targetRef")
+	}
+}

--- a/libs/capabilityeval/go.mod
+++ b/libs/capabilityeval/go.mod
@@ -1,0 +1,14 @@
+module github.com/tishan-harischandra/cerbos-poc/libs/capabilityeval
+
+go 1.25.11
+
+require github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog v0.0.0
+
+require (
+	github.com/tishan-harischandra/cerbos-poc/libs/cataloggen v0.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog => ../capabilitycatalog
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/cataloggen => ../cataloggen

--- a/libs/capabilityeval/go.sum
+++ b/libs/capabilityeval/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/libs/capabilityeval/property_test.go
+++ b/libs/capabilityeval/property_test.go
@@ -1,0 +1,135 @@
+package capabilityeval_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilityeval"
+)
+
+// referenceEvaluate is a second, independent implementation of the same
+// allOf/anyOf boolean semantics, written directly against plain Go bools
+// rather than against capabilitycatalog.Expression or capabilityeval's own
+// recursion. The property test below cross-checks Evaluate's verdict
+// against this reference for many randomly generated trees, so a bug in
+// Evaluate's actual recursive walk cannot also be present in the oracle it
+// is compared to.
+type refNode struct {
+	leaf     int // -1 when this node is not a leaf
+	isAnyOf  bool
+	children []refNode
+}
+
+func referenceEvaluate(n refNode, leafAllowed map[int]bool) bool {
+	if n.leaf >= 0 {
+		return leafAllowed[n.leaf]
+	}
+	if n.isAnyOf {
+		for _, c := range n.children {
+			if referenceEvaluate(c, leafAllowed) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, c := range n.children {
+		if !referenceEvaluate(c, leafAllowed) {
+			return false
+		}
+	}
+	return true
+}
+
+// randomTree generates a random allOf/anyOf/permission tree of bounded
+// depth and width, allocating fresh, globally unique leaf IDs as it goes.
+func randomTree(rng *rand.Rand, depth int, nextLeaf *int) refNode {
+	if depth <= 0 || rng.Intn(3) == 0 {
+		id := *nextLeaf
+		*nextLeaf++
+		return refNode{leaf: id}
+	}
+
+	width := 1 + rng.Intn(3)
+	children := make([]refNode, width)
+	for i := range children {
+		children[i] = randomTree(rng, depth-1, nextLeaf)
+	}
+	return refNode{leaf: -1, isAnyOf: rng.Intn(2) == 0, children: children}
+}
+
+// toExpression converts a refNode into the real capabilitycatalog.Expression
+// shape Evaluate consumes, resolving each leaf to its own dedicated
+// resource so no two leaves collide.
+func toExpression(n refNode) capabilitycatalog.Expression {
+	if n.leaf >= 0 {
+		targetRef := fmt.Sprintf("target-%d", n.leaf)
+		return permission("resource", "act", targetRef)
+	}
+	children := make([]capabilitycatalog.Expression, len(n.children))
+	for i, c := range n.children {
+		children[i] = toExpression(c)
+	}
+	if n.isAnyOf {
+		return capabilitycatalog.Expression{AnyOf: children}
+	}
+	return capabilitycatalog.Expression{AllOf: children}
+}
+
+func collectLeaves(n refNode, out map[int]bool) {
+	if n.leaf >= 0 {
+		out[n.leaf] = true
+		return
+	}
+	for _, c := range n.children {
+		collectLeaves(c, out)
+	}
+}
+
+// TestEvaluateMatchesAnIndependentBooleanReferenceAcrossRandomTrees is the
+// issue #11 acceptance criterion "Composition can never produce an allow
+// absent from all required leaf decisions, asserted by property test": for
+// many random allOf/anyOf/permission trees and random leaf decisions,
+// Evaluate's verdict must agree with the reference boolean evaluator, so an
+// allOf can never be allowed while one of its leaves is denied and an anyOf
+// can never be denied while one of its leaves is allowed.
+func TestEvaluateMatchesAnIndependentBooleanReferenceAcrossRandomTrees(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+
+	const iterations = 500
+	for i := 0; i < iterations; i++ {
+		nextLeaf := 0
+		tree := randomTree(rng, 4, &nextLeaf)
+
+		leafIDs := make(map[int]bool)
+		collectLeaves(tree, leafIDs)
+
+		leafAllowed := make(map[int]bool, len(leafIDs))
+		targets := make(map[string]capabilityeval.ResourceRef, len(leafIDs))
+		decisions := make(map[capabilityeval.Leaf]capabilityeval.LeafOutcome, len(leafIDs))
+		for id := range leafIDs {
+			allowed := rng.Intn(2) == 1
+			leafAllowed[id] = allowed
+
+			targetRef := fmt.Sprintf("target-%d", id)
+			ref := capabilityeval.ResourceRef{Kind: "resource", ID: fmt.Sprintf("r-%d", id)}
+			targets[targetRef] = ref
+			decisions[capabilityeval.Leaf{Resource: ref, Action: "act"}] = capabilityeval.LeafOutcome{Allowed: allowed}
+		}
+
+		defs := []capabilitycatalog.UiCapabilityDefinition{{Key: "under-test", Expression: toExpression(tree)}}
+
+		outcomes, err := capabilityeval.Evaluate(defs, targets, decisions)
+		if err != nil {
+			t.Fatalf("iteration %d: Evaluate: %v", i, err)
+		}
+
+		want := referenceEvaluate(tree, leafAllowed)
+		got := outcomes["under-test"].Allowed
+		if got != want {
+			t.Fatalf("iteration %d: Evaluate returned %v, reference evaluator says %v, for tree %+v with decisions %v",
+				i, got, want, tree, leafAllowed)
+		}
+	}
+}


### PR DESCRIPTION
## What changed

Implements the capability evaluator and the capability snapshot endpoint (§12.3, §12.4,
§12.7, §15.2, ADR-005): the mechanism that turns per-route PDP calls into one batched
evaluation per module or page context.

- **`libs/capabilityeval`** (pure, zero I/O): `Flatten` walks a capability's expression
  tree and returns the deduplicated set of `(resource kind, resource id, action)` leaves,
  resolving each permission's symbolic `targetRef` through an already-resolved map the
  caller supplies. `Evaluate` composes `allOf`/`anyOf` over a caller-supplied
  leaf-decision map, producing an `Outcome` with the §12.4 shape: `Allowed`, a stable
  `Reason` code, and `FailedRequirements` evidence. `ForEndUser` strips an `Outcome` to
  the audience-safe `{allowed, reason}` shape.
- **`libs/authzcache`**: a generic, bounded `Cache[K, V]` — TTL-aged *and*
  least-recently-used-evicted at a fixed `maxEntries` — generalizing the pattern
  `apps/ads/internal/assignments.CachingRoleMatrix` already proved out, so every cache on
  the hot path (role permissions, user overrides, the capability catalog, IdP metadata)
  shares the same bound.
- **`apps/ads/internal/capability`**: the §12.3 algorithm end to end — loads capability
  definitions for a module (`CapabilityCatalog` port, `FSCatalog` reads the same local
  release tree Cerbos reads its policies from, cached via `authzcache`), resolves every
  `targetRef` server-side (`TargetResolver` port; `DefaultTargetResolver` uses the
  `<targetRef>Id` routing-context convention §12.3's own example uses, falling back to
  hospital scope for module/collection leaves), flattens and deduplicates leaves,
  resolves assignments once per unique resource, batches Cerbos `CheckResources` calls
  and chunks them at a configurable `MaxResourcesPerCheck`, evaluates in memory via
  `capabilityeval`, and assembles the snapshot with both revisions and a stable sha256
  context fingerprint. `Audience` (`AudienceEndUser` by default) controls whether
  `FailedRequirements` is attached to a denial.
- Wired into the ADS: `server.Config.CapabilityHandler` mounts
  `POST /internal/capabilities/evaluate` (absent when unconfigured, exactly like the
  existing decision endpoint); `cmd/ads/main.go` builds it from `FSCatalog`,
  `DefaultTargetResolver` and the same cached assignment resolver the decision endpoint
  uses; `config.FromEnv` gains `CAPABILITY_CATALOG_DIR`, `CAPABILITY_CATALOG_REVISION`,
  `ROOT_POLICY_REVISION`; `docker-compose.yml` mounts
  `deploy/cerbos/catalog/ui-capabilities` into the `ads` container read-only.
- Exported `authz.DecisionSource` (was `decisionSource`) so the capability endpoint
  labels leaf decisions from the same Appendix A mapping instead of a second
  implementation of it.

## Acceptance criteria

- [x] An `allOf` capability is allowed only when every leaf is allowed —
  `TestEvaluateAllOfIsAllowedOnlyWhenEveryLeafIsAllowed`,
  `TestAnAllOfCapabilityIsAllowedOnlyWhenEveryLeafIsAllowed`
- [x] An `anyOf` capability is allowed when at least one leaf is allowed —
  `TestEvaluateAnyOfIsAllowedWhenAtLeastOneLeafIsAllowed`
- [x] A nested `allOf` containing an `anyOf` evaluates correctly —
  `TestEvaluateNestedAnyOfInsideAllOf`
- [x] Composition can never produce an allow absent from all required leaf decisions,
  asserted by property test —
  `TestEvaluateMatchesAnIndependentBooleanReferenceAcrossRandomTrees` (500 random
  allOf/anyOf/permission trees cross-checked against an independent boolean reference)
- [x] A leaf appearing in multiple requested capabilities is checked exactly once —
  `TestFlattenDeduplicatesALeafSharedAcrossCapabilities`,
  `TestASharedLeafIsCheckedExactlyOnceAcrossCapabilities`
- [x] Requesting many capabilities issues a bounded number of Cerbos calls, not one per
  capability — `TestManyCapabilitiesAreBatchedAndChunkedWithinResourceLimits`
- [x] Calls exceeding Cerbos request limits are chunked automatically — same test (250
  resources at a 50-per-call limit takes exactly 5 calls)
- [x] `targetRef` is resolved server-side; browser-supplied authorization attributes are
  ignored — `TestIdentityFieldsInTheRequestBodyAreRefused`,
  `TestUnknownRequestFieldsAreRefused`
- [x] The snapshot carries both revisions and a stable context fingerprint —
  `TestTheSnapshotCarriesBothRevisionsAndAStableFingerprint`
- [x] End-user evidence is a stable reason code only; full requirement trees never
  appear on end-user paths — `TestEndUserResponsesCarryNoFailedRequirementsTree`,
  `TestAdminAudienceResponsesCarryTheFailedRequirementsTree` (opt-in admin audience only)
- [x] `capabilityeval` has no I/O dependency and is unit-tested without infrastructure
  test doubles — the whole package (`Flatten`, `Evaluate`, the property test) is
  exercised with plain Go values only
- [x] Caches are bounded and cannot grow without limit under high user cardinality —
  `TestSizeNeverExceedsMaxEntriesUnderHighCardinality` (100,000 distinct keys against a
  100-entry bound), `TestLeastRecentlyUsedEntryIsEvictedFirst`

## How it was verified

- `bash scripts/go.sh libs/capabilityeval test ./...` — 9 tests, all green.
- `bash scripts/go.sh libs/authzcache test ./...` — 5 tests, all green.
- `bash scripts/go.sh apps/ads test ./...` — every package green, including the 12 new
  `internal/capability` tests and the 2 new `internal/server` route-mount tests.
- `bash scripts/go.sh tests/architecture test ./...` — 20 tests green, including
  `TestNoGoCodeEncodesPrecedenceOrdering` and `TestOwnershipRules`: nothing in this PR
  ranks a grant against a revoke in Go, and `capabilityeval` does not read Cerbos'
  decisions, only compose over ones the ADS already obtained.
- `python3 -c "import yaml; yaml.safe_load(open('docker-compose.yml'))"` — the compose
  file is valid YAML after the new volume mount and environment entries.

Closes #11


Closes #11
