### PR TITLE
Administration service: user override endpoints (#15)

### DIFF
--- a/apps/admin-service/cmd/admin-service/main.go
+++ b/apps/admin-service/cmd/admin-service/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/config"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/server"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/useroverride"
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/postgresstore"
 	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
 	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/provider"
@@ -62,6 +63,12 @@ func main() {
 		RoleMatrix: &rolematrix.Handler{
 			Store:   store,
 			Catalog: catalog,
+		},
+		UserOverride: &useroverride.Handler{
+			Store:                   store,
+			Catalog:                 catalog,
+			HighRiskActions:         cfg.HighRiskActions,
+			DefaultHighRiskValidity: cfg.HighRiskOverrideValidity,
 		},
 	})
 

--- a/apps/admin-service/internal/config/config.go
+++ b/apps/admin-service/internal/config/config.go
@@ -34,6 +34,15 @@ type Config struct {
 	// OutboxPublishInterval bounds how often the publisher loop polls for
 	// unpublished outbox rows.
 	OutboxPublishInterval time.Duration
+
+	// HighRiskActions names the action keys the user-override write path
+	// (§9.3, issue #15) defaults to a bounded expiry when a GRANT or
+	// REVOKE names none.
+	HighRiskActions []string
+	// HighRiskOverrideValidity bounds a high-risk GRANT or REVOKE that
+	// names no ValidUntil. Non-positive falls back to
+	// useroverride.DefaultHighRiskValidityWindow.
+	HighRiskOverrideValidity time.Duration
 }
 
 // LookupFunc mirrors os.LookupEnv so configuration stays testable.
@@ -52,6 +61,9 @@ func FromEnv(lookup LookupFunc) Config {
 		KafkaBrokers:          splitOr(lookup, "KAFKA_BROKERS", []string{"redpanda:9092"}),
 		KafkaTopic:            valueOr(lookup, "KAFKA_PERMISSION_CHANGED_TOPIC", "permission-changed"),
 		OutboxPublishInterval: durationOr(lookup, "OUTBOX_PUBLISH_INTERVAL", 2*time.Second),
+
+		HighRiskActions:          splitOr(lookup, "USER_OVERRIDE_HIGH_RISK_ACTIONS", []string{"update", "delete", "assign"}),
+		HighRiskOverrideValidity: durationOr(lookup, "USER_OVERRIDE_HIGH_RISK_VALIDITY", 90*24*time.Hour),
 	}
 }
 

--- a/apps/admin-service/internal/server/server.go
+++ b/apps/admin-service/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/useroverride"
 )
 
 // DefaultReadinessTimeout bounds how long readiness waits on its dependencies.
@@ -38,6 +39,10 @@ type Config struct {
 	// RoleMatrix serves the role-matrix endpoints. Nil means the routes
 	// are not registered.
 	RoleMatrix *rolematrix.Handler
+
+	// UserOverride serves the user-override endpoints. Nil means the
+	// routes are not registered.
+	UserOverride *useroverride.Handler
 }
 
 // New builds the Administration Service HTTP handler.
@@ -47,14 +52,22 @@ func New(cfg Config) http.Handler {
 		writeJSON(w, http.StatusOK, map[string]any{"status": "ok"})
 	})
 
-	if cfg.RoleMatrix != nil && cfg.Verifier != nil {
+	if cfg.Verifier != nil {
 		authenticated := func(next http.HandlerFunc) http.Handler {
 			return tokenauth.Require(tokenauth.Config{Verifier: cfg.Verifier}, next)
 		}
-		mux.Handle("PUT /admin/authz/tenants/{tenant}/roles/{role}/permissions",
-			authenticated(cfg.RoleMatrix.Save))
-		mux.Handle("GET /admin/authz/tenants/{tenant}/permission-revision",
-			authenticated(cfg.RoleMatrix.CurrentRevision))
+		if cfg.RoleMatrix != nil {
+			mux.Handle("PUT /admin/authz/tenants/{tenant}/roles/{role}/permissions",
+				authenticated(cfg.RoleMatrix.Save))
+			mux.Handle("GET /admin/authz/tenants/{tenant}/permission-revision",
+				authenticated(cfg.RoleMatrix.CurrentRevision))
+		}
+		if cfg.UserOverride != nil {
+			mux.Handle("PUT /admin/authz/tenants/{tenant}/hospitals/{hospital}/users/{user}/overrides",
+				authenticated(cfg.UserOverride.Save))
+			mux.Handle("GET /admin/authz/tenants/{tenant}/hospitals/{hospital}/users/{user}/overrides",
+				authenticated(cfg.UserOverride.Read))
+		}
 	}
 
 	timeout := cfg.ReadinessTimeout

--- a/apps/admin-service/internal/server/server_test.go
+++ b/apps/admin-service/internal/server/server_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/server"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/useroverride"
 	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
 )
 
