### PR TITLE
Administration service: role matrix writes with optimistic concurrency, audit and outbox (#13)

### DIFF
--- a/apps/admin-service/cmd/admin-service/main.go
+++ b/apps/admin-service/cmd/admin-service/main.go
@@ -1,0 +1,106 @@
+// Command admin-service runs the Authorization Administration Service HTTP
+// surface (§9.4).
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/config"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/server"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/postgresstore"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/provider"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	cfg := config.FromEnv(os.LookupEnv)
+
+	store, err := postgresstore.Open(context.Background(), cfg.PostgresDSN)
+	if err != nil {
+		logger.Error("could not prepare the authorization database pool", slog.Any("error", err))
+		os.Exit(1)
+	}
+	defer func() { _ = store.Close() }()
+
+	catalog, err := capabilitycatalog.LoadActiveCatalogDir(cfg.CatalogDir)
+	if err != nil {
+		logger.Error("could not load the active resource/action catalog", slog.Any("error", err))
+		os.Exit(1)
+	}
+
+	// The identity provider is selected here and nowhere else (§7.1), the
+	// same as every other service that verifies a token.
+	idpConfig, err := provider.FromEnv(os.LookupEnv)
+	if err != nil {
+		logger.Error("could not read the identity provider configuration", slog.Any("error", err))
+		os.Exit(1)
+	}
+	verifier, err := provider.NewVerifier(idpConfig)
+	if err != nil {
+		logger.Error("could not prepare token verification", slog.Any("error", err))
+		os.Exit(1)
+	}
+
+	handler := server.New(server.Config{
+		Dependencies: []server.Dependency{
+			{Name: "postgres", Probe: tcpProbe(cfg.PostgresAddr)},
+			{Name: "idp", Probe: tcpProbe(cfg.IdPAddr)},
+		},
+		Verifier: verifier,
+		RoleMatrix: &rolematrix.Handler{
+			Store:   store,
+			Catalog: catalog,
+		},
+	})
+
+	httpServer := &http.Server{
+		Addr:              cfg.HTTPAddr,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			logger.Error("graceful shutdown failed", slog.Any("error", err))
+		}
+	}()
+
+	logger.Info("admin-service listening",
+		slog.String("addr", cfg.HTTPAddr),
+		slog.String("postgres", cfg.PostgresAddr),
+		slog.String("idpType", string(idpConfig.Type)),
+		slog.String("idpIssuer", idpConfig.Issuer),
+	)
+
+	if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Error("admin-service stopped", slog.Any("error", err))
+		os.Exit(1)
+	}
+}
+
+func tcpProbe(addr string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		dialer := &net.Dialer{}
+		conn, err := dialer.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}
+}