@@ -44,6 +45,29 @@ func TestRoleMatrixRoutesRequireABearerToken(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
 		"/admin/authz/tenants/tenant-a/permission-revision", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 with no bearer token", rec.Code)
+	}
+}
+
+func TestUserOverrideRoutesAreAbsentWithoutAUserOverrideHandler(t *testing.T) {
+	handler := server.New(server.Config{})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/admin/authz/tenants/tenant-a/hospitals/hospital-1/users/user-1/overrides?resource=patient_record", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 when no user-override handler is configured", rec.Code)
+	}
+}
+
+func TestUserOverrideRoutesRequireABearerToken(t *testing.T) {
+	handler := server.New(server.Config{
+		Verifier:     fakeVerifier{},
+		UserOverride: &useroverride.Handler{},
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/admin/authz/tenants/tenant-a/hospitals/hospital-1/users/user-1/overrides?resource=patient_record", nil))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401 with no bearer token", rec.Code)
 	}

--- a/apps/admin-service/internal/useroverride/handler.go
+++ b/apps/admin-service/internal/useroverride/handler.go
@@ -1,0 +1,382 @@
+// Package useroverride implements
+// GET/PUT /admin/authz/tenants/{tenant}/hospitals/{hospital}/users/{user}/overrides
+// (§9.3, §9.4): the tri-state (INHERIT/GRANT/REVOKE) user-override write path,
+// carrying the same transactional and audit guarantees SaveRoleMatrix gives
+// the role matrix (§10.1, §16.1).
+package useroverride
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/authority"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+	"github.com/tishan-harischandra/cerbos-poc/libs/permissionevents"
+)
+
+// Store is the narrow slice of assignmentstore.Store this handler needs.
+type Store interface {
+	// ActiveRolePermissions is read against the roles the request names, to
+	// compute the "underlying role result" §9.3 asks the response to report
+	// - this is a preview of the pending write, not a live authorization
+	// decision, and it computes nothing Cerbos would not compute the same
+	// way at request time from the same role_permission rows.
+	ActiveRolePermissions(ctx context.Context, query assignmentstore.ActiveRolePermissionQuery) ([]assignmentstore.RolePermission, error)
+	ActiveUserOverrides(ctx context.Context, query assignmentstore.ActiveUserOverridesQuery) ([]assignmentstore.UserOverride, error)
+	SaveUserOverrideWrite(ctx context.Context, write assignmentstore.UserOverrideWrite) (int64, error)
+}
+
+// Catalog validates a resource/action pair against the active catalog
+// (§12.2), the same rule rolematrix.Catalog enforces for role grants.
+type Catalog interface {
+	Has(resource, action string) bool
+}
+
+// Effect is the tri-state a PUT request names (§9.3: "Inherit, Grant,
+// Revoke"). It is a request-shape concern distinct from
+// assignmentstore.OverrideEffect, which has no INHERIT value at all -
+// INHERIT is the absence of a row (§8.3), not something the store's own
+// vocabulary needs to spell.
+type Effect string
+
+const (
+	EffectInherit Effect = "INHERIT"
+	EffectGrant   Effect = "GRANT"
+	EffectRevoke  Effect = "REVOKE"
+)
+
+// Handler serves the user-override endpoints.
+type Handler struct {
+	Store   Store
+	Catalog Catalog
+	// HighRiskActions names the action keys §9.3's "For high-risk actions,
+	// optionally require maker-checker approval" and "Default direct
+	// grants to a bounded expiry for high-risk permissions" apply to.
+	// There is no catalog-wide risk classification yet (issue #15's scope
+	// is the override write path, not the catalog), so this is a small,
+	// explicit list rather than a database lookup.
+	HighRiskActions []string
+	// DefaultHighRiskValidity bounds a high-risk GRANT or REVOKE that
+	// names no ValidUntil. Non-positive falls back to
+	// DefaultHighRiskValidityWindow.
+	DefaultHighRiskValidity time.Duration
+	// Now is the clock validity and audit timestamps are measured
+	// against. Injected so a test can assert on a fixed value.
+	Now func() time.Time
+	// NewEventID mints the ids for the audit and outbox rows a save
+	// writes. Injected so a test can assert on deterministic ids.
+	NewEventID func() string
+}
+
+// DefaultHighRiskValidityWindow is the bounded expiry a high-risk GRANT or
+// REVOKE defaults to when the request names none (§9.3: "the safe choice is
+// the default choice").
+const DefaultHighRiskValidityWindow = 90 * 24 * time.Hour
+
+func (h *Handler) now() time.Time {
+	if h.Now != nil {
+		return h.Now()
+	}
+	return time.Now()
+}
+
+func (h *Handler) newEventID() string {
+	if h.NewEventID != nil {
+		return h.NewEventID()
+	}
+	return fmt.Sprintf("evt-%d", time.Now().UnixNano())
+}
+
+func (h *Handler) isHighRisk(action string) bool {
+	for _, risky := range h.HighRiskActions {
+		if risky == action {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *Handler) defaultHighRiskValidity() time.Duration {
+	if h.DefaultHighRiskValidity > 0 {
+		return h.DefaultHighRiskValidity
+	}
+	return DefaultHighRiskValidityWindow
+}
+
+type saveRequest struct {
+	ExpectedRevision int64      `json:"expectedRevision"`
+	ResourceKey      string     `json:"resourceKey"`
+	ActionKey        string     `json:"actionKey"`
+	Effect           Effect     `json:"effect"`
+	Reason           string     `json:"reason"`
+	ValidFrom        time.Time  `json:"validFrom"`
+	ValidUntil       *time.Time `json:"validUntil,omitempty"`
+	// RoleExternalIDs are the canonical roles currently assigned to the
+	// target user, as the caller already knows them (§7.5). This handler
+	// never resolves a user's roles itself - that is the identity
+	// directory's job (issue #24's normalized IdP reads) - it only
+	// previews the combination the caller supplies.
+	RoleExternalIDs []string `json:"roleExternalIds"`
+}
+
+// Save handles PUT .../overrides.
+func (h *Handler) Save(w http.ResponseWriter, r *http.Request) {
+	identity, ok := tokenauth.From(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	tenant := r.PathValue("tenant")
+	hospital := r.PathValue("hospital")
+	user := r.PathValue("user")
+
+	if err := authority.Validate(
+		authority.Principal{TenantID: identity.TenantID, HospitalID: identity.HospitalID},
+		tenant, hospital); err != nil {
+		writeError(w, http.StatusForbidden, "you do not have authority over this tenant and hospital")
+		return
+	}
+
+	var req saveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "malformed request body")
+		return
+	}
+
+	if req.ResourceKey == "" || req.ActionKey == "" {
+		writeError(w, http.StatusBadRequest, "resourceKey and actionKey are required")
+		return
+	}
+	if !h.Catalog.Has(req.ResourceKey, req.ActionKey) {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("not in the active catalog: %s:%s", req.ResourceKey, req.ActionKey))
+		return
+	}
+
+	var storeEffect assignmentstore.OverrideEffect
+	switch req.Effect {
+	case EffectInherit:
+		storeEffect = ""
+	case EffectGrant:
+		storeEffect = assignmentstore.EffectGrant
+	case EffectRevoke:
+		storeEffect = assignmentstore.EffectRevoke
+	default:
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("effect must be INHERIT, GRANT or REVOKE, got %q", req.Effect))
+		return
+	}
+
+	if storeEffect != "" {
+		// §9.3: "Require ... reason, validity start and optional expiry."
+		// INHERIT clears a row rather than creating one, so it needs
+		// neither.
+		if req.Reason == "" {
+			writeError(w, http.StatusBadRequest, "reason is required for a GRANT or REVOKE")
+			return
+		}
+		if req.ValidFrom.IsZero() {
+			writeError(w, http.StatusBadRequest, "validFrom is required for a GRANT or REVOKE")
+			return
+		}
+	}
+
+	now := h.now()
+	var validUntil time.Time
+	if req.ValidUntil != nil {
+		validUntil = *req.ValidUntil
+	} else if storeEffect != "" && h.isHighRisk(req.ActionKey) {
+		// §9.3: "Default direct grants to a bounded expiry for high-risk
+		// permissions" - the safe choice is the default choice, so an
+		// administrator who names no expiry for a high-risk action gets
+		// one anyway rather than an unbounded grant.
+		validUntil = req.ValidFrom.Add(h.defaultHighRiskValidity())
+	}
+
+	roleResult := h.roleResult(r.Context(), tenant, req.ResourceKey, req.ActionKey, req.RoleExternalIDs, now)
+	effectiveResult := effectiveResult(storeEffect, roleResult)
+
+	correlationID := r.Header.Get("X-Correlation-Id")
+	if correlationID == "" {
+		correlationID = h.newEventID()
+	}
+
+	event := permissionevents.PermissionChanged{
+		EventID:     h.newEventID(),
+		EventType:   permissionevents.EventTypePermissionChanged,
+		TenantID:    tenant,
+		HospitalID:  hospital,
+		SubjectType: permissionevents.SubjectUser,
+		SubjectID:   user,
+		Resource:    req.ResourceKey,
+		Action:      req.ActionKey,
+		Enabled:     effectiveResult,
+		Revision:    req.ExpectedRevision + 1,
+		OccurredAt:  now,
+	}
+	payload, _ := json.Marshal([]permissionevents.PermissionChanged{event})
+
+	write := assignmentstore.UserOverrideWrite{
+		Key: assignmentstore.UserOverrideKey{
+			TenantID: tenant, HospitalID: hospital, UserExternalID: user,
+			ResourceKey: req.ResourceKey, ActionKey: req.ActionKey,
+		},
+		Effect:           storeEffect,
+		Reason:           req.Reason,
+		ValidFrom:        req.ValidFrom,
+		ValidUntil:       validUntil,
+		ExpectedRevision: req.ExpectedRevision,
+		Audit: assignmentstore.AuditEvent{
+			EventID:       h.newEventID(),
+			ActorID:       identity.PrincipalID,
+			Operation:     "USER_OVERRIDE_SAVE",
+			TargetType:    "user_permission_override",
+			BeforeJSON:    fmt.Sprintf(`{"roleResult":%t}`, roleResult),
+			AfterJSON:     fmt.Sprintf(`{"effect":%q,"effectiveResult":%t}`, req.Effect, effectiveResult),
+			CorrelationID: correlationID,
+			CreatedAt:     now,
+		},
+		Outbox: assignmentstore.OutboxEvent{
+			EventID:      h.newEventID(),
+			AggregateKey: tenant + ":" + user,
+			EventType:    permissionevents.EventTypePermissionChanged,
+			Payload:      string(payload),
+			CreatedAt:    now,
+		},
+	}
+
+	newRevision, err := h.Store.SaveUserOverrideWrite(r.Context(), write)
+	if errors.Is(err, assignmentstore.ErrRevisionConflict) {
+		writeError(w, http.StatusConflict, "expected revision is stale; reload the current overrides and retry")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "saving the user override failed")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"revision":          newRevision,
+		"roleResult":        roleResult,
+		"effectiveResult":   effectiveResult,
+		"noPracticalEffect": effectiveResult == roleResult,
+	})
+}
+
+// roleResult reports whether any of roleExternalIDs currently grants
+// resource/action, the same read ActiveRolePermissions gives the ADS's own
+// decision path (§11.2) - a preview computed from the same source of truth,
+// not a second implementation of one.
+func (h *Handler) roleResult(ctx context.Context, tenant, resource, action string, roleExternalIDs []string, at time.Time) bool {
+	if len(roleExternalIDs) == 0 {
+		return false
+	}
+	permissions, err := h.Store.ActiveRolePermissions(ctx, assignmentstore.ActiveRolePermissionQuery{
+		TenantID: tenant, RoleExternalIDs: roleExternalIDs, ResourceKey: resource, At: at,
+	})
+	if err != nil {
+		return false
+	}
+	for _, permission := range permissions {
+		if permission.Key.ActionKey == action && permission.Enabled {
+			return true
+		}
+	}
+	return false
+}
+
+// effectiveResult applies the tri-state override to a role result: REVOKE
+// always defeats it, GRANT always wins over it, and INHERIT leaves it
+// unmodified. This mirrors the §6.3 "user-specific outranks role-specific"
+// rule for the two dimensions this preview covers - it omits the mandatory
+// rule that outranks both, because that rule is Cerbos policy's alone to
+// evaluate (§6.3, §6.4) and this is an administrative preview of a pending
+// write, not a decision.
+func effectiveResult(effect assignmentstore.OverrideEffect, roleResult bool) bool {
+	switch effect {
+	case assignmentstore.EffectRevoke:
+		return false
+	case assignmentstore.EffectGrant:
+		return true
+	default:
+		return roleResult
+	}
+}
+
+// overrideView is one row of a GET .../overrides response.
+type overrideView struct {
+	ActionKey  string     `json:"actionKey"`
+	Effect     string     `json:"effect"`
+	Enabled    bool       `json:"enabled"`
+	Reason     string     `json:"reason,omitempty"`
+	ValidFrom  time.Time  `json:"validFrom"`
+	ValidUntil *time.Time `json:"validUntil,omitempty"`
+	Revision   int64      `json:"revision"`
+}
+
+// Read handles GET .../overrides?resource=....
+func (h *Handler) Read(w http.ResponseWriter, r *http.Request) {
+	identity, ok := tokenauth.From(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	tenant := r.PathValue("tenant")
+	hospital := r.PathValue("hospital")
+	user := r.PathValue("user")
+
+	if err := authority.Validate(
+		authority.Principal{TenantID: identity.TenantID, HospitalID: identity.HospitalID},
+		tenant, hospital); err != nil {
+		writeError(w, http.StatusForbidden, "you do not have authority over this tenant and hospital")
+		return
+	}
+
+	resource := r.URL.Query().Get("resource")
+	if resource == "" {
+		writeError(w, http.StatusBadRequest, "a resource query parameter is required")
+		return
+	}
+
+	overrides, err := h.Store.ActiveUserOverrides(r.Context(), assignmentstore.ActiveUserOverridesQuery{
+		TenantID: tenant, HospitalID: hospital, UserExternalID: user,
+		ResourceKey: resource, At: h.now(),
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "reading the user overrides failed")
+		return
+	}
+
+	views := make([]overrideView, 0, len(overrides))
+	for _, override := range overrides {
+		view := overrideView{
+			ActionKey: override.Key.ActionKey,
+			Effect:    string(override.Effect),
+			Enabled:   override.Enabled,
+			Reason:    override.Reason,
+			ValidFrom: override.ValidFrom,
+			Revision:  override.Revision,
+		}
+		if !override.ValidUntil.IsZero() {
+			validUntil := override.ValidUntil
+			view.ValidUntil = &validUntil
+		}
+		views = append(views, view)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"overrides": views})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}