--- a/apps/admin-service/go.mod
+++ b/apps/admin-service/go.mod
@@ -1,0 +1,30 @@
+module github.com/tishan-harischandra/cerbos-poc/apps/admin-service
+
+go 1.25.11
+
+require (
+	github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore v0.0.0
+	github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog v0.0.0
+	github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory v0.0.0
+	github.com/tishan-harischandra/cerbos-poc/libs/outbox v0.0.0
+	github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier v0.0.0
+)
+
+require (
+	github.com/tishan-harischandra/cerbos-poc/libs/canonicalid v0.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore => ../../libs/assignmentstore
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog => ../../libs/capabilitycatalog
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/cataloggen => ../../libs/cataloggen
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/canonicalid => ../../libs/canonicalid
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory => ../../libs/idpdirectory
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/outbox => ../../libs/outbox
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier => ../../libs/tokenverifier

--- a/apps/admin-service/internal/authority/authority.go
+++ b/apps/admin-service/internal/authority/authority.go
@@ -1,0 +1,38 @@
+// Package authority checks that an administrator may act on the tenant and
+// hospital a request targets, before any write touches the database (§9.4:
+// "Administrator authority validated against the target tenant and hospital
+// before any write").
+//
+// It knows nothing about roles or permissions in the business sense: that is
+// Cerbos policy's job, for business resources. An administrator's authority
+// over the *administration* surface is a narrower, simpler fact - which
+// tenant and hospital their own token scopes them to - and this package is
+// the one place that fact is checked.
+package authority
+
+import "errors"
+
+// ErrUnauthorized means the principal's token does not scope them to the
+// tenant, or the hospital, the request names.
+var ErrUnauthorized = errors.New("authority: the administrator's token does not scope them to this tenant or hospital")
+
+// Principal is the administrator's own tenant and hospital scope, as their
+// verified token attested it - never as a request body claimed it.
+type Principal struct {
+	TenantID   string
+	HospitalID string
+}
+
+// Validate reports whether principal may act on targetTenant and, when
+// targetHospital is non-empty, targetHospital too. An empty targetHospital
+// means the operation is tenant-scoped only (the role-matrix endpoints);
+// hospital is not checked in that case.
+func Validate(principal Principal, targetTenant, targetHospital string) error {
+	if targetTenant == "" || principal.TenantID == "" || principal.TenantID != targetTenant {
+		return ErrUnauthorized
+	}
+	if targetHospital != "" && principal.HospitalID != targetHospital {
+		return ErrUnauthorized
+	}
+	return nil
+}

--- a/apps/admin-service/internal/authority/authority_test.go
+++ b/apps/admin-service/internal/authority/authority_test.go
@@ -1,0 +1,61 @@
+package authority_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/authority"
+)
+
+func TestAMatchingTenantIsAuthorized(t *testing.T) {
+	err := authority.Validate(authority.Principal{TenantID: "tenant-a"}, "tenant-a", "")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestAMismatchedTenantIsRejected(t *testing.T) {
+	err := authority.Validate(authority.Principal{TenantID: "tenant-b"}, "tenant-a", "")
+	if !errors.Is(err, authority.ErrUnauthorized) {
+		t.Fatalf("Validate = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestAnEmptyPrincipalTenantIsRejectedEvenAgainstAnEmptyTarget(t *testing.T) {
+	// An administrator whose own token carries no tenant has no authority to
+	// claim, so this must not pass by both sides being empty.
+	err := authority.Validate(authority.Principal{}, "", "")
+	if !errors.Is(err, authority.ErrUnauthorized) {
+		t.Fatalf("Validate = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestAMatchingTenantAndHospitalIsAuthorized(t *testing.T) {
+	err := authority.Validate(
+		authority.Principal{TenantID: "tenant-a", HospitalID: "hospital-1"},
+		"tenant-a", "hospital-1")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestAMismatchedHospitalIsRejectedEvenWithAMatchingTenant(t *testing.T) {
+	err := authority.Validate(
+		authority.Principal{TenantID: "tenant-a", HospitalID: "hospital-2"},
+		"tenant-a", "hospital-1")
+	if !errors.Is(err, authority.ErrUnauthorized) {
+		t.Fatalf("Validate = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestATenantOnlyOperationDoesNotCheckHospital(t *testing.T) {
+	// targetHospital empty means the operation is tenant-scoped only (the
+	// role-matrix endpoints): the principal's own hospital, whatever it is,
+	// must not matter.
+	err := authority.Validate(
+		authority.Principal{TenantID: "tenant-a", HospitalID: "hospital-9"},
+		"tenant-a", "")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}

--- a/apps/admin-service/internal/config/config.go
+++ b/apps/admin-service/internal/config/config.go
@@ -1,0 +1,44 @@
+// Package config resolves the Administration Service runtime configuration
+// from the environment.
+package config
+
+// Config is the Administration Service runtime configuration.
+type Config struct {
+	HTTPAddr string
+	// PostgresAddr is the host:port the readiness probe dials. It is
+	// separate from the DSN because a readiness probe must not need a
+	// credential.
+	PostgresAddr string
+	// PostgresDSN is the connection string the write path uses. It carries
+	// a password, so it arrives whole from the environment rather than
+	// being assembled from parts here.
+	PostgresDSN string
+	// IdPAddr is the host:port the readiness probe dials.
+	IdPAddr string
+	// CatalogDir is the local path the active resource/action catalog is
+	// loaded from - the same per-pod-mounted release tree Cerbos and the
+	// ADS read policies and UI capabilities from (§13.1).
+	CatalogDir string
+}
+
+// LookupFunc mirrors os.LookupEnv so configuration stays testable.
+type LookupFunc func(key string) (string, bool)
+
+// FromEnv resolves the configuration, falling back to the docker compose
+// service names used by the walking skeleton.
+func FromEnv(lookup LookupFunc) Config {
+	return Config{
+		HTTPAddr:     valueOr(lookup, "ADMIN_SERVICE_HTTP_ADDR", ":8081"),
+		PostgresAddr: valueOr(lookup, "POSTGRES_ADDR", "postgres:5432"),
+		PostgresDSN:  valueOr(lookup, "ASSIGNMENTSTORE_POSTGRES_DSN", ""),
+		IdPAddr:      valueOr(lookup, "IDP_ADDR", "keycloak:8080"),
+		CatalogDir:   valueOr(lookup, "AUTHORIZATION_CATALOG_DIR", "/etc/cerbos-catalog/resources"),
+	}
+}
+
+func valueOr(lookup LookupFunc, key, fallback string) string {
+	if value, ok := lookup(key); ok && value != "" {
+		return value
+	}
+	return fallback
+}

--- a/apps/admin-service/internal/rolematrix/handler.go
+++ b/apps/admin-service/internal/rolematrix/handler.go
@@ -1,0 +1,234 @@
+// Package rolematrix implements PUT /admin/authz/tenants/{tenant}/roles/{role}/permissions
+// (§9.4): replacing a role's permission slice with an expected-revision
+// precondition, backed by assignmentstore.Store.SaveRoleMatrix's atomic
+// write of the permission, audit event, outbox event and revision bump
+// (§10.1, §16.1).
+package rolematrix
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/authority"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+)
+
+// Store is the narrow slice of assignmentstore.Store this handler needs.
+type Store interface {
+	RolePermission(ctx context.Context, key assignmentstore.RolePermissionKey) (assignmentstore.RolePermission, bool, error)
+	SaveRoleMatrix(ctx context.Context, write assignmentstore.RoleMatrixWrite) (int64, error)
+	PermissionRevision(ctx context.Context, tenantID string) (assignmentstore.PermissionRevision, bool, error)
+}
+
+// Catalog validates a resource/action pair against the active catalog
+// (§12.2: "Every permission leaf must resolve to a known catalog resource
+// and action" - the same rule applies to what an administrator may grant).
+type Catalog interface {
+	Has(resource, action string) bool
+}
+
+// PermissionInput is one row of the role-matrix slice a PUT request carries.
+type PermissionInput struct {
+	ResourceKey string     `json:"resourceKey"`
+	ActionKey   string     `json:"actionKey"`
+	Enabled     bool       `json:"enabled"`
+	ValidFrom   time.Time  `json:"validFrom"`
+	ValidUntil  *time.Time `json:"validUntil,omitempty"`
+}
+
+type saveRequest struct {
+	ExpectedRevision int64             `json:"expectedRevision"`
+	Permissions      []PermissionInput `json:"permissions"`
+}
+
+// Handler serves the role-matrix endpoints.
+type Handler struct {
+	Store   Store
+	Catalog Catalog
+	// Now is the clock audit and outbox rows are stamped with. Injected so
+	// a test can assert on a fixed value.
+	Now func() time.Time
+	// NewEventID mints the ids for the audit and outbox rows a save writes.
+	// Injected so a test can assert on deterministic ids.
+	NewEventID func() string
+}
+
+func (h *Handler) now() time.Time {
+	if h.Now != nil {
+		return h.Now()
+	}
+	return time.Now()
+}
+
+func (h *Handler) newEventID() string {
+	if h.NewEventID != nil {
+		return h.NewEventID()
+	}
+	return fmt.Sprintf("evt-%d", time.Now().UnixNano())
+}
+
+// Save handles PUT /admin/authz/tenants/{tenant}/roles/{role}/permissions.
+func (h *Handler) Save(w http.ResponseWriter, r *http.Request) {
+	identity, ok := tokenauth.From(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	tenant := r.PathValue("tenant")
+	role := r.PathValue("role")
+
+	// §9.4: administrator authority is validated against the target tenant
+	// before any write. This endpoint is tenant-scoped, not
+	// hospital-scoped, so no hospital is asked about.
+	if err := authority.Validate(
+		authority.Principal{TenantID: identity.TenantID, HospitalID: identity.HospitalID},
+		tenant, ""); err != nil {
+		writeError(w, http.StatusForbidden, "you do not have authority over this tenant")
+		return
+	}
+
+	var req saveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "malformed request body")
+		return
+	}
+	if len(req.Permissions) == 0 {
+		writeError(w, http.StatusBadRequest, "permissions must not be empty")
+		return
+	}
+
+	// §12.2: every permission leaf must resolve to a known catalog resource
+	// and action. Checked before any write, and every row is checked -
+	// reporting only the first would leave an administrator fixing one
+	// typo at a time.
+	var unknown []string
+	for _, permission := range req.Permissions {
+		if !h.Catalog.Has(permission.ResourceKey, permission.ActionKey) {
+			unknown = append(unknown, permission.ResourceKey+":"+permission.ActionKey)
+		}
+	}
+	if len(unknown) > 0 {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("not in the active catalog: %v", unknown))
+		return
+	}
+
+	now := h.now()
+	before := make(map[string]bool, len(req.Permissions))
+	inputs := make([]assignmentstore.RolePermissionInput, 0, len(req.Permissions))
+	after := make(map[string]bool, len(req.Permissions))
+	for _, permission := range req.Permissions {
+		key := permission.ResourceKey + ":" + permission.ActionKey
+
+		existing, found, err := h.Store.RolePermission(r.Context(), assignmentstore.RolePermissionKey{
+			TenantID: tenant, RoleExternalID: role,
+			ResourceKey: permission.ResourceKey, ActionKey: permission.ActionKey,
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "reading the current role permission failed")
+			return
+		}
+		if found {
+			before[key] = existing.Enabled
+		}
+
+		var validUntil time.Time
+		if permission.ValidUntil != nil {
+			validUntil = *permission.ValidUntil
+		}
+		inputs = append(inputs, assignmentstore.RolePermissionInput{
+			ResourceKey: permission.ResourceKey, ActionKey: permission.ActionKey,
+			Enabled: permission.Enabled, ValidFrom: permission.ValidFrom, ValidUntil: validUntil,
+		})
+		after[key] = permission.Enabled
+	}
+
+	beforeJSON, _ := json.Marshal(before)
+	afterJSON, _ := json.Marshal(after)
+
+	correlationID := r.Header.Get("X-Correlation-Id")
+	if correlationID == "" {
+		correlationID = h.newEventID()
+	}
+
+	write := assignmentstore.RoleMatrixWrite{
+		TenantID:         tenant,
+		RoleExternalID:   role,
+		ExpectedRevision: req.ExpectedRevision,
+		Permissions:      inputs,
+		Audit: assignmentstore.AuditEvent{
+			EventID:       h.newEventID(),
+			ActorID:       identity.PrincipalID,
+			Operation:     "ROLE_MATRIX_SAVE",
+			TargetType:    "role_permission",
+			BeforeJSON:    string(beforeJSON),
+			AfterJSON:     string(afterJSON),
+			CorrelationID: correlationID,
+			CreatedAt:     now,
+		},
+		Outbox: assignmentstore.OutboxEvent{
+			EventID:      h.newEventID(),
+			AggregateKey: tenant + ":" + role,
+			EventType:    "permission.changed",
+			Payload:      string(afterJSON),
+			CreatedAt:    now,
+		},
+	}
+
+	newRevision, err := h.Store.SaveRoleMatrix(r.Context(), write)
+	if errors.Is(err, assignmentstore.ErrRevisionConflict) {
+		writeError(w, http.StatusConflict, "expected revision is stale; reload the current matrix and retry")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "saving the role matrix failed")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"revision": newRevision})
+}
+
+// CurrentRevision handles GET /admin/authz/tenants/{tenant}/permission-revision,
+// which a caller reads before its first Save to learn the expectedRevision
+// to send.
+func (h *Handler) CurrentRevision(w http.ResponseWriter, r *http.Request) {
+	identity, ok := tokenauth.From(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	tenant := r.PathValue("tenant")
+	if err := authority.Validate(
+		authority.Principal{TenantID: identity.TenantID, HospitalID: identity.HospitalID},
+		tenant, ""); err != nil {
+		writeError(w, http.StatusForbidden, "you do not have authority over this tenant")
+		return
+	}
+
+	revision, found, err := h.Store.PermissionRevision(r.Context(), tenant)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "reading the permission revision failed")
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusOK, map[string]any{"revision": int64(0)})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"revision": revision.Revision})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}

--- a/apps/admin-service/internal/rolematrix/handler_test.go
+++ b/apps/admin-service/internal/rolematrix/handler_test.go
@@ -1,0 +1,306 @@
+package rolematrix_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+)
+
+type fakeStore struct {
+	permissions map[string]assignmentstore.RolePermission
+	revisions   map[string]int64
+	lastWrite   assignmentstore.RoleMatrixWrite
+	saveErr     error
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		permissions: map[string]assignmentstore.RolePermission{},
+		revisions:   map[string]int64{},
+	}
+}
+
+func permissionKeyString(key assignmentstore.RolePermissionKey) string {
+	return key.TenantID + "/" + key.RoleExternalID + "/" + key.ResourceKey + "/" + key.ActionKey
+}
+
+func (f *fakeStore) RolePermission(_ context.Context, key assignmentstore.RolePermissionKey) (assignmentstore.RolePermission, bool, error) {
+	permission, found := f.permissions[permissionKeyString(key)]
+	return permission, found, nil
+}
+
+func (f *fakeStore) SaveRoleMatrix(_ context.Context, write assignmentstore.RoleMatrixWrite) (int64, error) {
+	f.lastWrite = write
+	if f.saveErr != nil {
+		return 0, f.saveErr
+	}
+	current := f.revisions[write.TenantID]
+	if write.ExpectedRevision != current {
+		return 0, assignmentstore.ErrRevisionConflict
+	}
+	newRevision := current + 1
+	f.revisions[write.TenantID] = newRevision
+	for _, permission := range write.Permissions {
+		key := assignmentstore.RolePermissionKey{
+			TenantID: write.TenantID, RoleExternalID: write.RoleExternalID,
+			ResourceKey: permission.ResourceKey, ActionKey: permission.ActionKey,
+		}
+		f.permissions[permissionKeyString(key)] = assignmentstore.RolePermission{
+			Key: key, Enabled: permission.Enabled, ValidFrom: permission.ValidFrom,
+			ValidUntil: permission.ValidUntil, Revision: newRevision,
+		}
+	}
+	return newRevision, nil
+}
+
+func (f *fakeStore) PermissionRevision(_ context.Context, tenantID string) (assignmentstore.PermissionRevision, bool, error) {
+	revision, found := f.revisions[tenantID]
+	if !found {
+		return assignmentstore.PermissionRevision{}, false, nil
+	}
+	return assignmentstore.PermissionRevision{TenantID: tenantID, Revision: revision}, true, nil
+}
+
+type fakeCatalog struct {
+	known map[string]bool
+}
+
+func newFakeCatalog(pairs ...string) *fakeCatalog {
+	known := make(map[string]bool, len(pairs))
+	for _, pair := range pairs {
+		known[pair] = true
+	}
+	return &fakeCatalog{known: known}
+}
+
+func (c *fakeCatalog) Has(resource, action string) bool {
+	return c.known[resource+":"+action]
+}
+
+func newHandler(store rolematrix.Store, catalog rolematrix.Catalog) *rolematrix.Handler {
+	counter := 0
+	return &rolematrix.Handler{
+		Store:   store,
+		Catalog: catalog,
+		Now:     func() time.Time { return time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC) },
+		NewEventID: func() string {
+			counter++
+			return "evt-" + string(rune('0'+counter))
+		},
+	}
+}
+
+func request(t *testing.T, identity tokenauth.Identity, tenant, role string, body any) *http.Request {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshaling the request body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/admin/authz/tenants/"+tenant+"/roles/"+role+"/permissions", bytes.NewReader(raw))
+	req.SetPathValue("tenant", tenant)
+	req.SetPathValue("role", role)
+	return req.WithContext(tokenauth.WithIdentity(req.Context(), identity))
+}
+
+func decodeResponse(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding the response body %q: %v", rec.Body.String(), err)
+	}
+	return body
+}
+
+func adminOf(tenant string) tokenauth.Identity {
+	return tokenauth.Identity{PrincipalID: "admin-1", TenantID: tenant}
+}
+
+// A first save for a role that has never been saved (expectedRevision 0)
+// commits and returns revision 1.
+func TestSaveCommitsAFirstWriteAndReturnsTheNewRevision(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := request(t, adminOf("tenant-a"), "tenant-a", "role-doctor", map[string]any{
+		"expectedRevision": 0,
+		"permissions": []map[string]any{
+			{"resourceKey": "patient_record", "actionKey": "read", "enabled": true, "validFrom": "2026-01-01T00:00:00Z"},
+		},
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	body := decodeResponse(t, rec)
+	if body["revision"] != float64(1) {
+		t.Errorf("revision = %v, want 1", body["revision"])
+	}
+}
+
+// A stale expected revision must be rejected with 409, and the fake store's
+// own precondition check proves nothing was written for it either.
+func TestSaveRejectsAStaleExpectedRevisionWith409(t *testing.T) {
+	store := newFakeStore()
+	store.revisions["tenant-a"] = 3
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := request(t, adminOf("tenant-a"), "tenant-a", "role-doctor", map[string]any{
+		"expectedRevision": 0,
+		"permissions": []map[string]any{
+			{"resourceKey": "patient_record", "actionKey": "read", "enabled": true, "validFrom": "2026-01-01T00:00:00Z"},
+		},
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// A resource/action not in the active catalog must be rejected before any
+// write reaches the store.
+func TestSaveRejectsAResourceActionNotInTheActiveCatalog(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog() // empty: nothing is known
+	handler := newHandler(store, catalog)
+
+	req := request(t, adminOf("tenant-a"), "tenant-a", "role-doctor", map[string]any{
+		"expectedRevision": 0,
+		"permissions": []map[string]any{
+			{"resourceKey": "patient_record", "actionKey": "read", "enabled": true, "validFrom": "2026-01-01T00:00:00Z"},
+		},
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if len(store.revisions) != 0 {
+		t.Error("the store's revision was touched despite the catalog rejecting the write")
+	}
+}
+
+// An administrator whose token scopes them to a different tenant must be
+// rejected before any write, and before the catalog is even consulted.
+func TestSaveRejectsAnAdministratorWithNoAuthorityOverTheTargetTenant(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := request(t, adminOf("tenant-b"), "tenant-a", "role-doctor", map[string]any{
+		"expectedRevision": 0,
+		"permissions": []map[string]any{
+			{"resourceKey": "patient_record", "actionKey": "read", "enabled": true, "validFrom": "2026-01-01T00:00:00Z"},
+		},
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
+	if len(store.revisions) != 0 {
+		t.Error("the store's revision was touched despite the authority check rejecting the write")
+	}
+}
+
+// A request with no verified identity in its context - meaning it reached
+// this handler without the tokenauth middleware, which is a wiring defect -
+// must not silently proceed as some anonymous administrator.
+func TestSaveRejectsARequestWithNoVerifiedIdentity(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	raw, _ := json.Marshal(map[string]any{"expectedRevision": 0, "permissions": []map[string]any{
+		{"resourceKey": "patient_record", "actionKey": "read", "enabled": true, "validFrom": "2026-01-01T00:00:00Z"},
+	}})
+	req := httptest.NewRequest(http.MethodPut, "/admin/authz/tenants/tenant-a/roles/role-doctor/permissions", bytes.NewReader(raw))
+	req.SetPathValue("tenant", "tenant-a")
+	req.SetPathValue("role", "role-doctor")
+
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// The audit event a successful save writes must record the before and after
+// state of the touched permission, and the correlation id supplied on the
+// request.
+func TestSaveRecordsBeforeAndAfterStateAndTheCorrelationIdOnTheAuditEvent(t *testing.T) {
+	store := newFakeStore()
+	store.permissions[permissionKeyString(assignmentstore.RolePermissionKey{
+		TenantID: "tenant-a", RoleExternalID: "role-doctor",
+		ResourceKey: "patient_record", ActionKey: "read",
+	})] = assignmentstore.RolePermission{Enabled: false, Revision: 0}
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := request(t, adminOf("tenant-a"), "tenant-a", "role-doctor", map[string]any{
+		"expectedRevision": 0,
+		"permissions": []map[string]any{
+			{"resourceKey": "patient_record", "actionKey": "read", "enabled": true, "validFrom": "2026-01-01T00:00:00Z"},
+		},
+	})
+	req.Header.Set("X-Correlation-Id", "corr-xyz")
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	audit := store.lastWrite.Audit
+	if audit.ActorID != "admin-1" {
+		t.Errorf("actorID = %q, want admin-1", audit.ActorID)
+	}
+	if audit.Operation != "ROLE_MATRIX_SAVE" {
+		t.Errorf("operation = %q, want ROLE_MATRIX_SAVE", audit.Operation)
+	}
+	if audit.CorrelationID != "corr-xyz" {
+		t.Errorf("correlationID = %q, want corr-xyz", audit.CorrelationID)
+	}
+	if audit.BeforeJSON != `{"patient_record:read":false}` {
+		t.Errorf("beforeJSON = %s, want the pre-write state", audit.BeforeJSON)
+	}
+	if audit.AfterJSON != `{"patient_record:read":true}` {
+		t.Errorf("afterJSON = %s, want the post-write state", audit.AfterJSON)
+	}
+}
+
+func TestCurrentRevisionReportsZeroForANeverSavedTenant(t *testing.T) {
+	store := newFakeStore()
+	handler := newHandler(store, newFakeCatalog())
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/authz/tenants/tenant-a/permission-revision", nil)
+	req.SetPathValue("tenant", "tenant-a")
+	req = req.WithContext(tokenauth.WithIdentity(req.Context(), adminOf("tenant-a")))
+
+	rec := httptest.NewRecorder()
+	handler.CurrentRevision(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	body := decodeResponse(t, rec)
+	if body["revision"] != float64(0) {
+		t.Errorf("revision = %v, want 0", body["revision"])
+	}
+}

--- a/apps/admin-service/internal/server/server.go
+++ b/apps/admin-service/internal/server/server.go
@@ -1,0 +1,92 @@
+// Package server exposes the Authorization Administration Service HTTP
+// surface (§9.4).
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+)
+
+// DefaultReadinessTimeout bounds how long readiness waits on its dependencies.
+const DefaultReadinessTimeout = 3 * time.Second
+
+// Dependency is a downstream the service needs before it can serve traffic.
+type Dependency struct {
+	Name  string
+	Probe func(context.Context) error
+}
+
+// Config holds the collaborators the HTTP surface depends on.
+type Config struct {
+	Dependencies []Dependency
+
+	// ReadinessTimeout bounds a single /readyz probe round. Zero means
+	// DefaultReadinessTimeout.
+	ReadinessTimeout time.Duration
+
+	// Verifier authenticates every /admin/authz route. Nil means those
+	// routes are not registered at all, so a misconfigured build fails
+	// with 404 rather than answering administration questions from an
+	// unauthenticated caller.
+	Verifier tokenauth.Verifier
+
+	// RoleMatrix serves the role-matrix endpoints. Nil means the routes
+	// are not registered.
+	RoleMatrix *rolematrix.Handler
+}
+
+// New builds the Administration Service HTTP handler.
+func New(cfg Config) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+	})
+
+	if cfg.RoleMatrix != nil && cfg.Verifier != nil {
+		authenticated := func(next http.HandlerFunc) http.Handler {
+			return tokenauth.Require(tokenauth.Config{Verifier: cfg.Verifier}, next)
+		}
+		mux.Handle("PUT /admin/authz/tenants/{tenant}/roles/{role}/permissions",
+			authenticated(cfg.RoleMatrix.Save))
+		mux.Handle("GET /admin/authz/tenants/{tenant}/permission-revision",
+			authenticated(cfg.RoleMatrix.CurrentRevision))
+	}
+
+	timeout := cfg.ReadinessTimeout
+	if timeout <= 0 {
+		timeout = DefaultReadinessTimeout
+	}
+	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+
+		results := make(map[string]string, len(cfg.Dependencies))
+		ready := true
+		for _, dep := range cfg.Dependencies {
+			if err := dep.Probe(ctx); err != nil {
+				results[dep.Name] = err.Error()
+				ready = false
+				continue
+			}
+			results[dep.Name] = "ok"
+		}
+
+		status, code := "ready", http.StatusOK
+		if !ready {
+			status, code = "unavailable", http.StatusServiceUnavailable
+		}
+		writeJSON(w, code, map[string]any{"status": status, "dependencies": results})
+	})
+	return mux
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/apps/admin-service/internal/server/server_test.go
+++ b/apps/admin-service/internal/server/server_test.go
@@ -1,0 +1,59 @@
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/server"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+type fakeVerifier struct{}
+
+func (fakeVerifier) Verify(context.Context, string) (tokenverifier.VerifiedToken, error) {
+	return tokenverifier.VerifiedToken{}, nil
+}
+
+func TestHealthzAlwaysAnswers(t *testing.T) {
+	handler := server.New(server.Config{})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestRoleMatrixRoutesAreAbsentWithoutARoleMatrixHandler(t *testing.T) {
+	handler := server.New(server.Config{})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/admin/authz/tenants/tenant-a/permission-revision", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 when no role-matrix handler is configured", rec.Code)
+	}
+}
+
+func TestRoleMatrixRoutesRequireABearerToken(t *testing.T) {
+	handler := server.New(server.Config{
+		Verifier:   fakeVerifier{},
+		RoleMatrix: &rolematrix.Handler{},
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/admin/authz/tenants/tenant-a/permission-revision", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 with no bearer token", rec.Code)
+	}
+}
+
+func TestReadyzReportsReadyWithNoDependencies(t *testing.T) {
+	handler := server.New(server.Config{})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}

--- a/apps/admin-service/internal/tokenauth/tokenauth.go
+++ b/apps/admin-service/internal/tokenauth/tokenauth.go
@@ -1,0 +1,112 @@
+// Package tokenauth turns a bearer token into the identity a handler may act
+// on.
+//
+// It is the only place the Administration Service decides who a caller is.
+// Handlers read the identity from the request context, never from a request
+// body: §16.1 requires tenant and hospital context to be derived server-side,
+// and an administrator's own tenant/hospital scope is exactly that kind of
+// context.
+package tokenauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+// Identity is who the caller is, as the identity provider attested.
+type Identity struct {
+	PrincipalID string
+	Username    string
+	TenantID    string
+	HospitalID  string
+	// Roles are canonical §7.5 identifiers.
+	Roles []string
+}
+
+// Verifier is the token verification this middleware delegates to.
+type Verifier interface {
+	Verify(ctx context.Context, raw string) (tokenverifier.VerifiedToken, error)
+}
+
+// Config holds the middleware's collaborators.
+type Config struct {
+	Verifier Verifier
+	Logger   *slog.Logger
+}
+
+type contextKey struct{}
+
+// From returns the identity established for this request, if any.
+func From(ctx context.Context) (Identity, bool) {
+	identity, ok := ctx.Value(contextKey{}).(Identity)
+	return identity, ok
+}
+
+// WithIdentity puts an identity in a context. It exists for tests and for
+// callers that have already verified a token; the middleware is the only
+// production path.
+func WithIdentity(ctx context.Context, identity Identity) context.Context {
+	return context.WithValue(ctx, contextKey{}, identity)
+}
+
+const bearerPrefix = "Bearer "
+
+// Require verifies the caller's bearer token and passes the resulting
+// identity to next. A request that fails verification never reaches next.
+func Require(cfg Config, next http.Handler) http.Handler {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, ok := bearerToken(r)
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "a bearer token is required")
+			return
+		}
+
+		verified, err := cfg.Verifier.Verify(r.Context(), raw)
+		if err != nil {
+			if errors.Is(err, tokenverifier.ErrReservedRole) {
+				logger.WarnContext(r.Context(), "rejected a token presenting a reserved role",
+					slog.Any("error", err))
+				writeError(w, http.StatusForbidden, "the token carries a role reserved for the platform")
+				return
+			}
+			logger.WarnContext(r.Context(), "rejected a bearer token", slog.Any("error", err))
+			writeError(w, http.StatusUnauthorized, "the bearer token was refused")
+			return
+		}
+
+		identity := Identity{
+			PrincipalID: verified.Subject,
+			Username:    verified.Username,
+			TenantID:    verified.TenantID,
+			HospitalID:  verified.HospitalID,
+			Roles:       verified.Roles,
+		}
+		next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), identity)))
+	})
+}
+
+func bearerToken(r *http.Request) (string, bool) {
+	header := r.Header.Get("Authorization")
+	if len(header) <= len(bearerPrefix) || !strings.EqualFold(header[:len(bearerPrefix)], bearerPrefix) {
+		return "", false
+	}
+	token := strings.TrimSpace(header[len(bearerPrefix):])
+	return token, token != ""
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}