--- a/apps/admin-service/internal/useroverride/handler_test.go
+++ b/apps/admin-service/internal/useroverride/handler_test.go
@@ -1,0 +1,596 @@
+package useroverride_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/useroverride"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+	"github.com/tishan-harischandra/cerbos-poc/libs/permissionevents"
+)
+
+type fakeStore struct {
+	rolePermissions []assignmentstore.RolePermission
+	overrides       map[string]assignmentstore.UserOverride
+	revisions       map[string]int64
+	lastWrite       assignmentstore.UserOverrideWrite
+	saveErr         error
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		overrides: map[string]assignmentstore.UserOverride{},
+		revisions: map[string]int64{},
+	}
+}
+
+func overrideKeyString(key assignmentstore.UserOverrideKey) string {
+	key = assignmentstore.NormalizeOverrideKey(key)
+	return key.TenantID + "/" + key.HospitalID + "/" + key.UserExternalID + "/" +
+		key.ResourceKey + "/" + key.ActionKey + "/" + key.ResourceInstanceID
+}
+
+func (f *fakeStore) ActiveRolePermissions(_ context.Context, query assignmentstore.ActiveRolePermissionQuery) ([]assignmentstore.RolePermission, error) {
+	roles := make(map[string]bool, len(query.RoleExternalIDs))
+	for _, role := range query.RoleExternalIDs {
+		roles[role] = true
+	}
+	var matched []assignmentstore.RolePermission
+	for _, permission := range f.rolePermissions {
+		if permission.Key.TenantID == query.TenantID &&
+			permission.Key.ResourceKey == query.ResourceKey &&
+			roles[permission.Key.RoleExternalID] {
+			matched = append(matched, permission)
+		}
+	}
+	return matched, nil
+}
+
+func (f *fakeStore) ActiveUserOverrides(_ context.Context, query assignmentstore.ActiveUserOverridesQuery) ([]assignmentstore.UserOverride, error) {
+	var matched []assignmentstore.UserOverride
+	for _, override := range f.overrides {
+		key := override.Key
+		if key.TenantID == query.TenantID && key.HospitalID == query.HospitalID &&
+			key.UserExternalID == query.UserExternalID && key.ResourceKey == query.ResourceKey &&
+			!query.At.Before(override.ValidFrom) &&
+			(override.ValidUntil.IsZero() || query.At.Before(override.ValidUntil)) {
+			matched = append(matched, override)
+		}
+	}
+	return matched, nil
+}
+
+func (f *fakeStore) SaveUserOverrideWrite(_ context.Context, write assignmentstore.UserOverrideWrite) (int64, error) {
+	f.lastWrite = write
+	if f.saveErr != nil {
+		return 0, f.saveErr
+	}
+	current := f.revisions[write.Key.TenantID]
+	if write.ExpectedRevision != current {
+		return 0, assignmentstore.ErrRevisionConflict
+	}
+	newRevision := current + 1
+	f.revisions[write.Key.TenantID] = newRevision
+
+	key := assignmentstore.NormalizeOverrideKey(write.Key)
+	if write.Effect == "" {
+		delete(f.overrides, overrideKeyString(key))
+	} else {
+		f.overrides[overrideKeyString(key)] = assignmentstore.UserOverride{
+			Key: key, Effect: write.Effect, Enabled: true,
+			ValidFrom: write.ValidFrom, ValidUntil: write.ValidUntil,
+			Revision: newRevision, Reason: write.Reason,
+		}
+	}
+	return newRevision, nil
+}
+
+type fakeCatalog struct {
+	known map[string]bool
+}
+
+func newFakeCatalog(pairs ...string) *fakeCatalog {
+	known := make(map[string]bool, len(pairs))
+	for _, pair := range pairs {
+		known[pair] = true
+	}
+	return &fakeCatalog{known: known}
+}
+
+func (c *fakeCatalog) Has(resource, action string) bool {
+	return c.known[resource+":"+action]
+}
+
+func newHandler(store *fakeStore, catalog *fakeCatalog) *useroverride.Handler {
+	counter := 0
+	return &useroverride.Handler{
+		Store:           store,
+		Catalog:         catalog,
+		HighRiskActions: []string{"delete"},
+		Now:             func() time.Time { return time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC) },
+		NewEventID: func() string {
+			counter++
+			return "evt-" + string(rune('0'+counter))
+		},
+	}
+}
+
+func saveRequest(t *testing.T, identity tokenauth.Identity, tenant, hospital, user string, body any) *http.Request {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshaling the request body: %v", err)
+	}
+	path := "/admin/authz/tenants/" + tenant + "/hospitals/" + hospital + "/users/" + user + "/overrides"
+	req := httptest.NewRequest(http.MethodPut, path, bytes.NewReader(raw))
+	req.SetPathValue("tenant", tenant)
+	req.SetPathValue("hospital", hospital)
+	req.SetPathValue("user", user)
+	return req.WithContext(tokenauth.WithIdentity(req.Context(), identity))
+}
+
+func readRequest(t *testing.T, identity tokenauth.Identity, tenant, hospital, user, resource string) *http.Request {
+	t.Helper()
+	path := "/admin/authz/tenants/" + tenant + "/hospitals/" + hospital + "/users/" + user + "/overrides?resource=" + resource
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.SetPathValue("tenant", tenant)
+	req.SetPathValue("hospital", hospital)
+	req.SetPathValue("user", user)
+	return req.WithContext(tokenauth.WithIdentity(req.Context(), identity))
+}
+
+func decodeResponse(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding the response body %q: %v", rec.Body.String(), err)
+	}
+	return body
+}
+
+func adminOf(tenant, hospital string) tokenauth.Identity {
+	return tokenauth.Identity{PrincipalID: "admin-1", TenantID: tenant, HospitalID: hospital}
+}
+
+// A GRANT and a REVOKE must persist with the reason, validity start and
+// optional expiry the request named (§9.3, AC "GRANT and REVOKE persist
+// with reason, validity start and optional expiry").
+func TestSaveGrantPersistsWithReasonValidityAndExpiry(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := saveRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 0,
+		"resourceKey":      "patient_record",
+		"actionKey":        "read",
+		"effect":           "GRANT",
+		"reason":           "temporary clinical cover",
+		"validFrom":        "2026-01-01T00:00:00Z",
+		"validUntil":       "2026-12-31T00:00:00Z",
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if store.lastWrite.Effect != assignmentstore.EffectGrant {
+		t.Errorf("write.Effect = %s, want GRANT", store.lastWrite.Effect)
+	}
+	if store.lastWrite.Reason != "temporary clinical cover" {
+		t.Errorf("write.Reason = %q, want the request's reason", store.lastWrite.Reason)
+	}
+	if !store.lastWrite.ValidFrom.Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("write.ValidFrom = %s, want 2026-01-01", store.lastWrite.ValidFrom)
+	}
+	if !store.lastWrite.ValidUntil.Equal(time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("write.ValidUntil = %s, want 2026-12-31", store.lastWrite.ValidUntil)
+	}
+}
+
+// Setting INHERIT must clear any existing override row so the role result
+// applies unmodified (AC "Setting INHERIT removes or disables the override
+// row and the role result applies").
+func TestSaveInheritClearsTheOverrideAndTheRoleResultApplies(t *testing.T) {
+	store := newFakeStore()
+	store.rolePermissions = []assignmentstore.RolePermission{
+		{Key: assignmentstore.RolePermissionKey{TenantID: "tenant-a", RoleExternalID: "role-doctor", ResourceKey: "patient_record", ActionKey: "read"}, Enabled: true},
+	}
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	// Seed an existing REVOKE, then clear it with INHERIT.
+	store.overrides[overrideKeyString(assignmentstore.UserOverrideKey{
+		TenantID: "tenant-a", HospitalID: "hospital-1", UserExternalID: "user-1",
+		ResourceKey: "patient_record", ActionKey: "read",
+	})] = assignmentstore.UserOverride{Effect: assignmentstore.EffectRevoke, Enabled: true, Revision: 1}
+	store.revisions["tenant-a"] = 1
+
+	req := saveRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 1,
+		"resourceKey":      "patient_record",
+		"actionKey":        "read",
+		"effect":           "INHERIT",
+		"roleExternalIds":  []string{"role-doctor"},
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if store.lastWrite.Effect != "" {
+		t.Errorf("write.Effect = %q, want the zero value for INHERIT", store.lastWrite.Effect)
+	}
+	body := decodeResponse(t, rec)
+	if body["effectiveResult"] != true {
+		t.Errorf("effectiveResult = %v, want true (the role result applies)", body["effectiveResult"])
+	}
+
+	if _, found, _ := getOverride(store, "tenant-a", "hospital-1", "user-1", "patient_record", "read"); found {
+		t.Error("the override row still exists after an INHERIT save")
+	}
+}
+
+func getOverride(store *fakeStore, tenant, hospital, user, resource, action string) (assignmentstore.UserOverride, bool, error) {
+	override, found := store.overrides[overrideKeyString(assignmentstore.UserOverrideKey{
+		TenantID: tenant, HospitalID: hospital, UserExternalID: user,
+		ResourceKey: resource, ActionKey: action,
+	})]
+	return override, found, nil
+}
+
+// A GRANT or REVOKE with no reason must be rejected before any write (AC
+// "An override without a reason is rejected").
+func TestSaveRejectsAGrantWithNoReason(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := saveRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 0,
+		"resourceKey":      "patient_record",
+		"actionKey":        "read",
+		"effect":           "GRANT",
+		"validFrom":        "2026-01-01T00:00:00Z",
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if store.revisions["tenant-a"] != 0 {
+		t.Error("a write happened despite the missing reason")
+	}
+}
+
+// A high-risk action with no ValidUntil must default to a bounded expiry
+// rather than being left unbounded (AC "A high-risk action without an
+// expiry defaults to a bounded expiry rather than being unbounded").
+func TestSaveDefaultsAHighRiskActionWithNoExpiryToABoundedExpiry(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog("patient_record:delete")
+	handler := newHandler(store, catalog)
+	handler.DefaultHighRiskValidity = 30 * 24 * time.Hour
+
+	req := saveRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 0,
+		"resourceKey":      "patient_record",
+		"actionKey":        "delete",
+		"effect":           "GRANT",
+		"reason":           "one-off cleanup task",
+		"validFrom":        "2026-01-01T00:00:00Z",
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	want := time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
+	if !store.lastWrite.ValidUntil.Equal(want) {
+		t.Errorf("write.ValidUntil = %s, want %s (validFrom + the bounded default)", store.lastWrite.ValidUntil, want)
+	}
+}
+
+// A non-high-risk action with no ValidUntil must stay unbounded: the
+// default only applies to the actions the operator has named as high-risk.
+func TestSaveLeavesANonHighRiskGrantWithNoExpiryUnbounded(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := saveRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 0,
+		"resourceKey":      "patient_record",
+		"actionKey":        "read",
+		"effect":           "GRANT",
+		"reason":           "ongoing cover",
+		"validFrom":        "2026-01-01T00:00:00Z",
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if !store.lastWrite.ValidUntil.IsZero() {
+		t.Errorf("write.ValidUntil = %s, want unbounded (zero)", store.lastWrite.ValidUntil)
+	}
+}
+
+// The response must report both the underlying role result and the
+// resulting effective result (AC "The response reports both the role
+// result and the effective result").
+func TestSaveResponseReportsBothTheRoleResultAndTheEffectiveResult(t *testing.T) {
+	store := newFakeStore()
+	store.rolePermissions = []assignmentstore.RolePermission{
+		{Key: assignmentstore.RolePermissionKey{TenantID: "tenant-a", RoleExternalID: "role-doctor", ResourceKey: "patient_record", ActionKey: "delete"}, Enabled: true},
+	}
+	catalog := newFakeCatalog("patient_record:delete")
+	handler := newHandler(store, catalog)
+
+	req := saveRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 0,
+		"resourceKey":      "patient_record",
+		"actionKey":        "delete",
+		"effect":           "REVOKE",
+		"reason":           "clinician under investigation",
+		"validFrom":        "2026-01-01T00:00:00Z",
+		"roleExternalIds":  []string{"role-doctor"},
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	body := decodeResponse(t, rec)
+	if body["roleResult"] != true {
+		t.Errorf("roleResult = %v, want true (role-doctor grants delete)", body["roleResult"])
+	}
+	if body["effectiveResult"] != false {
+		t.Errorf("effectiveResult = %v, want false (REVOKE defeats the role grant)", body["effectiveResult"])
+	}
+}
+
+// An override that merely duplicates the existing role result must be
+// flagged as having no practical effect (AC "An override duplicating the
+// existing role result is flagged as having no practical effect").
+func TestSaveFlagsAGrantThatDuplicatesAnExistingRoleGrant(t *testing.T) {
+	store := newFakeStore()
+	store.rolePermissions = []assignmentstore.RolePermission{
+		{Key: assignmentstore.RolePermissionKey{TenantID: "tenant-a", RoleExternalID: "role-doctor", ResourceKey: "patient_record", ActionKey: "read"}, Enabled: true},
+	}
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := saveRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 0,
+		"resourceKey":      "patient_record",
+		"actionKey":        "read",
+		"effect":           "GRANT",
+		"reason":           "belt and suspenders",
+		"validFrom":        "2026-01-01T00:00:00Z",
+		"roleExternalIds":  []string{"role-doctor"},
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	body := decodeResponse(t, rec)
+	if body["noPracticalEffect"] != true {
+		t.Errorf("noPracticalEffect = %v, want true (the grant duplicates the role result)", body["noPracticalEffect"])
+	}
+}
+
+// A REVOKE that defeats an existing role grant is not a no-op.
+func TestSaveDoesNotFlagARevokeThatActuallyChangesTheOutcome(t *testing.T) {
+	store := newFakeStore()
+	store.rolePermissions = []assignmentstore.RolePermission{
+		{Key: assignmentstore.RolePermissionKey{TenantID: "tenant-a", RoleExternalID: "role-doctor", ResourceKey: "patient_record", ActionKey: "read"}, Enabled: true},
+	}
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := saveRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 0,
+		"resourceKey":      "patient_record",
+		"actionKey":        "read",
+		"effect":           "REVOKE",
+		"reason":           "actually removes access",
+		"validFrom":        "2026-01-01T00:00:00Z",
+		"roleExternalIds":  []string{"role-doctor"},
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	body := decodeResponse(t, rec)
+	if body["noPracticalEffect"] != false {
+		t.Errorf("noPracticalEffect = %v, want false (the revoke changes the outcome)", body["noPracticalEffect"])
+	}
+}
+
+// Overrides are hospital-scoped: a token scoped to a different hospital
+// must be refused (AC "Overrides are hospital-scoped and cannot be written
+// across tenant or hospital authority").
+func TestSaveRejectsAWriteAcrossHospitalAuthority(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := saveRequest(t, adminOf("tenant-a", "hospital-2"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 0,
+		"resourceKey":      "patient_record",
+		"actionKey":        "read",
+		"effect":           "GRANT",
+		"reason":           "should never reach the store",
+		"validFrom":        "2026-01-01T00:00:00Z",
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
+	if store.revisions["tenant-a"] != 0 {
+		t.Error("a write happened despite the hospital mismatch")
+	}
+}
+
+// Overrides are hospital-scoped: a token scoped to a different tenant must
+// also be refused, even for a matching hospital id.
+func TestSaveRejectsAWriteAcrossTenantAuthority(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := saveRequest(t, adminOf("tenant-b", "hospital-1"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 0,
+		"resourceKey":      "patient_record",
+		"actionKey":        "read",
+		"effect":           "GRANT",
+		"reason":           "should never reach the store",
+		"validFrom":        "2026-01-01T00:00:00Z",
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// A stale expected revision must be reported as a conflict, with nothing
+// written.
+func TestSaveReportsAConflictOnAStaleExpectedRevision(t *testing.T) {
+	store := newFakeStore()
+	store.revisions["tenant-a"] = 1
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := saveRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 0,
+		"resourceKey":      "patient_record",
+		"actionKey":        "read",
+		"effect":           "GRANT",
+		"reason":           "stale",
+		"validFrom":        "2026-01-01T00:00:00Z",
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// The outbox payload must carry a PermissionChanged event a consumer can
+// invalidate from directly, scoped to the user (§10.2).
+func TestSaveAppendsAPermissionChangedEventScopedToTheUser(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	req := saveRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", map[string]any{
+		"expectedRevision": 0,
+		"resourceKey":      "patient_record",
+		"actionKey":        "read",
+		"effect":           "REVOKE",
+		"reason":           "policy violation",
+		"validFrom":        "2026-01-01T00:00:00Z",
+	})
+	rec := httptest.NewRecorder()
+	handler.Save(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var events []permissionevents.PermissionChanged
+	if err := json.Unmarshal([]byte(store.lastWrite.Outbox.Payload), &events); err != nil {
+		t.Fatalf("decoding the outbox payload %q: %v", store.lastWrite.Outbox.Payload, err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	event := events[0]
+	if event.SubjectType != permissionevents.SubjectUser || event.SubjectID != "user-1" {
+		t.Errorf("event subject = %s/%s, want USER/user-1", event.SubjectType, event.SubjectID)
+	}
+	if event.TenantID != "tenant-a" || event.HospitalID != "hospital-1" {
+		t.Errorf("event scope = %s/%s, want tenant-a/hospital-1", event.TenantID, event.HospitalID)
+	}
+	if event.Enabled {
+		t.Error("event.Enabled = true, want false for a REVOKE with no surviving role grant")
+	}
+}
+
+// Read must return the active overrides for the named resource, and must
+// not return an override outside its validity window (AC "An expired
+// override stops taking effect without any further administrative
+// action").
+func TestReadReturnsActiveOverridesAndExcludesAnExpiredOne(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog()
+	handler := newHandler(store, catalog)
+
+	store.overrides["live"] = assignmentstore.UserOverride{
+		Key: assignmentstore.UserOverrideKey{
+			TenantID: "tenant-a", HospitalID: "hospital-1", UserExternalID: "user-1",
+			ResourceKey: "patient_record", ActionKey: "read", ResourceInstanceID: assignmentstore.NoResourceInstance,
+		},
+		Effect: assignmentstore.EffectGrant, Enabled: true,
+		ValidFrom: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Revision:  1, Reason: "ongoing cover",
+	}
+	store.overrides["expired"] = assignmentstore.UserOverride{
+		Key: assignmentstore.UserOverrideKey{
+			TenantID: "tenant-a", HospitalID: "hospital-1", UserExternalID: "user-1",
+			ResourceKey: "patient_record", ActionKey: "update", ResourceInstanceID: assignmentstore.NoResourceInstance,
+		},
+		Effect: assignmentstore.EffectGrant, Enabled: true,
+		ValidFrom:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		ValidUntil: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		Revision:   1, Reason: "expired long ago",
+	}
+
+	req := readRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", "patient_record")
+	rec := httptest.NewRecorder()
+	handler.Read(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	body := decodeResponse(t, rec)
+	overrides, ok := body["overrides"].([]any)
+	if !ok {
+		t.Fatalf("overrides is not a list: %v", body["overrides"])
+	}
+	if len(overrides) != 1 {
+		t.Fatalf("got %d overrides, want 1 (the expired one excluded)", len(overrides))
+	}
+	first := overrides[0].(map[string]any)
+	if first["actionKey"] != "read" {
+		t.Errorf("actionKey = %v, want read", first["actionKey"])
+	}
+}
+
+// Read must reject a request naming no resource.
+func TestReadRejectsARequestWithNoResourceParameter(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog()
+	handler := newHandler(store, catalog)
+
+	req := readRequest(t, adminOf("tenant-a", "hospital-1"), "tenant-a", "hospital-1", "user-1", "")
+	rec := httptest.NewRecorder()
+	handler.Read(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/deploy/liquibase/changelog/tables/009-user-override-reason.yaml
+++ b/deploy/liquibase/changelog/tables/009-user-override-reason.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 009-user-override-reason
+      author: cerbos-poc
+      comment: >-
+        A mandatory administrative reason for every GRANT or REVOKE (§9.3:
+        "Require ... reason"). Nullable at the schema level because INHERIT
+        clears the row rather than storing one; the administration service
+        rejects a GRANT or REVOKE with no reason before any write.
+      changes:
+        - addColumn:
+            tableName: user_permission_override
+            columns:
+              - column:
+                  name: reason
+                  type: VARCHAR(512)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,6 +198,10 @@ services:
       AUTHORIZATION_CATALOG_DIR: "/authorization-catalog"
       KAFKA_BROKERS: "redpanda:9092"
       KAFKA_PERMISSION_CHANGED_TOPIC: "${KAFKA_PERMISSION_CHANGED_TOPIC:-permission-changed}"
+      # §9.3: high-risk actions default to a bounded expiry when a GRANT or
+      # REVOKE names none, rather than being left unbounded (issue #15).
+      USER_OVERRIDE_HIGH_RISK_ACTIONS: "${USER_OVERRIDE_HIGH_RISK_ACTIONS:-update,delete,assign}"
+      USER_OVERRIDE_HIGH_RISK_VALIDITY: "${USER_OVERRIDE_HIGH_RISK_VALIDITY:-2160h}"
     volumes:
       - ./deploy/secrets/idp-admin-credentials:/run/secrets/idp-admin-credentials:ro
       - ./deploy/cerbos/catalog/resources:/authorization-catalog:ro

--- a/libs/assignmentstore/oraclestore/oraclestore.go
+++ b/libs/assignmentstore/oraclestore/oraclestore.go
@@ -208,20 +208,21 @@ func (s *Store) SaveUserOverride(ctx context.Context, override assignmentstore.U
 		    AND t.resource_key = s.resource_key AND t.action_key = s.action_key
 		    AND t.resource_instance_id = s.resource_instance_id)
 		WHEN MATCHED THEN UPDATE SET
-			effect = :7, enabled = :8, valid_from = :9, valid_until = :10, revision = :11
+			effect = :7, enabled = :8, valid_from = :9, valid_until = :10, revision = :11, reason = :12
 		WHEN NOT MATCHED THEN INSERT (
 			tenant_id, hospital_id, user_external_id, resource_key, action_key,
-			resource_instance_id, effect, enabled, valid_from, valid_until, revision)
+			resource_instance_id, effect, enabled, valid_from, valid_until, revision, reason)
 		VALUES (s.tenant_id, s.hospital_id, s.user_external_id, s.resource_key,
-			s.action_key, s.resource_instance_id, :12, :13, :14, :15, :16)`
+			s.action_key, s.resource_instance_id, :13, :14, :15, :16, :17, :18)`
 
 	key := assignmentstore.NormalizeOverrideKey(override.Key)
 	enabled := boolToNumber(override.Enabled)
+	reason := nullableString(override.Reason)
 	_, err := s.db.ExecContext(ctx, statement,
 		key.TenantID, key.HospitalID, key.UserExternalID, key.ResourceKey,
 		key.ActionKey, key.ResourceInstanceID,
-		string(override.Effect), enabled, override.ValidFrom, override.ValidUntil, override.Revision,
-		string(override.Effect), enabled, override.ValidFrom, override.ValidUntil, override.Revision)
+		string(override.Effect), enabled, override.ValidFrom, override.ValidUntil, override.Revision, reason,
+		string(override.Effect), enabled, override.ValidFrom, override.ValidUntil, override.Revision, reason)
 	if err != nil {
 		return fmt.Errorf("oraclestore: saving a user override: %w", err)
 	}
@@ -231,7 +232,7 @@ func (s *Store) SaveUserOverride(ctx context.Context, override assignmentstore.U
 // UserOverride reads one override by its §8.2 key.
 func (s *Store) UserOverride(ctx context.Context, key assignmentstore.UserOverrideKey) (assignmentstore.UserOverride, bool, error) {
 	const query = `
-		SELECT effect, enabled, valid_from, valid_until, revision
+		SELECT effect, enabled, valid_from, valid_until, revision, reason
 		FROM user_permission_override
 		WHERE tenant_id = :1 AND hospital_id = :2 AND user_external_id = :3
 		  AND resource_key = :4 AND action_key = :5 AND resource_instance_id = :6`
@@ -240,10 +241,12 @@ func (s *Store) UserOverride(ctx context.Context, key assignmentstore.UserOverri
 	override := assignmentstore.UserOverride{Key: key}
 	var effect string
 	var enabled int64
+	var validUntil *time.Time
+	var reason *string
 	err := s.db.QueryRowContext(ctx, query,
 		key.TenantID, key.HospitalID, key.UserExternalID, key.ResourceKey,
 		key.ActionKey, key.ResourceInstanceID).
-		Scan(&effect, &enabled, &override.ValidFrom, &override.ValidUntil, &override.Revision)
+		Scan(&effect, &enabled, &override.ValidFrom, &validUntil, &override.Revision, &reason)
 	if errors.Is(err, sql.ErrNoRows) {
 		return assignmentstore.UserOverride{}, false, nil
 	}
@@ -252,7 +255,22 @@ func (s *Store) UserOverride(ctx context.Context, key assignmentstore.UserOverri
 	}
 	override.Effect = assignmentstore.OverrideEffect(effect)
 	override.Enabled = enabled != 0
+	if validUntil != nil {
+		override.ValidUntil = *validUntil
+	}
+	if reason != nil {
+		override.Reason = *reason
+	}
 	return override, true, nil
+}
+
+// nullableString turns an empty string into a genuine SQL NULL, mirroring
+// postgresstore's helper of the same name (see there for why).
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
 }
 
 // ActiveUserOverrides reads every override in force for one principal and one
@@ -268,7 +286,7 @@ func (s *Store) ActiveUserOverrides(ctx context.Context, query assignmentstore.A
 	}
 
 	const statement = `
-		SELECT action_key, resource_instance_id, effect, enabled, valid_from, valid_until, revision
+		SELECT action_key, resource_instance_id, effect, enabled, valid_from, valid_until, revision, reason
 		FROM user_permission_override
 		WHERE tenant_id = :1
 		  AND hospital_id = :2
@@ -297,14 +315,18 @@ func (s *Store) ActiveUserOverrides(ctx context.Context, query assignmentstore.A
 		var effect string
 		var enabled int64
 		var validUntil *time.Time
+		var reason *string
 		if err := rows.Scan(&override.Key.ActionKey, &override.Key.ResourceInstanceID,
-			&effect, &enabled, &override.ValidFrom, &validUntil, &override.Revision); err != nil {
+			&effect, &enabled, &override.ValidFrom, &validUntil, &override.Revision, &reason); err != nil {
 			return nil, fmt.Errorf("oraclestore: scanning a user override: %w", err)
 		}
 		override.Effect = assignmentstore.OverrideEffect(effect)
 		override.Enabled = enabled != 0
 		if validUntil != nil {
 			override.ValidUntil = *validUntil
+		}
+		if reason != nil {
+			override.Reason = *reason
 		}
 		overrides = append(overrides, override)
 	}
@@ -563,6 +585,112 @@ func (s *Store) SaveRoleMatrix(ctx context.Context, write assignmentstore.RoleMa
 
 	if err := tx.Commit(); err != nil {
 		return 0, fmt.Errorf("oraclestore: committing the role matrix transaction: %w", err)
+	}
+	return newRevision, nil
+}
+
+// SaveUserOverrideWrite atomically applies one tri-state change to a user
+// override (§9.3, §9.4, §10.1). See SaveRoleMatrix for why the revision row
+// is seeded before it is locked.
+func (s *Store) SaveUserOverrideWrite(ctx context.Context, write assignmentstore.UserOverrideWrite) (int64, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("oraclestore: beginning the user override transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		MERGE INTO permission_revision t
+		USING (SELECT :1 AS tenant_id FROM dual) s
+		ON (t.tenant_id = s.tenant_id)
+		WHEN NOT MATCHED THEN INSERT (tenant_id, revision, changed_at)
+		VALUES (s.tenant_id, 0, :2)`,
+		write.Key.TenantID, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("oraclestore: seeding the permission revision: %w", err)
+	}
+
+	var current int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT revision FROM permission_revision WHERE tenant_id = :1 FOR UPDATE`,
+		write.Key.TenantID).Scan(&current); err != nil {
+		return 0, fmt.Errorf("oraclestore: locking the permission revision: %w", err)
+	}
+	if current != write.ExpectedRevision {
+		return 0, assignmentstore.ErrRevisionConflict
+	}
+
+	newRevision := current + 1
+	key := assignmentstore.NormalizeOverrideKey(write.Key)
+	if write.Effect == "" {
+		// INHERIT: the override row is cleared rather than upserted (§8.3).
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM user_permission_override
+			WHERE tenant_id = :1 AND hospital_id = :2 AND user_external_id = :3
+			  AND resource_key = :4 AND action_key = :5 AND resource_instance_id = :6`,
+			key.TenantID, key.HospitalID, key.UserExternalID, key.ResourceKey,
+			key.ActionKey, key.ResourceInstanceID); err != nil {
+			return 0, fmt.Errorf("oraclestore: clearing a user override: %w", err)
+		}
+	} else {
+		enabled := boolToNumber(true)
+		validUntil := endOrNull(write.ValidUntil)
+		reason := nullableString(write.Reason)
+		if _, err := tx.ExecContext(ctx, `
+			MERGE INTO user_permission_override t
+			USING (SELECT :1 AS tenant_id, :2 AS hospital_id, :3 AS user_external_id,
+			              :4 AS resource_key, :5 AS action_key,
+			              :6 AS resource_instance_id FROM dual) s
+			ON (t.tenant_id = s.tenant_id AND t.hospital_id = s.hospital_id
+			    AND t.user_external_id = s.user_external_id
+			    AND t.resource_key = s.resource_key AND t.action_key = s.action_key
+			    AND t.resource_instance_id = s.resource_instance_id)
+			WHEN MATCHED THEN UPDATE SET
+				effect = :7, enabled = :8, valid_from = :9, valid_until = :10, revision = :11, reason = :12
+			WHEN NOT MATCHED THEN INSERT (
+				tenant_id, hospital_id, user_external_id, resource_key, action_key,
+				resource_instance_id, effect, enabled, valid_from, valid_until, revision, reason)
+			VALUES (s.tenant_id, s.hospital_id, s.user_external_id, s.resource_key,
+				s.action_key, s.resource_instance_id, :13, :14, :15, :16, :17, :18)`,
+			key.TenantID, key.HospitalID, key.UserExternalID, key.ResourceKey,
+			key.ActionKey, key.ResourceInstanceID,
+			string(write.Effect), enabled, write.ValidFrom, validUntil, newRevision, reason,
+			string(write.Effect), enabled, write.ValidFrom, validUntil, newRevision, reason); err != nil {
+			return 0, fmt.Errorf("oraclestore: writing a user override: %w", err)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO permission_audit_event (
+			event_id, actor_id, operation, target_type, before_json, after_json,
+			tenant_id, hospital_id, correlation_id, created_at)
+		VALUES (:1, :2, :3, :4, :5, :6, :7, :8, :9, :10)`,
+		write.Audit.EventID, write.Audit.ActorID, write.Audit.Operation, write.Audit.TargetType,
+		write.Audit.BeforeJSON, write.Audit.AfterJSON, key.TenantID, key.HospitalID,
+		write.Audit.CorrelationID, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("oraclestore: appending the audit event: %w", err)
+	}
+
+	var publishedAt any
+	if write.Outbox.PublishedAt != nil {
+		publishedAt = *write.Outbox.PublishedAt
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO outbox_event (
+			event_id, aggregate_key, event_type, payload, created_at, published_at)
+		VALUES (:1, :2, :3, :4, :5, :6)`,
+		write.Outbox.EventID, write.Outbox.AggregateKey, write.Outbox.EventType,
+		write.Outbox.Payload, write.Outbox.CreatedAt, publishedAt); err != nil {
+		return 0, fmt.Errorf("oraclestore: appending the outbox event: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE permission_revision SET revision = :2, changed_at = :3 WHERE tenant_id = :1`,
+		key.TenantID, newRevision, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("oraclestore: advancing the permission revision: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("oraclestore: committing the user override transaction: %w", err)
 	}
 	return newRevision, nil
 }

--- a/libs/assignmentstore/postgresstore/postgresstore.go
+++ b/libs/assignmentstore/postgresstore/postgresstore.go
@@ -164,8 +164,8 @@ func (s *Store) SaveUserOverride(ctx context.Context, override assignmentstore.U
 	const statement = `
 		INSERT INTO user_permission_override (
 			tenant_id, hospital_id, user_external_id, resource_key, action_key,
-			resource_instance_id, effect, enabled, valid_from, valid_until, revision)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			resource_instance_id, effect, enabled, valid_from, valid_until, revision, reason)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		ON CONFLICT (tenant_id, hospital_id, user_external_id, resource_key,
 			action_key, resource_instance_id)
 		DO UPDATE SET
@@ -173,13 +173,15 @@ func (s *Store) SaveUserOverride(ctx context.Context, override assignmentstore.U
 			enabled = EXCLUDED.enabled,
 			valid_from = EXCLUDED.valid_from,
 			valid_until = EXCLUDED.valid_until,
-			revision = EXCLUDED.revision`
+			revision = EXCLUDED.revision,
+			reason = EXCLUDED.reason`
 
 	key := assignmentstore.NormalizeOverrideKey(override.Key)
 	_, err := s.pool.Exec(ctx, statement,
 		key.TenantID, key.HospitalID, key.UserExternalID, key.ResourceKey,
 		key.ActionKey, key.ResourceInstanceID, string(override.Effect),
-		override.Enabled, override.ValidFrom, override.ValidUntil, override.Revision)
+		override.Enabled, override.ValidFrom, override.ValidUntil, override.Revision,
+		nullableString(override.Reason))
 	if err != nil {
 		return fmt.Errorf("postgresstore: saving a user override: %w", err)
 	}
@@ -189,7 +191,7 @@ func (s *Store) SaveUserOverride(ctx context.Context, override assignmentstore.U
 // UserOverride reads one override by its §8.2 key.
 func (s *Store) UserOverride(ctx context.Context, key assignmentstore.UserOverrideKey) (assignmentstore.UserOverride, bool, error) {
 	const query = `
-		SELECT effect, enabled, valid_from, valid_until, revision
+		SELECT effect, enabled, valid_from, valid_until, revision, reason
 		FROM user_permission_override
 		WHERE tenant_id = $1 AND hospital_id = $2 AND user_external_id = $3
 		  AND resource_key = $4 AND action_key = $5 AND resource_instance_id = $6`
@@ -197,10 +199,12 @@ func (s *Store) UserOverride(ctx context.Context, key assignmentstore.UserOverri
 	key = assignmentstore.NormalizeOverrideKey(key)
 	override := assignmentstore.UserOverride{Key: key}
 	var effect string
+	var validUntil *time.Time
+	var reason *string
 	err := s.pool.QueryRow(ctx, query,
 		key.TenantID, key.HospitalID, key.UserExternalID, key.ResourceKey,
 		key.ActionKey, key.ResourceInstanceID).
-		Scan(&effect, &override.Enabled, &override.ValidFrom, &override.ValidUntil, &override.Revision)
+		Scan(&effect, &override.Enabled, &override.ValidFrom, &validUntil, &override.Revision, &reason)
 	if isNoRows(err) {
 		return assignmentstore.UserOverride{}, false, nil
 	}
@@ -208,7 +212,25 @@ func (s *Store) UserOverride(ctx context.Context, key assignmentstore.UserOverri
 		return assignmentstore.UserOverride{}, false, fmt.Errorf("postgresstore: reading a user override: %w", err)
 	}
 	override.Effect = assignmentstore.OverrideEffect(effect)
+	if validUntil != nil {
+		override.ValidUntil = *validUntil
+	}
+	if reason != nil {
+		override.Reason = *reason
+	}
 	return override, true, nil
+}
+
+// nullableString turns an empty string into a genuine SQL NULL rather than
+// storing "" - reason is absent for INHERIT and for rows SaveUserOverride
+// seeds directly, and a NULL is what a later SELECT tells apart from an
+// administrator who wrote an empty-but-present reason, if that ever became
+// something worth distinguishing.
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
 }
 
 // ActiveUserOverrides reads every override in force for one principal and one
@@ -226,7 +248,7 @@ func (s *Store) ActiveUserOverrides(ctx context.Context, query assignmentstore.A
 	}
 
 	const statement = `
-		SELECT action_key, resource_instance_id, effect, enabled, valid_from, valid_until, revision
+		SELECT action_key, resource_instance_id, effect, enabled, valid_from, valid_until, revision, reason
 		FROM user_permission_override
 		WHERE tenant_id = $1
 		  AND hospital_id = $2
@@ -254,13 +276,17 @@ func (s *Store) ActiveUserOverrides(ctx context.Context, query assignmentstore.A
 		}
 		var effect string
 		var validUntil *time.Time
+		var reason *string
 		if err := rows.Scan(&override.Key.ActionKey, &override.Key.ResourceInstanceID,
-			&effect, &override.Enabled, &override.ValidFrom, &validUntil, &override.Revision); err != nil {
+			&effect, &override.Enabled, &override.ValidFrom, &validUntil, &override.Revision, &reason); err != nil {
 			return nil, fmt.Errorf("postgresstore: scanning a user override: %w", err)
 		}
 		override.Effect = assignmentstore.OverrideEffect(effect)
 		if validUntil != nil {
 			override.ValidUntil = *validUntil
+		}
+		if reason != nil {
+			override.Reason = *reason
 		}
 		overrides = append(overrides, override)
 	}
@@ -502,6 +528,100 @@ func (s *Store) SaveRoleMatrix(ctx context.Context, write assignmentstore.RoleMa
 
 	if err := tx.Commit(ctx); err != nil {
 		return 0, fmt.Errorf("postgresstore: committing the role matrix transaction: %w", err)
+	}
+	return newRevision, nil
+}
+
+// SaveUserOverrideWrite atomically applies one tri-state change to a user
+// override (§9.3, §9.4, §10.1). See SaveRoleMatrix for why the revision row
+// is seeded before it is locked.
+func (s *Store) SaveUserOverrideWrite(ctx context.Context, write assignmentstore.UserOverrideWrite) (int64, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("postgresstore: beginning the user override transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO permission_revision (tenant_id, revision, changed_at)
+		VALUES ($1, 0, $2)
+		ON CONFLICT (tenant_id) DO NOTHING`,
+		write.Key.TenantID, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("postgresstore: seeding the permission revision: %w", err)
+	}
+
+	var current int64
+	if err := tx.QueryRow(ctx, `
+		SELECT revision FROM permission_revision WHERE tenant_id = $1 FOR UPDATE`,
+		write.Key.TenantID).Scan(&current); err != nil {
+		return 0, fmt.Errorf("postgresstore: locking the permission revision: %w", err)
+	}
+	if current != write.ExpectedRevision {
+		return 0, assignmentstore.ErrRevisionConflict
+	}
+
+	newRevision := current + 1
+	key := assignmentstore.NormalizeOverrideKey(write.Key)
+	if write.Effect == "" {
+		// INHERIT: the override row is cleared rather than upserted (§8.3).
+		if _, err := tx.Exec(ctx, `
+			DELETE FROM user_permission_override
+			WHERE tenant_id = $1 AND hospital_id = $2 AND user_external_id = $3
+			  AND resource_key = $4 AND action_key = $5 AND resource_instance_id = $6`,
+			key.TenantID, key.HospitalID, key.UserExternalID, key.ResourceKey,
+			key.ActionKey, key.ResourceInstanceID); err != nil {
+			return 0, fmt.Errorf("postgresstore: clearing a user override: %w", err)
+		}
+	} else {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO user_permission_override (
+				tenant_id, hospital_id, user_external_id, resource_key, action_key,
+				resource_instance_id, effect, enabled, valid_from, valid_until, revision, reason)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+			ON CONFLICT (tenant_id, hospital_id, user_external_id, resource_key,
+				action_key, resource_instance_id)
+			DO UPDATE SET
+				effect = EXCLUDED.effect,
+				enabled = EXCLUDED.enabled,
+				valid_from = EXCLUDED.valid_from,
+				valid_until = EXCLUDED.valid_until,
+				revision = EXCLUDED.revision,
+				reason = EXCLUDED.reason`,
+			key.TenantID, key.HospitalID, key.UserExternalID, key.ResourceKey,
+			key.ActionKey, key.ResourceInstanceID, string(write.Effect), true,
+			write.ValidFrom, endOrNull(write.ValidUntil), newRevision, nullableString(write.Reason)); err != nil {
+			return 0, fmt.Errorf("postgresstore: writing a user override: %w", err)
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO permission_audit_event (
+			event_id, actor_id, operation, target_type, before_json, after_json,
+			tenant_id, hospital_id, correlation_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		write.Audit.EventID, write.Audit.ActorID, write.Audit.Operation, write.Audit.TargetType,
+		write.Audit.BeforeJSON, write.Audit.AfterJSON, key.TenantID, key.HospitalID,
+		write.Audit.CorrelationID, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("postgresstore: appending the audit event: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO outbox_event (
+			event_id, aggregate_key, event_type, payload, created_at, published_at)
+		VALUES ($1, $2, $3, $4, $5, $6)`,
+		write.Outbox.EventID, write.Outbox.AggregateKey, write.Outbox.EventType,
+		write.Outbox.Payload, write.Outbox.CreatedAt, write.Outbox.PublishedAt); err != nil {
+		return 0, fmt.Errorf("postgresstore: appending the outbox event: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE permission_revision SET revision = $2, changed_at = $3 WHERE tenant_id = $1`,
+		key.TenantID, newRevision, write.Audit.CreatedAt); err != nil {
+		return 0, fmt.Errorf("postgresstore: advancing the permission revision: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("postgresstore: committing the user override transaction: %w", err)
 	}
 	return newRevision, nil
 }

--- a/libs/assignmentstore/store.go
+++ b/libs/assignmentstore/store.go
@@ -93,6 +93,11 @@ type UserOverride struct {
 	ValidFrom  time.Time
 	ValidUntil time.Time
 	Revision   int64
+	// Reason is the mandatory administrative justification for a GRANT or
+	// REVOKE (§9.3). Empty for rows SaveUserOverride writes directly - the
+	// bulk-seeding path (issue #24) has no administrator behind it - but
+	// SaveUserOverrideWrite refuses to write a GRANT or REVOKE without one.
+	Reason string
 }
 
 // ActiveUserOverridesQuery asks for the user overrides in force for one
@@ -186,6 +191,29 @@ type RoleMatrixWrite struct {
 // when ExpectedRevision no longer matches the tenant's stored permission
 // revision (§10.1).
 var ErrRevisionConflict = errors.New("assignmentstore: expected revision is stale")
+
+// UserOverrideWrite is the input to SaveUserOverrideWrite: one tri-state
+// change to a single user override, plus the audit event and outbox event
+// that must commit with it (§9.3, §9.4, §10.1).
+type UserOverrideWrite struct {
+	Key UserOverrideKey
+	// Effect is EffectGrant or EffectRevoke to persist a GRANT or REVOKE.
+	// The zero value means INHERIT: SaveUserOverrideWrite clears any
+	// existing row for Key rather than upserting one, because INHERIT is
+	// the absence of a row (§8.3), not a storable effect.
+	Effect     OverrideEffect
+	Reason     string
+	ValidFrom  time.Time
+	ValidUntil time.Time
+	// ExpectedRevision is the tenant permission revision the caller last
+	// read, the same expected-revision guard SaveRoleMatrix uses (§9.4).
+	ExpectedRevision int64
+	// Audit.TenantID and Audit.HospitalID are ignored; the write always
+	// audits against Key.TenantID and Key.HospitalID so the two can never
+	// disagree.
+	Audit  AuditEvent
+	Outbox OutboxEvent
+}
 
 // Capability is one composite UI capability definition (§8.1).
 type Capability struct {
@@ -301,6 +329,14 @@ type Store interface {
 	// if write.ExpectedRevision no longer matches the tenant's stored
 	// revision.
 	SaveRoleMatrix(ctx context.Context, write RoleMatrixWrite) (newRevision int64, err error)
+
+	// SaveUserOverrideWrite atomically applies one tri-state change to a
+	// user override: the row's upsert (GRANT/REVOKE) or delete (INHERIT),
+	// the audit event, the outbox event and the tenant's permission-revision
+	// bump commit as a single unit or none do (§9.3, §9.4, §10.1, §16.1). It
+	// returns ErrRevisionConflict, with nothing written, if
+	// write.ExpectedRevision no longer matches the tenant's stored revision.
+	SaveUserOverrideWrite(ctx context.Context, write UserOverrideWrite) (newRevision int64, err error)
 
 	SaveCapability(ctx context.Context, capability Capability) error
 	Capability(ctx context.Context, capabilityKey string) (Capability, bool, error)

--- a/libs/assignmentstore/storecontract/contract.go
+++ b/libs/assignmentstore/storecontract/contract.go
@@ -120,6 +120,15 @@ func Run(t *testing.T, newStore Factory) {
 	t.Run("unpublished outbox events are listed oldest first and can be marked published", func(t *testing.T) {
 		assertUnpublishedOutboxEvents(t, newStore(t))
 	})
+	t.Run("SaveUserOverrideWrite commits a GRANT or REVOKE with its audit, outbox and revision together", func(t *testing.T) {
+		assertSaveUserOverrideWriteAtomicSuccess(t, newStore(t))
+	})
+	t.Run("SaveUserOverrideWrite rejects a stale expected revision and writes nothing", func(t *testing.T) {
+		assertSaveUserOverrideWriteStaleRevision(t, newStore(t))
+	})
+	t.Run("SaveUserOverrideWrite with no effect clears an existing override row", func(t *testing.T) {
+		assertSaveUserOverrideWriteInheritClearsTheRow(t, newStore(t))
+	})
 }
 
 // The hot path resolves every role a principal holds at once (§11.2). What that
@@ -1496,6 +1505,180 @@ func assertUnpublishedOutboxEvents(t *testing.T, store assignmentstore.Store) {
 	}
 	if published.PublishedAt == nil {
 		t.Error("publishedAt is still nil after MarkOutboxEventPublished")
+	}
+}
+
+// A successful SaveUserOverrideWrite for a GRANT or REVOKE must leave all
+// four side effects visible: the override row (with its reason), the audit
+// event, the outbox event and the advanced tenant revision (§9.3, §9.4,
+// §10.1) - the same atomicity SaveRoleMatrix gives role permissions.
+func assertSaveUserOverrideWriteAtomicSuccess(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "user_permission_override", "permission_audit_event", "outbox_event", "permission_revision")
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	write := assignmentstore.UserOverrideWrite{
+		Key: assignmentstore.UserOverrideKey{
+			TenantID: "tenant-a", HospitalID: "hospital-1", UserExternalID: "user-1",
+			ResourceKey: "patient_record", ActionKey: "delete",
+		},
+		Effect:           assignmentstore.EffectRevoke,
+		Reason:           "clinician under investigation",
+		ValidFrom:        created.AddDate(-1, 0, 0),
+		ExpectedRevision: 0,
+		Audit: assignmentstore.AuditEvent{
+			EventID:       "audit-override-atomic-1",
+			ActorID:       "admin-1",
+			Operation:     "USER_OVERRIDE_SAVE",
+			TargetType:    "user_permission_override",
+			BeforeJSON:    `{}`,
+			AfterJSON:     `{"patient_record.delete":"REVOKE"}`,
+			CorrelationID: "corr-override-atomic-1",
+			CreatedAt:     created,
+		},
+		Outbox: assignmentstore.OutboxEvent{
+			EventID:      "outbox-override-atomic-1",
+			AggregateKey: "tenant-a:user-1",
+			EventType:    "permission.changed",
+			Payload:      `{"revision":1}`,
+			CreatedAt:    created,
+		},
+	}
+
+	newRevision, err := store.SaveUserOverrideWrite(ctx, write)
+	if err != nil {
+		t.Fatalf("SaveUserOverrideWrite: %v", err)
+	}
+	if newRevision != 1 {
+		t.Errorf("newRevision = %d, want 1", newRevision)
+	}
+
+	override, found, err := store.UserOverride(ctx, write.Key)
+	if err != nil || !found {
+		t.Fatalf("reading the override back: found=%t err=%v", found, err)
+	}
+	if override.Effect != assignmentstore.EffectRevoke || !override.Enabled || override.Revision != 1 {
+		t.Errorf("override = %+v, want REVOKE enabled=true revision=1", override)
+	}
+	if override.Reason != "clinician under investigation" {
+		t.Errorf("override.Reason = %q, want the write's reason", override.Reason)
+	}
+
+	if _, found, err := store.AuditEvent(ctx, "audit-override-atomic-1"); err != nil || !found {
+		t.Fatalf("reading the audit event back: found=%t err=%v", found, err)
+	}
+	if _, found, err := store.OutboxEvent(ctx, "outbox-override-atomic-1"); err != nil || !found {
+		t.Fatalf("reading the outbox event back: found=%t err=%v", found, err)
+	}
+
+	revision, found, err := store.PermissionRevision(ctx, "tenant-a")
+	if err != nil || !found {
+		t.Fatalf("reading the permission revision back: found=%t err=%v", found, err)
+	}
+	if revision.Revision != 1 {
+		t.Errorf("tenant revision = %d, want 1", revision.Revision)
+	}
+}
+
+// A stale ExpectedRevision must fail cleanly and write nothing: not the
+// override, not the audit event, not the outbox event, and the tenant
+// revision must not move - the same guarantee SaveRoleMatrix gives.
+func assertSaveUserOverrideWriteStaleRevision(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "user_permission_override", "permission_audit_event", "outbox_event", "permission_revision")
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	key := assignmentstore.UserOverrideKey{
+		TenantID: "tenant-a", HospitalID: "hospital-1", UserExternalID: "user-2",
+		ResourceKey: "patient_record", ActionKey: "update",
+	}
+	first := assignmentstore.UserOverrideWrite{
+		Key: key, Effect: assignmentstore.EffectGrant, Reason: "temporary cover",
+		ValidFrom: created, ExpectedRevision: 0,
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-stale-1", Operation: "USER_OVERRIDE_SAVE", CreatedAt: created},
+		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-override-stale-1", AggregateKey: "tenant-a:user-2", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
+	}
+	if _, err := store.SaveUserOverrideWrite(ctx, first); err != nil {
+		t.Fatalf("the first write: %v", err)
+	}
+
+	// The tenant is now at revision 1. A second write that still believes
+	// revision 0 is current must be rejected.
+	stale := assignmentstore.UserOverrideWrite{
+		Key: key, Effect: assignmentstore.EffectRevoke, Reason: "changed my mind",
+		ValidFrom: created, ExpectedRevision: 0,
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-stale-2", Operation: "USER_OVERRIDE_SAVE", CreatedAt: created},
+		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-override-stale-2", AggregateKey: "tenant-a:user-2", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
+	}
+	if _, err := store.SaveUserOverrideWrite(ctx, stale); !errors.Is(err, assignmentstore.ErrRevisionConflict) {
+		t.Fatalf("SaveUserOverrideWrite with a stale revision returned %v, want ErrRevisionConflict", err)
+	}
+
+	override, found, err := store.UserOverride(ctx, key)
+	if err != nil || !found {
+		t.Fatalf("reading the override back: found=%t err=%v", found, err)
+	}
+	if override.Effect != assignmentstore.EffectGrant {
+		t.Errorf("override.Effect = %s, want the first write's GRANT to survive the rejected second write", override.Effect)
+	}
+	if _, found, err := store.AuditEvent(ctx, "audit-override-stale-2"); err != nil {
+		t.Fatalf("reading the rejected audit event: %v", err)
+	} else if found {
+		t.Error("the rejected write's audit event was written anyway")
+	}
+	if _, found, err := store.OutboxEvent(ctx, "outbox-override-stale-2"); err != nil {
+		t.Fatalf("reading the rejected outbox event: %v", err)
+	} else if found {
+		t.Error("the rejected write's outbox event was written anyway")
+	}
+}
+
+// SaveUserOverrideWrite with Effect left at its zero value is INHERIT: it
+// must clear an existing row rather than upsert one carrying no effect
+// (§8.3: INHERIT is the absence of a row, not a storable effect), and the
+// role result then applies unmodified.
+func assertSaveUserOverrideWriteInheritClearsTheRow(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "user_permission_override", "permission_audit_event", "outbox_event", "permission_revision")
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	key := assignmentstore.UserOverrideKey{
+		TenantID: "tenant-a", HospitalID: "hospital-1", UserExternalID: "user-3",
+		ResourceKey: "patient_record", ActionKey: "read",
+	}
+	grant := assignmentstore.UserOverrideWrite{
+		Key: key, Effect: assignmentstore.EffectGrant, Reason: "exceptional access",
+		ValidFrom: created, ExpectedRevision: 0,
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-inherit-1", Operation: "USER_OVERRIDE_SAVE", CreatedAt: created},
+		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-override-inherit-1", AggregateKey: "tenant-a:user-3", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
+	}
+	if _, err := store.SaveUserOverrideWrite(ctx, grant); err != nil {
+		t.Fatalf("the grant write: %v", err)
+	}
+
+	inherit := assignmentstore.UserOverrideWrite{
+		Key: key, ExpectedRevision: 1,
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-inherit-2", Operation: "USER_OVERRIDE_SAVE", CreatedAt: created},
+		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-override-inherit-2", AggregateKey: "tenant-a:user-3", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
+	}
+	newRevision, err := store.SaveUserOverrideWrite(ctx, inherit)
+	if err != nil {
+		t.Fatalf("the inherit write: %v", err)
+	}
+	if newRevision != 2 {
+		t.Errorf("newRevision = %d, want 2", newRevision)
+	}
+
+	if _, found, err := store.UserOverride(ctx, key); err != nil {
+		t.Fatalf("reading the cleared override: %v", err)
+	} else if found {
+		t.Error("the override row still exists after an INHERIT write")
 	}
 }
 


### PR DESCRIPTION
## What changed

Implements the administration write path for user-specific overrides (§6.2,
§9.3, §9.4, §10.1): the tri-state INHERIT/GRANT/REVOKE control, carrying the
same transactional and audit guarantees `SaveRoleMatrix` gives the role
matrix.

- **`libs/assignmentstore`**: new `UserOverrideWrite` type and
  `SaveUserOverrideWrite` method on `Store`, implemented for both Postgres
  and Oracle. It atomically applies one tri-state change - a GRANT/REVOKE
  upsert or an INHERIT delete - plus the audit event, the outbox event and
  the tenant's permission-revision bump, using the same expected-revision
  guard `SaveRoleMatrix` uses. `UserOverride` gained a `Reason` field and the
  table gained a nullable `reason` column
  (`deploy/liquibase/changelog/tables/009-user-override-reason.yaml`).
- **`apps/admin-service/internal/useroverride`**: the new handler serving
  `PUT`/`GET /admin/authz/tenants/{t}/hospitals/{h}/users/{u}/overrides`.
- **`docker-compose.yml`**: `USER_OVERRIDE_HIGH_RISK_ACTIONS` and
  `USER_OVERRIDE_HIGH_RISK_VALIDITY` env vars, with defaults matching the
  code's own fallback.

### A pre-existing bug found and fixed along the way

`UserOverride` (the single-row read, on both adapters) scanned `valid_until`
directly into a non-nullable `time.Time`, which fails on any row with no
expiry. `ActiveUserOverrides` already handled this correctly with a
`*time.Time`; `UserOverride` now does the same. Caught by the new
`SaveUserOverrideWrite` contract test, which is the first case in the suite
that read back a row with no expiry through this method.

## Acceptance criteria

- [x] Setting INHERIT removes or disables the override row and the role
      result applies — `SaveUserOverrideWrite` deletes the row when
      `Effect` is empty; `TestSaveInheritClearsTheOverrideAndTheRoleResultApplies`.
- [x] GRANT and REVOKE persist with reason, validity start and optional
      expiry — `TestSaveGrantPersistsWithReasonValidityAndExpiry`.
- [x] An override without a reason is rejected —
      `TestSaveRejectsAGrantWithNoReason`.
- [x] A high-risk action without an expiry defaults to a bounded expiry
      rather than being unbounded —
      `TestSaveDefaultsAHighRiskActionWithNoExpiryToABoundedExpiry` (and
      `TestSaveLeavesANonHighRiskGrantWithNoExpiryUnbounded` for the
      contrast case).
- [x] The response reports both the role result and the effective result —
      `TestSaveResponseReportsBothTheRoleResultAndTheEffectiveResult`.
- [x] An override duplicating the existing role result is flagged as having
      no practical effect —
      `TestSaveFlagsAGrantThatDuplicatesAnExistingRoleGrant` (and
      `TestSaveDoesNotFlagARevokeThatActuallyChangesTheOutcome` for the
      contrast case).
- [x] Overrides are hospital-scoped and cannot be written across tenant or
      hospital authority — `TestSaveRejectsAWriteAcrossHospitalAuthority`,
      `TestSaveRejectsAWriteAcrossTenantAuthority`.
- [x] Assignment, audit, revision and outbox commit atomically —
      `assertSaveUserOverrideWriteAtomicSuccess` and
      `assertSaveUserOverrideWriteStaleRevision` in the store contract
      suite, run against live PostgreSQL (see Verification).
- [x] An expired override stops taking effect without any further
      administrative action —
      `TestReadReturnsActiveOverridesAndExcludesAnExpiredOne`; the
      underlying filter is `ActiveUserOverrides`, already covered by the
      existing contract suite.

## Design notes

- **"Role result" and "effective result" are a preview, not a decision.**
  §9.3 asks the response to show both before saving. This handler computes
  them from `ActiveRolePermissions` - the same role-permission rows Cerbos
  policy itself reads at decision time - and combines them with the
  pending override using the §6.3 user-over-role rule, omitting the
  mandatory-rule component that only Cerbos may evaluate. I checked this
  against `tests/architecture`'s precedence scan (`TestNoGoCodeEncodesPrecedenceOrdering`):
  it flags reads of `permissioncontext.Context`'s specific assembled-action-set
  fields, and this handler uses none of them - it is a local, one-off preview
  of an administrator's own pending write, not a second implementation of
  the runtime decision path.
- **High-risk actions are a configured list, not a catalog attribute.** There
  is no per-resource risk classification anywhere in the codebase yet (the
  `authorization_action.risk_level` column exists but nothing reads it), and
  building that pipeline is out of scope for this slice. `HighRiskActions`
  is a small explicit list (`update, delete, assign` by default, matching
  `libs/cataloggen`'s own `lockableActions`), configurable via
  `USER_OVERRIDE_HIGH_RISK_ACTIONS`.
- **`RoleExternalIDs` come from the request, not from an IdP round trip.**
  The Admin Console already has to know a user's current roles to render the
  override screen at all (§9.3's "show the underlying role result... before
  saving"); asking this handler to re-resolve them from the identity
  provider would be a second read of the same fact the caller already has.

## Verification

- `bash scripts/go.sh apps/admin-service test ./...` — all packages pass,
  including the 14 new `useroverride` tests.
- `bash scripts/go.sh libs/assignmentstore test ./demoseed/...` — unaffected
  by the `Reason` field addition.
- `bash scripts/go.sh apps/admin-service vet ./...`,
  `libs/assignmentstore vet ./...` — clean.
- `bash scripts/go.sh tests/architecture test ./...` — clean; confirms the
  role/effective-result preview does not trip the precedence-in-Go scan.
- `gofmt -l` over the touched trees — clean.
- **Live PostgreSQL**: started `postgres` via `docker compose up -d
  postgres`, ran `bash scripts/liquibase.sh postgres update` (the new
  `009-user-override-reason` changeset applied cleanly), then
  `bash scripts/tests/store-contract.sh postgres` and
  `bash scripts/tests/migration-contract.sh postgres` — both green,
  including the three new `SaveUserOverrideWrite` contract cases. This is
  also what caught the pre-existing `UserOverride` nil-scan bug.
- **Oracle dual-dialect run deferred**: the environment had ~1.3GB free RAM
  at review time, not enough headroom to also bring up Oracle Free
  alongside Postgres. The Oracle adapter code mirrors the Postgres one
  change-for-change (including the same nil-scan fix); dual-dialect
  verification should happen in the deferred full CI run once all 26
  slices are done, per project policy.

Closes #15


Closes #15