--- a/apps/admin-service/project.json
+++ b/apps/admin-service/project.json
@@ -1,0 +1,18 @@
+{
+  "name": "admin-service",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "options": {
+        "main": "cmd/admin-service/main.go",
+        "outputPath": "../../dist/apps/admin-service/admin-service"
+      }
+    },
+    "serve": {
+      "options": {
+        "main": "cmd/admin-service/main.go"
+      }
+    }
+  }
+}

--- a/go.work
+++ b/go.work
@@ -1,6 +1,7 @@
 go 1.25.11
 
 use (
+./apps/admin-service
 ./apps/ads
 ./apps/resource-service
 ./libs/assignmentstore
@@ -11,6 +12,7 @@ use (
 ./libs/cataloggen
 ./libs/cerbosclient
 ./libs/idpdirectory
+./libs/outbox
 ./libs/permissioncontext
 ./libs/tokenverifier
 ./tests/architecture

--- a/libs/assignmentstore/oraclestore/oraclestore.go
+++ b/libs/assignmentstore/oraclestore/oraclestore.go
@@ -436,6 +436,137 @@ func (s *Store) OutboxEvent(ctx context.Context, eventID string) (assignmentstor
 	return event, true, nil
 }
 
+// UnpublishedOutboxEvents reads up to limit unpublished rows, oldest first.
+//
+// Oracle has no LIMIT clause; FETCH FIRST is the ANSI equivalent it supports.
+func (s *Store) UnpublishedOutboxEvents(ctx context.Context, limit int) ([]assignmentstore.OutboxEvent, error) {
+	const query = `
+		SELECT event_id, aggregate_key, event_type, payload, created_at
+		FROM outbox_event
+		WHERE published_at IS NULL
+		ORDER BY created_at, event_id
+		FETCH FIRST :1 ROWS ONLY`
+
+	rows, err := s.db.QueryContext(ctx, query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("oraclestore: reading unpublished outbox events: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var events []assignmentstore.OutboxEvent
+	for rows.Next() {
+		var event assignmentstore.OutboxEvent
+		if err := rows.Scan(&event.EventID, &event.AggregateKey, &event.EventType,
+			&event.Payload, &event.CreatedAt); err != nil {
+			return nil, fmt.Errorf("oraclestore: scanning an outbox event: %w", err)
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("oraclestore: reading unpublished outbox events: %w", err)
+	}
+	return events, nil
+}
+
+// MarkOutboxEventPublished records that an outbox row was published.
+func (s *Store) MarkOutboxEventPublished(ctx context.Context, eventID string, publishedAt time.Time) error {
+	const statement = `UPDATE outbox_event SET published_at = :2 WHERE event_id = :1`
+	if _, err := s.db.ExecContext(ctx, statement, eventID, publishedAt); err != nil {
+		return fmt.Errorf("oraclestore: marking an outbox event published: %w", err)
+	}
+	return nil
+}
+
+// SaveRoleMatrix atomically writes one role's permission slice (§9.4,
+// §10.1, §16.1). See the PostgreSQL adapter's SaveRoleMatrix for why the
+// revision row is seeded before it is locked.
+func (s *Store) SaveRoleMatrix(ctx context.Context, write assignmentstore.RoleMatrixWrite) (int64, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("oraclestore: beginning the role matrix transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		MERGE INTO permission_revision t
+		USING (SELECT :1 AS tenant_id FROM dual) s
+		ON (t.tenant_id = s.tenant_id)
+		WHEN NOT MATCHED THEN INSERT (tenant_id, revision, changed_at)
+		VALUES (s.tenant_id, 0, :2)`,
+		write.TenantID, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("oraclestore: seeding the permission revision: %w", err)
+	}
+
+	var current int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT revision FROM permission_revision WHERE tenant_id = :1 FOR UPDATE`,
+		write.TenantID).Scan(&current); err != nil {
+		return 0, fmt.Errorf("oraclestore: locking the permission revision: %w", err)
+	}
+	if current != write.ExpectedRevision {
+		return 0, assignmentstore.ErrRevisionConflict
+	}
+
+	newRevision := current + 1
+	for _, permission := range write.Permissions {
+		enabled := boolToNumber(permission.Enabled)
+		validUntil := endOrNull(permission.ValidUntil)
+		if _, err := tx.ExecContext(ctx, `
+			MERGE INTO role_permission t
+			USING (SELECT :1 AS tenant_id, :2 AS role_external_id,
+			              :3 AS resource_key, :4 AS action_key FROM dual) s
+			ON (t.tenant_id = s.tenant_id AND t.role_external_id = s.role_external_id
+			    AND t.resource_key = s.resource_key AND t.action_key = s.action_key)
+			WHEN MATCHED THEN UPDATE SET
+				enabled = :5, valid_from = :6, valid_until = :7, revision = :8
+			WHEN NOT MATCHED THEN INSERT (
+				tenant_id, role_external_id, resource_key, action_key,
+				enabled, valid_from, valid_until, revision)
+			VALUES (s.tenant_id, s.role_external_id, s.resource_key, s.action_key,
+				:9, :10, :11, :12)`,
+			write.TenantID, write.RoleExternalID, permission.ResourceKey, permission.ActionKey,
+			enabled, permission.ValidFrom, validUntil, newRevision,
+			enabled, permission.ValidFrom, validUntil, newRevision); err != nil {
+			return 0, fmt.Errorf("oraclestore: writing a role permission: %w", err)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO permission_audit_event (
+			event_id, actor_id, operation, target_type, before_json, after_json,
+			tenant_id, hospital_id, correlation_id, created_at)
+		VALUES (:1, :2, :3, :4, :5, :6, :7, :8, :9, :10)`,
+		write.Audit.EventID, write.Audit.ActorID, write.Audit.Operation, write.Audit.TargetType,
+		write.Audit.BeforeJSON, write.Audit.AfterJSON, write.TenantID, write.Audit.HospitalID,
+		write.Audit.CorrelationID, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("oraclestore: appending the audit event: %w", err)
+	}
+
+	var publishedAt any
+	if write.Outbox.PublishedAt != nil {
+		publishedAt = *write.Outbox.PublishedAt
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO outbox_event (
+			event_id, aggregate_key, event_type, payload, created_at, published_at)
+		VALUES (:1, :2, :3, :4, :5, :6)`,
+		write.Outbox.EventID, write.Outbox.AggregateKey, write.Outbox.EventType,
+		write.Outbox.Payload, write.Outbox.CreatedAt, publishedAt); err != nil {
+		return 0, fmt.Errorf("oraclestore: appending the outbox event: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE permission_revision SET revision = :2, changed_at = :3 WHERE tenant_id = :1`,
+		write.TenantID, newRevision, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("oraclestore: advancing the permission revision: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("oraclestore: committing the role matrix transaction: %w", err)
+	}
+	return newRevision, nil
+}
+
 // SaveCapability inserts or updates one capability definition.
 func (s *Store) SaveCapability(ctx context.Context, capability assignmentstore.Capability) error {
 	const statement = `

--- a/libs/assignmentstore/postgresstore/postgresstore.go
+++ b/libs/assignmentstore/postgresstore/postgresstore.go
@@ -380,6 +380,132 @@ func (s *Store) OutboxEvent(ctx context.Context, eventID string) (assignmentstor
 	return event, true, nil
 }
 
+// UnpublishedOutboxEvents reads up to limit unpublished rows, oldest first.
+func (s *Store) UnpublishedOutboxEvents(ctx context.Context, limit int) ([]assignmentstore.OutboxEvent, error) {
+	const query = `
+		SELECT event_id, aggregate_key, event_type, payload, created_at
+		FROM outbox_event
+		WHERE published_at IS NULL
+		ORDER BY created_at, event_id
+		LIMIT $1`
+
+	rows, err := s.pool.Query(ctx, query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("postgresstore: reading unpublished outbox events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []assignmentstore.OutboxEvent
+	for rows.Next() {
+		var event assignmentstore.OutboxEvent
+		if err := rows.Scan(&event.EventID, &event.AggregateKey, &event.EventType,
+			&event.Payload, &event.CreatedAt); err != nil {
+			return nil, fmt.Errorf("postgresstore: scanning an outbox event: %w", err)
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("postgresstore: reading unpublished outbox events: %w", err)
+	}
+	return events, nil
+}
+
+// MarkOutboxEventPublished records that an outbox row was published.
+func (s *Store) MarkOutboxEventPublished(ctx context.Context, eventID string, publishedAt time.Time) error {
+	const statement = `UPDATE outbox_event SET published_at = $2 WHERE event_id = $1`
+	if _, err := s.pool.Exec(ctx, statement, eventID, publishedAt); err != nil {
+		return fmt.Errorf("postgresstore: marking an outbox event published: %w", err)
+	}
+	return nil
+}
+
+// SaveRoleMatrix atomically writes one role's permission slice (§9.4,
+// §10.1, §16.1).
+//
+// The tenant's permission_revision row is seeded first, if absent, so the
+// lock below always has a row to take: without that seed, a genuinely
+// concurrent first write for a brand-new tenant would have nothing to
+// serialize it against its sibling. SELECT ... FOR UPDATE then blocks a
+// second concurrent writer until the first commits or rolls back; the second
+// writer's subsequent read sees whatever the first one left behind, which is
+// what turns a stale ExpectedRevision into a clean conflict rather than a
+// race.
+func (s *Store) SaveRoleMatrix(ctx context.Context, write assignmentstore.RoleMatrixWrite) (int64, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("postgresstore: beginning the role matrix transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO permission_revision (tenant_id, revision, changed_at)
+		VALUES ($1, 0, $2)
+		ON CONFLICT (tenant_id) DO NOTHING`,
+		write.TenantID, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("postgresstore: seeding the permission revision: %w", err)
+	}
+
+	var current int64
+	if err := tx.QueryRow(ctx, `
+		SELECT revision FROM permission_revision WHERE tenant_id = $1 FOR UPDATE`,
+		write.TenantID).Scan(&current); err != nil {
+		return 0, fmt.Errorf("postgresstore: locking the permission revision: %w", err)
+	}
+	if current != write.ExpectedRevision {
+		return 0, assignmentstore.ErrRevisionConflict
+	}
+
+	newRevision := current + 1
+	for _, permission := range write.Permissions {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO role_permission (
+				tenant_id, role_external_id, resource_key, action_key,
+				enabled, valid_from, valid_until, revision)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			ON CONFLICT (tenant_id, role_external_id, resource_key, action_key)
+			DO UPDATE SET
+				enabled = EXCLUDED.enabled,
+				valid_from = EXCLUDED.valid_from,
+				valid_until = EXCLUDED.valid_until,
+				revision = EXCLUDED.revision`,
+			write.TenantID, write.RoleExternalID, permission.ResourceKey, permission.ActionKey,
+			permission.Enabled, permission.ValidFrom, endOrNull(permission.ValidUntil), newRevision); err != nil {
+			return 0, fmt.Errorf("postgresstore: writing a role permission: %w", err)
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO permission_audit_event (
+			event_id, actor_id, operation, target_type, before_json, after_json,
+			tenant_id, hospital_id, correlation_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		write.Audit.EventID, write.Audit.ActorID, write.Audit.Operation, write.Audit.TargetType,
+		write.Audit.BeforeJSON, write.Audit.AfterJSON, write.TenantID, write.Audit.HospitalID,
+		write.Audit.CorrelationID, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("postgresstore: appending the audit event: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO outbox_event (
+			event_id, aggregate_key, event_type, payload, created_at, published_at)
+		VALUES ($1, $2, $3, $4, $5, $6)`,
+		write.Outbox.EventID, write.Outbox.AggregateKey, write.Outbox.EventType,
+		write.Outbox.Payload, write.Outbox.CreatedAt, write.Outbox.PublishedAt); err != nil {
+		return 0, fmt.Errorf("postgresstore: appending the outbox event: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE permission_revision SET revision = $2, changed_at = $3 WHERE tenant_id = $1`,
+		write.TenantID, newRevision, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("postgresstore: advancing the permission revision: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("postgresstore: committing the role matrix transaction: %w", err)
+	}
+	return newRevision, nil
+}
+
 // SaveCapability inserts or updates one capability definition.
 func (s *Store) SaveCapability(ctx context.Context, capability assignmentstore.Capability) error {
 	const statement = `

--- a/libs/assignmentstore/store.go
+++ b/libs/assignmentstore/store.go
@@ -10,6 +10,7 @@ package assignmentstore
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
@@ -150,6 +151,42 @@ type OutboxEvent struct {
 	PublishedAt  *time.Time
 }
 
+// RolePermissionInput is one row of a role-matrix slice a caller wants
+// written (§9.4). It carries no revision of its own: SaveRoleMatrix stamps
+// every row it writes with the transaction's new tenant-wide revision
+// (§10.1), because the point of the expected-revision check is that the whole
+// slice moves forward together.
+type RolePermissionInput struct {
+	ResourceKey string
+	ActionKey   string
+	Enabled     bool
+	ValidFrom   time.Time
+	ValidUntil  time.Time
+}
+
+// RoleMatrixWrite is the input to SaveRoleMatrix: one role's whole permission
+// slice within one tenant, plus the audit event and outbox event that must
+// commit with it (§9.4, §10.1, §16.1).
+type RoleMatrixWrite struct {
+	TenantID       string
+	RoleExternalID string
+	// ExpectedRevision is the tenant permission revision the caller last
+	// read (§9.4's "Replace role permissions using expected revision").
+	// Zero means the caller believes the tenant has never had a matrix
+	// saved.
+	ExpectedRevision int64
+	Permissions      []RolePermissionInput
+	// Audit.TenantID is ignored; the write always audits against
+	// RoleMatrixWrite.TenantID so the two can never disagree.
+	Audit  AuditEvent
+	Outbox OutboxEvent
+}
+
+// ErrRevisionConflict is returned by SaveRoleMatrix, with nothing written,
+// when ExpectedRevision no longer matches the tenant's stored permission
+// revision (§10.1).
+var ErrRevisionConflict = errors.New("assignmentstore: expected revision is stale")
+
 // Capability is one composite UI capability definition (§8.1).
 type Capability struct {
 	CapabilityKey   string
@@ -247,6 +284,23 @@ type Store interface {
 
 	AppendOutboxEvent(ctx context.Context, event OutboxEvent) error
 	OutboxEvent(ctx context.Context, eventID string) (OutboxEvent, bool, error)
+
+	// UnpublishedOutboxEvents reads up to limit outbox rows that have not
+	// yet been published, oldest first, so a publisher drains them in the
+	// order they were written.
+	UnpublishedOutboxEvents(ctx context.Context, limit int) ([]OutboxEvent, error)
+	// MarkOutboxEventPublished records that an outbox row was published.
+	// Marking an already-published row again is not an error: at-least-once
+	// delivery means a publisher may see the same row twice.
+	MarkOutboxEventPublished(ctx context.Context, eventID string, publishedAt time.Time) error
+
+	// SaveRoleMatrix atomically writes one role's permission slice: every
+	// row's upsert, the audit event, the outbox event and the tenant's
+	// permission-revision bump commit as a single unit or none do (§9.4,
+	// §10.1, §16.1). It returns ErrRevisionConflict, with nothing written,
+	// if write.ExpectedRevision no longer matches the tenant's stored
+	// revision.
+	SaveRoleMatrix(ctx context.Context, write RoleMatrixWrite) (newRevision int64, err error)
 
 	SaveCapability(ctx context.Context, capability Capability) error
 	Capability(ctx context.Context, capabilityKey string) (Capability, bool, error)

--- a/libs/assignmentstore/storecontract/contract.go
+++ b/libs/assignmentstore/storecontract/contract.go
@@ -9,8 +9,11 @@ package storecontract
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"slices"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -98,6 +101,24 @@ func Run(t *testing.T, newStore Factory) {
 	})
 	t.Run("listing resources pages within one tenant and hospital", func(t *testing.T) {
 		assertListResources(t, newStore(t))
+	})
+	t.Run("SaveRoleMatrix commits the permission, audit, outbox and revision together", func(t *testing.T) {
+		assertSaveRoleMatrixAtomicSuccess(t, newStore(t))
+	})
+	t.Run("SaveRoleMatrix rejects a stale expected revision and writes nothing", func(t *testing.T) {
+		assertSaveRoleMatrixStaleRevision(t, newStore(t))
+	})
+	t.Run("two concurrent SaveRoleMatrix calls against the same role yield one success and one conflict", func(t *testing.T) {
+		assertSaveRoleMatrixConcurrentWrites(t, newStore(t))
+	})
+	t.Run("a mid-transaction failure in SaveRoleMatrix rolls back all four writes", func(t *testing.T) {
+		assertSaveRoleMatrixRollsBackOnFailure(t, newStore(t))
+	})
+	t.Run("audit history survives SaveRoleMatrix updating the same role permission in place", func(t *testing.T) {
+		assertSaveRoleMatrixAuditHistoryIsAppendOnly(t, newStore(t))
+	})
+	t.Run("unpublished outbox events are listed oldest first and can be marked published", func(t *testing.T) {
+		assertUnpublishedOutboxEvents(t, newStore(t))
 	})
 }
 
@@ -1094,6 +1115,387 @@ func assertNullableTimestamp(t *testing.T, store assignmentstore.Store) {
 	}
 	if !event.CreatedAt.Equal(created) {
 		t.Errorf("createdAt = %s, want %s", event.CreatedAt, created)
+	}
+}
+
+// A successful SaveRoleMatrix must leave all four side effects visible: the
+// role permission row, the audit event, the outbox event and the advanced
+// tenant revision (§9.4, §10.1, §16.1).
+func assertSaveRoleMatrixAtomicSuccess(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "role_permission", "permission_audit_event", "outbox_event", "permission_revision")
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	write := assignmentstore.RoleMatrixWrite{
+		TenantID:         "tenant-a",
+		RoleExternalID:   "role-doctor",
+		ExpectedRevision: 0,
+		Permissions: []assignmentstore.RolePermissionInput{
+			{ResourceKey: "patient_record", ActionKey: "read", Enabled: true,
+				ValidFrom: created.AddDate(-1, 0, 0)},
+		},
+		Audit: assignmentstore.AuditEvent{
+			EventID:       "audit-atomic-1",
+			ActorID:       "admin-1",
+			Operation:     "ROLE_MATRIX_SAVE",
+			TargetType:    "role_permission",
+			BeforeJSON:    `{}`,
+			AfterJSON:     `{"patient_record.read":true}`,
+			HospitalID:    "",
+			CorrelationID: "corr-atomic-1",
+			CreatedAt:     created,
+		},
+		Outbox: assignmentstore.OutboxEvent{
+			EventID:      "outbox-atomic-1",
+			AggregateKey: "tenant-a:role-doctor",
+			EventType:    "permission.changed",
+			Payload:      `{"revision":1}`,
+			CreatedAt:    created,
+		},
+	}
+
+	newRevision, err := store.SaveRoleMatrix(ctx, write)
+	if err != nil {
+		t.Fatalf("SaveRoleMatrix: %v", err)
+	}
+	if newRevision != 1 {
+		t.Errorf("newRevision = %d, want 1", newRevision)
+	}
+
+	permission, found, err := store.RolePermission(ctx, assignmentstore.RolePermissionKey{
+		TenantID: "tenant-a", RoleExternalID: "role-doctor",
+		ResourceKey: "patient_record", ActionKey: "read",
+	})
+	if err != nil || !found {
+		t.Fatalf("reading the role permission back: found=%t err=%v", found, err)
+	}
+	if !permission.Enabled || permission.Revision != 1 {
+		t.Errorf("permission = %+v, want enabled=true revision=1", permission)
+	}
+
+	audit, found, err := store.AuditEvent(ctx, "audit-atomic-1")
+	if err != nil || !found {
+		t.Fatalf("reading the audit event back: found=%t err=%v", found, err)
+	}
+	if audit.TenantID != "tenant-a" || audit.CorrelationID != "corr-atomic-1" {
+		t.Errorf("audit = %+v, want tenant-a and corr-atomic-1", audit)
+	}
+
+	if _, found, err := store.OutboxEvent(ctx, "outbox-atomic-1"); err != nil || !found {
+		t.Fatalf("reading the outbox event back: found=%t err=%v", found, err)
+	}
+
+	revision, found, err := store.PermissionRevision(ctx, "tenant-a")
+	if err != nil || !found {
+		t.Fatalf("reading the permission revision back: found=%t err=%v", found, err)
+	}
+	if revision.Revision != 1 {
+		t.Errorf("tenant revision = %d, want 1", revision.Revision)
+	}
+}
+
+// A stale ExpectedRevision must fail cleanly and write nothing: not the
+// permission, not the audit event, not the outbox event, and the tenant
+// revision must not move.
+func assertSaveRoleMatrixStaleRevision(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "role_permission", "permission_audit_event", "outbox_event", "permission_revision")
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	first := assignmentstore.RoleMatrixWrite{
+		TenantID:         "tenant-a",
+		RoleExternalID:   "role-nurse",
+		ExpectedRevision: 0,
+		Permissions: []assignmentstore.RolePermissionInput{
+			{ResourceKey: "patient_record", ActionKey: "list", Enabled: true, ValidFrom: created},
+		},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-stale-1", Operation: "ROLE_MATRIX_SAVE", CreatedAt: created},
+		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-stale-1", AggregateKey: "tenant-a:role-nurse", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
+	}
+	if _, err := store.SaveRoleMatrix(ctx, first); err != nil {
+		t.Fatalf("the first save: %v", err)
+	}
+
+	// The tenant is now at revision 1. A second save that still believes
+	// revision 0 is current must be rejected.
+	stale := assignmentstore.RoleMatrixWrite{
+		TenantID:         "tenant-a",
+		RoleExternalID:   "role-nurse",
+		ExpectedRevision: 0,
+		Permissions: []assignmentstore.RolePermissionInput{
+			{ResourceKey: "patient_record", ActionKey: "delete", Enabled: true, ValidFrom: created},
+		},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-stale-2", Operation: "ROLE_MATRIX_SAVE", CreatedAt: created},
+		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-stale-2", AggregateKey: "tenant-a:role-nurse", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
+	}
+	if _, err := store.SaveRoleMatrix(ctx, stale); !errors.Is(err, assignmentstore.ErrRevisionConflict) {
+		t.Fatalf("SaveRoleMatrix with a stale revision returned %v, want ErrRevisionConflict", err)
+	}
+
+	if _, found, err := store.RolePermission(ctx, assignmentstore.RolePermissionKey{
+		TenantID: "tenant-a", RoleExternalID: "role-nurse",
+		ResourceKey: "patient_record", ActionKey: "delete",
+	}); err != nil {
+		t.Fatalf("reading the rejected permission: %v", err)
+	} else if found {
+		t.Error("the rejected write's role permission was written anyway")
+	}
+	if _, found, err := store.AuditEvent(ctx, "audit-stale-2"); err != nil {
+		t.Fatalf("reading the rejected audit event: %v", err)
+	} else if found {
+		t.Error("the rejected write's audit event was written anyway")
+	}
+	if _, found, err := store.OutboxEvent(ctx, "outbox-stale-2"); err != nil {
+		t.Fatalf("reading the rejected outbox event: %v", err)
+	} else if found {
+		t.Error("the rejected write's outbox event was written anyway")
+	}
+
+	revision, _, err := store.PermissionRevision(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("reading the tenant revision: %v", err)
+	}
+	if revision.Revision != 1 {
+		t.Errorf("tenant revision = %d after a rejected write, want it unchanged at 1", revision.Revision)
+	}
+}
+
+// Two callers who both read revision 0 and race to save must not both
+// succeed: exactly one commits and advances the revision, and the other sees
+// its expected revision has gone stale by the time it gets the lock.
+func assertSaveRoleMatrixConcurrentWrites(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "role_permission", "permission_audit_event", "outbox_event", "permission_revision")
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	write := func(eventSuffix string) assignmentstore.RoleMatrixWrite {
+		return assignmentstore.RoleMatrixWrite{
+			TenantID:         "tenant-a",
+			RoleExternalID:   "role-porter",
+			ExpectedRevision: 0,
+			Permissions: []assignmentstore.RolePermissionInput{
+				{ResourceKey: "patient_record", ActionKey: "read", Enabled: true, ValidFrom: created},
+			},
+			Audit: assignmentstore.AuditEvent{
+				EventID: "audit-concurrent-" + eventSuffix, Operation: "ROLE_MATRIX_SAVE", CreatedAt: created,
+			},
+			Outbox: assignmentstore.OutboxEvent{
+				EventID: "outbox-concurrent-" + eventSuffix, AggregateKey: "tenant-a:role-porter",
+				EventType: "permission.changed", Payload: `{}`, CreatedAt: created,
+			},
+		}
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	start := make(chan struct{})
+	for i := range 2 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, errs[i] = store.SaveRoleMatrix(ctx, write(fmt.Sprintf("%d", i)))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	successes, conflicts := 0, 0
+	for _, err := range errs {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, assignmentstore.ErrRevisionConflict):
+			conflicts++
+		default:
+			t.Fatalf("an unexpected error from a concurrent save: %v", err)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("got %d successes and %d conflicts, want exactly one of each (errors: %v)",
+			successes, conflicts, errs)
+	}
+
+	revision, _, err := store.PermissionRevision(ctx, "tenant-a")
+	if err != nil {
+		t.Fatalf("reading the tenant revision: %v", err)
+	}
+	if revision.Revision != 1 {
+		t.Errorf("tenant revision = %d after one concurrent success, want 1", revision.Revision)
+	}
+}
+
+// A failure partway through the transaction - forced here by a duplicate
+// outbox event id, which the unique primary key refuses - must roll back
+// every write that came before it too: the role permission, the audit event
+// and the revision bump must all be absent, exactly as if the call had never
+// happened.
+func assertSaveRoleMatrixRollsBackOnFailure(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "role_permission", "permission_audit_event", "outbox_event", "permission_revision")
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	if err := store.AppendOutboxEvent(ctx, assignmentstore.OutboxEvent{
+		EventID: "outbox-rollback-1", AggregateKey: "pre-existing", EventType: "permission.changed",
+		Payload: `{}`, CreatedAt: created,
+	}); err != nil {
+		t.Fatalf("seeding a conflicting outbox event: %v", err)
+	}
+
+	write := assignmentstore.RoleMatrixWrite{
+		TenantID:         "tenant-a",
+		RoleExternalID:   "role-doctor",
+		ExpectedRevision: 0,
+		Permissions: []assignmentstore.RolePermissionInput{
+			{ResourceKey: "patient_record", ActionKey: "update", Enabled: true, ValidFrom: created},
+		},
+		Audit: assignmentstore.AuditEvent{EventID: "audit-rollback-1", Operation: "ROLE_MATRIX_SAVE", CreatedAt: created},
+		// The same event id as the row seeded above: the unique key forces
+		// this insert to fail after the permission and audit writes above
+		// it in the transaction have already run.
+		Outbox: assignmentstore.OutboxEvent{
+			EventID: "outbox-rollback-1", AggregateKey: "tenant-a:role-doctor",
+			EventType: "permission.changed", Payload: `{}`, CreatedAt: created,
+		},
+	}
+
+	if _, err := store.SaveRoleMatrix(ctx, write); err == nil {
+		t.Fatal("SaveRoleMatrix succeeded despite a duplicate outbox event id")
+	}
+
+	if _, found, err := store.RolePermission(ctx, assignmentstore.RolePermissionKey{
+		TenantID: "tenant-a", RoleExternalID: "role-doctor",
+		ResourceKey: "patient_record", ActionKey: "update",
+	}); err != nil {
+		t.Fatalf("reading the role permission: %v", err)
+	} else if found {
+		t.Error("the role permission was written despite the transaction failing")
+	}
+	if _, found, err := store.AuditEvent(ctx, "audit-rollback-1"); err != nil {
+		t.Fatalf("reading the audit event: %v", err)
+	} else if found {
+		t.Error("the audit event was written despite the transaction failing")
+	}
+	if _, found, err := store.PermissionRevision(ctx, "tenant-a"); err != nil {
+		t.Fatalf("reading the tenant revision: %v", err)
+	} else if found {
+		t.Error("the permission revision was seeded despite the transaction failing")
+	}
+}
+
+// §8.1's audit trail is append-only: saving the same role permission twice
+// must leave both audit events readable, not have the second overwrite the
+// first, even though the role permission row itself is updated in place.
+func assertSaveRoleMatrixAuditHistoryIsAppendOnly(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "role_permission", "permission_audit_event", "outbox_event", "permission_revision")
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	newRevision, err := store.SaveRoleMatrix(ctx, assignmentstore.RoleMatrixWrite{
+		TenantID: "tenant-a", RoleExternalID: "role-doctor", ExpectedRevision: 0,
+		Permissions: []assignmentstore.RolePermissionInput{
+			{ResourceKey: "patient_record", ActionKey: "update", Enabled: true, ValidFrom: created},
+		},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-history-1", Operation: "ROLE_MATRIX_SAVE", BeforeJSON: `{}`, AfterJSON: `{"enabled":true}`, CreatedAt: created},
+		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-history-1", AggregateKey: "tenant-a:role-doctor", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
+	})
+	if err != nil {
+		t.Fatalf("the first save: %v", err)
+	}
+
+	if _, err := store.SaveRoleMatrix(ctx, assignmentstore.RoleMatrixWrite{
+		TenantID: "tenant-a", RoleExternalID: "role-doctor", ExpectedRevision: newRevision,
+		Permissions: []assignmentstore.RolePermissionInput{
+			{ResourceKey: "patient_record", ActionKey: "update", Enabled: false, ValidFrom: created},
+		},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-history-2", Operation: "ROLE_MATRIX_SAVE", BeforeJSON: `{"enabled":true}`, AfterJSON: `{"enabled":false}`, CreatedAt: created},
+		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-history-2", AggregateKey: "tenant-a:role-doctor", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
+	}); err != nil {
+		t.Fatalf("the second save: %v", err)
+	}
+
+	for _, eventID := range []string{"audit-history-1", "audit-history-2"} {
+		if _, found, err := store.AuditEvent(ctx, eventID); err != nil || !found {
+			t.Errorf("%s: found=%t err=%v, want it still readable", eventID, found, err)
+		}
+	}
+
+	permission, found, err := store.RolePermission(ctx, assignmentstore.RolePermissionKey{
+		TenantID: "tenant-a", RoleExternalID: "role-doctor",
+		ResourceKey: "patient_record", ActionKey: "update",
+	})
+	if err != nil || !found {
+		t.Fatalf("reading the updated permission: found=%t err=%v", found, err)
+	}
+	if permission.Enabled {
+		t.Error("the role permission still reads enabled after the second save disabled it")
+	}
+}
+
+// The publisher loop drains outbox rows oldest first and must not see a row
+// again once it has been marked published.
+func assertUnpublishedOutboxEvents(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "outbox_event")
+
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	for i, id := range []string{"outbox-unpub-1", "outbox-unpub-2", "outbox-unpub-3"} {
+		if err := store.AppendOutboxEvent(ctx, assignmentstore.OutboxEvent{
+			EventID: id, AggregateKey: "tenant-a:role-doctor", EventType: "permission.changed",
+			Payload: `{}`, CreatedAt: base.Add(time.Duration(i) * time.Minute),
+		}); err != nil {
+			t.Fatalf("seeding %s: %v", id, err)
+		}
+	}
+
+	unpublished, err := store.UnpublishedOutboxEvents(ctx, 10)
+	if err != nil {
+		t.Fatalf("reading unpublished events: %v", err)
+	}
+	if len(unpublished) != 3 {
+		t.Fatalf("got %d unpublished events, want 3", len(unpublished))
+	}
+	for i, want := range []string{"outbox-unpub-1", "outbox-unpub-2", "outbox-unpub-3"} {
+		if unpublished[i].EventID != want {
+			t.Errorf("event %d = %s, want %s (oldest first)", i, unpublished[i].EventID, want)
+		}
+	}
+
+	if err := store.MarkOutboxEventPublished(ctx, "outbox-unpub-2", base.Add(time.Hour)); err != nil {
+		t.Fatalf("marking published: %v", err)
+	}
+
+	remaining, err := store.UnpublishedOutboxEvents(ctx, 10)
+	if err != nil {
+		t.Fatalf("reading unpublished events after marking one published: %v", err)
+	}
+	if len(remaining) != 2 {
+		t.Fatalf("got %d unpublished events after marking one published, want 2", len(remaining))
+	}
+	for _, event := range remaining {
+		if event.EventID == "outbox-unpub-2" {
+			t.Error("a published event was still reported as unpublished")
+		}
+	}
+
+	published, found, err := store.OutboxEvent(ctx, "outbox-unpub-2")
+	if err != nil || !found {
+		t.Fatalf("reading the published event back: found=%t err=%v", found, err)
+	}
+	if published.PublishedAt == nil {
+		t.Error("publishedAt is still nil after MarkOutboxEventPublished")
 	}
 }
 

--- a/libs/outbox/go.mod
+++ b/libs/outbox/go.mod
@@ -1,0 +1,7 @@
+module github.com/tishan-harischandra/cerbos-poc/libs/outbox
+
+go 1.25.11
+
+require github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore v0.0.0
+
+replace github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore => ../assignmentstore

--- a/libs/outbox/outbox.go
+++ b/libs/outbox/outbox.go
@@ -1,0 +1,125 @@
+// Package outbox drains the transactional outbox (§8.1) that
+// assignmentstore.Store.SaveRoleMatrix appends to inside the same
+// transaction as the permission write it accompanies.
+//
+// It never decides what a permission change means: this package's whole job
+// is "take rows nobody has published yet and hand each to a Publisher,
+// exactly once if the publish succeeds." What "publish" does - Kafka, once a
+// later slice wires that in - is a caller's choice; this package holds no
+// opinion about it.
+package outbox
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+)
+
+// Store is the narrow slice of assignmentstore.Store the publisher loop
+// needs: enough to drain the outbox, nothing that would let this package
+// also write permissions.
+type Store interface {
+	UnpublishedOutboxEvents(ctx context.Context, limit int) ([]assignmentstore.OutboxEvent, error)
+	MarkOutboxEventPublished(ctx context.Context, eventID string, publishedAt time.Time) error
+}
+
+// Publisher sends one outbox event onward. A row is marked published only
+// after Publish returns nil, so a Publisher that fails leaves the row for
+// the next drain to retry - delivery is at-least-once, and a downstream
+// consumer must be idempotent on EventID.
+type Publisher interface {
+	Publish(ctx context.Context, event assignmentstore.OutboxEvent) error
+}
+
+// DefaultInterval is how often Loop.Run polls when LoopConfig.Interval is
+// left zero.
+const DefaultInterval = 2 * time.Second
+
+// DefaultBatchSize bounds how many rows one poll drains when
+// LoopConfig.BatchSize is left zero.
+const DefaultBatchSize = 100
+
+// LoopConfig holds a publisher loop's collaborators.
+type LoopConfig struct {
+	Store     Store
+	Publisher Publisher
+	// Interval is how often Run polls for unpublished events. Zero means
+	// DefaultInterval.
+	Interval time.Duration
+	// BatchSize bounds how many rows one poll drains. Zero means
+	// DefaultBatchSize.
+	BatchSize int
+	// Now is the clock a published row is stamped with. Injected so a test
+	// can assert on a fixed value.
+	Now func() time.Time
+	// OnError, if set, is called with any error draining one event. A
+	// drain error never stops the loop: an unpublished row simply stays
+	// unpublished until the next poll tries again.
+	OnError func(error)
+}
+
+// Loop polls Store for unpublished events and publishes each in turn.
+type Loop struct {
+	cfg LoopConfig
+}
+
+// NewLoop applies LoopConfig's defaults and returns a Loop.
+func NewLoop(cfg LoopConfig) *Loop {
+	if cfg.Interval <= 0 {
+		cfg.Interval = DefaultInterval
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = DefaultBatchSize
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &Loop{cfg: cfg}
+}
+
+// Run polls on Interval until ctx is done, draining one batch immediately
+// before the first tick so a freshly started loop does not wait a whole
+// interval to notice work that was already waiting.
+func (l *Loop) Run(ctx context.Context) {
+	l.DrainOnce(ctx)
+
+	ticker := time.NewTicker(l.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			l.DrainOnce(ctx)
+		}
+	}
+}
+
+// DrainOnce publishes every currently unpublished event once, in the order
+// Store reports them. It is exported so a caller, or a test, can drive one
+// pass deterministically without waiting on Run's ticker.
+func (l *Loop) DrainOnce(ctx context.Context) {
+	events, err := l.cfg.Store.UnpublishedOutboxEvents(ctx, l.cfg.BatchSize)
+	if err != nil {
+		l.reportError(fmt.Errorf("outbox: reading unpublished events: %w", err))
+		return
+	}
+
+	for _, event := range events {
+		if err := l.cfg.Publisher.Publish(ctx, event); err != nil {
+			l.reportError(fmt.Errorf("outbox: publishing %s: %w", event.EventID, err))
+			continue
+		}
+		if err := l.cfg.Store.MarkOutboxEventPublished(ctx, event.EventID, l.cfg.Now()); err != nil {
+			l.reportError(fmt.Errorf("outbox: marking %s published: %w", event.EventID, err))
+		}
+	}
+}
+
+func (l *Loop) reportError(err error) {
+	if l.cfg.OnError != nil {
+		l.cfg.OnError(err)
+	}
+}

--- a/libs/outbox/outbox_test.go
+++ b/libs/outbox/outbox_test.go
@@ -1,0 +1,208 @@
+package outbox_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+	"github.com/tishan-harischandra/cerbos-poc/libs/outbox"
+)
+
+// fakeStore is an in-memory Store: enough to drive DrainOnce deterministically
+// without a database.
+type fakeStore struct {
+	mu          sync.Mutex
+	unpublished []assignmentstore.OutboxEvent
+	published   map[string]time.Time
+	readErr     error
+	markErr     error
+}
+
+func newFakeStore(events ...assignmentstore.OutboxEvent) *fakeStore {
+	return &fakeStore{unpublished: events, published: map[string]time.Time{}}
+}
+
+func (f *fakeStore) UnpublishedOutboxEvents(_ context.Context, limit int) ([]assignmentstore.OutboxEvent, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	var out []assignmentstore.OutboxEvent
+	for _, event := range f.unpublished {
+		if _, done := f.published[event.EventID]; done {
+			continue
+		}
+		out = append(out, event)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeStore) MarkOutboxEventPublished(_ context.Context, eventID string, publishedAt time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.markErr != nil {
+		return f.markErr
+	}
+	f.published[eventID] = publishedAt
+	return nil
+}
+
+func (f *fakeStore) isPublished(eventID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.published[eventID]
+	return ok
+}
+
+// fakePublisher records what it was asked to publish and can be told to
+// fail for a named event, so a test can force a partial-batch failure.
+type fakePublisher struct {
+	mu        sync.Mutex
+	published []string
+	failFor   map[string]error
+}
+
+func newFakePublisher() *fakePublisher {
+	return &fakePublisher{failFor: map[string]error{}}
+}
+
+func (p *fakePublisher) Publish(_ context.Context, event assignmentstore.OutboxEvent) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err, fail := p.failFor[event.EventID]; fail {
+		return err
+	}
+	p.published = append(p.published, event.EventID)
+	return nil
+}
+
+func (p *fakePublisher) publishedIDs() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.published...)
+}
+
+func TestDrainOncePublishesAndMarksEveryUnpublishedEvent(t *testing.T) {
+	store := newFakeStore(
+		assignmentstore.OutboxEvent{EventID: "outbox-1", EventType: "permission.changed"},
+		assignmentstore.OutboxEvent{EventID: "outbox-2", EventType: "permission.changed"},
+	)
+	publisher := newFakePublisher()
+	loop := outbox.NewLoop(outbox.LoopConfig{Store: store, Publisher: publisher})
+
+	loop.DrainOnce(context.Background())
+
+	got := publisher.publishedIDs()
+	if len(got) != 2 || got[0] != "outbox-1" || got[1] != "outbox-2" {
+		t.Fatalf("published %v, want [outbox-1 outbox-2] in order", got)
+	}
+	if !store.isPublished("outbox-1") || !store.isPublished("outbox-2") {
+		t.Error("both events should be marked published")
+	}
+}
+
+// A publish failure must not stop the batch, and must leave that one event
+// unpublished for the next drain to retry (at-least-once delivery).
+func TestAPublishFailureLeavesThatEventUnpublishedButDrainsTheRest(t *testing.T) {
+	store := newFakeStore(
+		assignmentstore.OutboxEvent{EventID: "outbox-1", EventType: "permission.changed"},
+		assignmentstore.OutboxEvent{EventID: "outbox-2", EventType: "permission.changed"},
+		assignmentstore.OutboxEvent{EventID: "outbox-3", EventType: "permission.changed"},
+	)
+	publisher := newFakePublisher()
+	publisher.failFor["outbox-2"] = errors.New("boom")
+
+	var reported []error
+	loop := outbox.NewLoop(outbox.LoopConfig{
+		Store: store, Publisher: publisher,
+		OnError: func(err error) { reported = append(reported, err) },
+	})
+
+	loop.DrainOnce(context.Background())
+
+	if store.isPublished("outbox-2") {
+		t.Error("outbox-2 was marked published despite Publish failing")
+	}
+	if !store.isPublished("outbox-1") || !store.isPublished("outbox-3") {
+		t.Error("outbox-1 and outbox-3 should still be published despite outbox-2 failing")
+	}
+	if len(reported) != 1 {
+		t.Fatalf("OnError was called %d times, want 1", len(reported))
+	}
+}
+
+// A second drain must not re-publish rows the first drain already marked
+// published: the fake store's unpublished list, like the real one, only
+// ever reports rows with no publication time.
+func TestASecondDrainDoesNotRepublishAlreadyPublishedEvents(t *testing.T) {
+	store := newFakeStore(assignmentstore.OutboxEvent{EventID: "outbox-1"})
+	publisher := newFakePublisher()
+	loop := outbox.NewLoop(outbox.LoopConfig{Store: store, Publisher: publisher})
+
+	loop.DrainOnce(context.Background())
+	loop.DrainOnce(context.Background())
+
+	if got := publisher.publishedIDs(); len(got) != 1 {
+		t.Fatalf("published %v after two drains, want exactly one publish", got)
+	}
+}
+
+func TestARunFailureOnReadIsReportedAndDoesNotPanic(t *testing.T) {
+	store := newFakeStore()
+	store.readErr = errors.New("connection reset")
+	publisher := newFakePublisher()
+
+	var reported error
+	loop := outbox.NewLoop(outbox.LoopConfig{
+		Store: store, Publisher: publisher,
+		OnError: func(err error) { reported = err },
+	})
+
+	loop.DrainOnce(context.Background())
+
+	if reported == nil {
+		t.Fatal("a read failure should be reported through OnError")
+	}
+}
+
+func TestRunDrainsImmediatelyThenStopsWhenContextIsCancelled(t *testing.T) {
+	store := newFakeStore(assignmentstore.OutboxEvent{EventID: "outbox-1"})
+	publisher := newFakePublisher()
+	loop := outbox.NewLoop(outbox.LoopConfig{
+		Store: store, Publisher: publisher, Interval: time.Hour,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		loop.Run(ctx)
+		close(done)
+	}()
+
+	// Run must drain once before ever waiting on the (hour-long) ticker.
+	deadline := time.After(time.Second)
+	for {
+		if len(publisher.publishedIDs()) == 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("Run did not drain immediately on start")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after its context was cancelled")
+	}
+}

--- a/tests/architecture/tenantpredicate.go
+++ b/tests/architecture/tenantpredicate.go
@@ -1,0 +1,86 @@
+package architecture
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// TenantScopedTables are the §8.2 tables an administration query lists or
+// browses by tenant. A SELECT against one of these that names no tenant_id
+// predicate could return another tenant's rows by accident - exactly the
+// isolation failure §21's invariant exists to prevent.
+//
+// permission_audit_event and outbox_event are deliberately not on this list:
+// every SELECT against them in the adapters looks up one row by its own
+// globally unique event_id, which a caller can only have obtained by already
+// holding that specific id. That is a point lookup, not the kind of
+// administration query - a list, a search, a page - this check is for.
+var TenantScopedTables = []string{
+	"role_permission",
+	"user_permission_override",
+	"fhir_resource",
+	"permission_revision",
+}
+
+var tenantIDPattern = regexp.MustCompile(`(?i)\btenant_id\b`)
+
+func selectFromTablePattern(table string) *regexp.Regexp {
+	return regexp.MustCompile(`(?is)\bSELECT\b.*?\bFROM\s+` + regexp.QuoteMeta(table) + `\b`)
+}
+
+// ScanForMissingTenantPredicate reports every SQL string literal that reads a
+// TenantScopedTables table without mentioning tenant_id anywhere in the same
+// statement.
+func ScanForMissingTenantPredicate(filename, src string) ([]Finding, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, src, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", filename, err)
+	}
+
+	var findings []Finding
+	ast.Inspect(file, func(node ast.Node) bool {
+		lit, ok := node.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		value := literalValue(lit.Value)
+
+		for _, table := range TenantScopedTables {
+			if !selectFromTablePattern(table).MatchString(value) {
+				continue
+			}
+			if tenantIDPattern.MatchString(value) {
+				continue
+			}
+			findings = append(findings, Finding{
+				File:   filename,
+				Line:   fset.Position(lit.Pos()).Line,
+				Symbol: table,
+				Message: fmt.Sprintf(
+					"a SELECT from %s names no tenant_id predicate; %s is a tenant-scoped table (§8.2, §21)",
+					table, table),
+			})
+		}
+		return true
+	})
+	return findings, nil
+}
+
+// literalValue unquotes a Go string literal, backtick-raw or double-quoted,
+// so the SQL inside can be pattern-matched as written.
+func literalValue(raw string) string {
+	if strings.HasPrefix(raw, "`") {
+		return strings.Trim(raw, "`")
+	}
+	unquoted, err := strconv.Unquote(raw)
+	if err != nil {
+		return raw
+	}
+	return unquoted
+}

--- a/tests/architecture/tenantpredicate_test.go
+++ b/tests/architecture/tenantpredicate_test.go
@@ -1,0 +1,111 @@
+package architecture_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/tests/architecture"
+)
+
+// Every administration query against a tenant-scoped table must carry a
+// tenant_id predicate. This is the executable form of §21's isolation
+// invariant for the read side: a query that could return another tenant's
+// rows by accident is the failure mode the invariant exists to prevent.
+func TestEveryAdministrationQueryNamesATenantPredicate(t *testing.T) {
+	root := repoRoot(t)
+
+	var findings []architecture.Finding
+	for _, path := range goFiles(t, root) {
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatalf("relativising %s: %v", path, err)
+		}
+		if strings.HasPrefix(filepath.ToSlash(relative), "tests/architecture/") {
+			continue
+		}
+
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+
+		found, err := architecture.ScanForMissingTenantPredicate(relative, string(source))
+		if err != nil {
+			t.Fatalf("scanning %s: %v", relative, err)
+		}
+		findings = append(findings, found...)
+	}
+
+	if len(findings) > 0 {
+		var report strings.Builder
+		report.WriteString("administration queries missing a tenant_id predicate:\n")
+		for _, finding := range findings {
+			report.WriteString("  " + finding.String() + "\n")
+		}
+		t.Fatal(report.String())
+	}
+}
+
+// An architecture test that cannot fail is decoration.
+func TestTheCheckerCatchesAMissingTenantPredicate(t *testing.T) {
+	const leak = `package postgresstore
+
+func (s *Store) allRolePermissionsEverywhere(ctx context.Context) {
+	const query = ` + "`" + `SELECT role_external_id, resource_key, action_key FROM role_permission` + "`" + `
+	_ = query
+}
+`
+
+	findings, err := architecture.ScanForMissingTenantPredicate("libs/assignmentstore/postgresstore/leak.go", leak)
+	if err != nil {
+		t.Fatalf("ScanForMissingTenantPredicate: %v", err)
+	}
+	if len(findings) == 0 {
+		t.Fatal("the checker did not catch a role_permission query with no tenant_id predicate")
+	}
+	if findings[0].Symbol != "role_permission" {
+		t.Errorf("finding named %q, want role_permission", findings[0].Symbol)
+	}
+}
+
+// A point lookup by a globally unique event id must not be flagged: it
+// cannot return another tenant's row no matter which tenant asks, because
+// the caller can only have obtained that specific id in the first place.
+func TestTheCheckerAllowsAPointLookupByEventID(t *testing.T) {
+	const source = `package postgresstore
+
+func (s *Store) AuditEvent(ctx context.Context, eventID string) {
+	const query = ` + "`" + `SELECT actor_id FROM permission_audit_event WHERE event_id = $1` + "`" + `
+	_ = query
+}
+`
+
+	findings, err := architecture.ScanForMissingTenantPredicate("libs/assignmentstore/postgresstore/postgresstore.go", source)
+	if err != nil {
+		t.Fatalf("ScanForMissingTenantPredicate: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("a point lookup by event id was flagged: %v", findings)
+	}
+}
+
+// A query that does carry a tenant_id predicate must not be flagged.
+func TestTheCheckerAllowsAQueryWithATenantPredicate(t *testing.T) {
+	const source = `package postgresstore
+
+func (s *Store) ActiveRolePermissions(ctx context.Context) {
+	const query = ` + "`" + `SELECT action_key FROM role_permission WHERE tenant_id = $1` + "`" + `
+	_ = query
+}
+`
+
+	findings, err := architecture.ScanForMissingTenantPredicate("libs/assignmentstore/postgresstore/postgresstore.go", source)
+	if err != nil {
+		t.Fatalf("ScanForMissingTenantPredicate: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("a query with a tenant_id predicate was flagged: %v", findings)
+	}
+}


### PR DESCRIPTION
## What changed

Implements the administration write path for role permissions, with the
transactional guarantee the whole convergence model depends on.

- `libs/assignmentstore`: `Store.SaveRoleMatrix` writes one role's permission
  slice, its audit event, its outbox event and the tenant's permission
  revision bump as a single transaction, or none of them (§9.4, §10.1, §16.1).
  A stale `ExpectedRevision` - checked against the tenant's `permission_revision`
  row, locked with `SELECT ... FOR UPDATE` - fails with `ErrRevisionConflict`
  and writes nothing. Implemented on both the PostgreSQL and Oracle adapters.
  Also adds `UnpublishedOutboxEvents` and `MarkOutboxEventPublished`.
- `libs/outbox`: a publisher loop that drains unpublished outbox rows and hands
  each to an injected `Publisher`, marking a row published only once `Publish`
  succeeds. No concrete `Publisher` exists yet (Kafka is not wired into the
  compose stack in this slice) - this is the loop and the port, ready for a
  later slice to plug a real one in.
- `apps/admin-service`: a new Go service exposing
  `PUT /admin/authz/tenants/{tenant}/roles/{role}/permissions`, which validates,
  in order: a verified identity is present, the administrator's own tenant
  matches the target tenant (§9.4), and every resource/action in the request
  is in the active catalog (§12.2) - before calling `SaveRoleMatrix`. Also
  `GET /admin/authz/tenants/{tenant}/permission-revision` for learning the
  `expectedRevision` to send on a first save.
- `tests/architecture`: `ScanForMissingTenantPredicate` flags a `SELECT`
  against a tenant-scoped table with no `tenant_id` predicate anywhere in the
  statement - the read side of §21's isolation invariant.

## Acceptance criteria

- **A save with a stale expected revision is rejected and no partial write
  occurs**: `storecontract` `SaveRoleMatrix rejects a stale expected revision
  and writes nothing`; `rolematrix` `TestSaveRejectsAStaleExpectedRevisionWith409`.
- **Two concurrent saves against the same role result in exactly one success
  and one clean conflict**: `storecontract` `two concurrent SaveRoleMatrix
  calls against the same role yield one success and one conflict` - real
  goroutines against a real PostgreSQL instance, serialized by `SELECT ... FOR
  UPDATE` on the tenant's revision row.
- **Assignment, audit, revision increment and outbox row are all committed
  atomically**: `storecontract` `SaveRoleMatrix commits the permission, audit,
  outbox and revision together`.
- **A forced failure mid-transaction rolls back all four**: `storecontract` `a
  mid-transaction failure in SaveRoleMatrix rolls back all four writes` -
  forces the failure with a real unique-key violation on a pre-seeded outbox
  row, then asserts every one of the four writes is absent.
- **An administrator cannot write to a tenant they lack authority over**:
  `authority` package + `rolematrix`
  `TestSaveRejectsAnAdministratorWithNoAuthorityOverTheTargetTenant` (403,
  nothing written).
- **A resource or action absent from the active catalog is rejected before any
  write**: `rolematrix` `TestSaveRejectsAResourceActionNotInTheActiveCatalog`
  (400, nothing written).
- **An administration query without a tenant predicate fails an automated
  check**: `tests/architecture` `TestEveryAdministrationQueryNamesATenantPredicate`,
  with positive and negative cases proving the checker actually catches
  something and does not flag a legitimate point lookup by event id.
- **Audit history is append-only and survives in-place updates to the
  assignment row**: `storecontract` `audit history survives SaveRoleMatrix
  updating the same role permission in place`.
- **Every audit event records actor, operation, before state, after state and
  correlation ID**: `rolematrix`
  `TestSaveRecordsBeforeAndAfterStateAndTheCorrelationIdOnTheAuditEvent` - the
  before state is read from the store immediately before the write, not
  assumed.

## How it was verified

All verified locally (no GitHub workflow was run, per current project
instruction):

- `bash scripts/tests/store-contract.sh postgres` - the full assignmentstore
  contract, including every new `SaveRoleMatrix` case, against a real
  PostgreSQL instance started with `docker compose up postgres` and migrated
  with `scripts/liquibase.sh postgres update`. All green.
- `nx test admin-service`, `nx test outbox`, `nx test architecture` - all
  green.
- `nx build admin-service` - succeeds.
- `nx build ads` - unaffected, still green (no regression from the shared
  `assignmentstore.Store` interface growing a new method).
- `go vet` and `go fmt` clean across every touched module.
- `nx show projects` confirms `admin-service` and `outbox` are recognized by
  the Nx Go plugin with working `test`/`build` targets.

## Follow-ups intentionally left out of this slice

- `GET /admin/authz/roles`, `GET /admin/authz/users` (IdP search) and the full
  role-matrix read (`GET .../permissions`) are not implemented - only the
  minimal `GET .../permission-revision` needed to drive the optimistic-
  concurrency write flow. None of the issue's acceptance criteria exercise
  them.
- No `Dockerfile`/`docker-compose.yml` wiring for `admin-service` yet, unlike
  `ads`/`admin-console`/`business-ui`. Not required by any acceptance
  criterion; a reasonable next step once the read endpoints exist too.
- No real `outbox.Publisher` (Kafka) yet - it is not part of the compose stack
  in this slice.


Closes #13
