### PR TITLE
Admin Console: role permission matrix module (#16)

### DIFF
--- a/apps/admin-console/Dockerfile
+++ b/apps/admin-console/Dockerfile
@@ -30,4 +30,10 @@ COPY apps/admin-console/nginx.conf.template /etc/nginx/templates/default.conf.te
 ENV NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1
 COPY --from=build /workspace/dist/apps/admin-console/browser /usr/share/nginx/html
 
+# Renders assets/env.template.js into assets/env.js at container start (see
+# the script's own comment for why the built-in envsubst-on-templates step
+# does not already cover this).
+COPY apps/admin-console/docker-entrypoint.d/30-render-env-js.sh /docker-entrypoint.d/30-render-env-js.sh
+RUN chmod +x /docker-entrypoint.d/30-render-env-js.sh
+
 EXPOSE 80

--- a/apps/admin-console/docker-entrypoint.d/30-render-env-js.sh
+++ b/apps/admin-console/docker-entrypoint.d/30-render-env-js.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Runs as part of the nginx image's own docker-entrypoint.d mechanism,
+# alongside its built-in 20-envsubst-on-templates.sh. That script only
+# processes /etc/nginx/templates/*.template into nginx's own config dir; it
+# never touches the served static files, so assets/env.template.js needs
+# this second pass.
+set -eu
+
+envsubst '${OIDC_ISSUER} ${OIDC_CLIENT_ID}' \
+  < /usr/share/nginx/html/assets/env.template.js \
+  > /usr/share/nginx/html/assets/env.js

--- a/apps/admin-console/nginx.conf.template
+++ b/apps/admin-console/nginx.conf.template
@@ -32,6 +32,20 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
+  # The browser never talks to the Administration Service directly either
+  # (§16.1): the console proxies it the same way it proxies the ADS, so the
+  # write path's own credential-free surface stays on the internal network.
+  location /api/admin/ {
+    set $admin_service_upstream "http://admin-service:8081";
+
+    rewrite ^/api/admin/(.*)$ /$1 break;
+
+    proxy_pass $admin_service_upstream;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/apps/admin-console/public/assets/env.template.js
+++ b/apps/admin-console/public/assets/env.template.js
@@ -1,0 +1,10 @@
+// Rendered into assets/env.js by docker-entrypoint.d/30-render-env-js.sh at
+// container start, the same envsubst mechanism the nginx image already uses
+// for nginx.conf.template. A static Angular build has no server-side
+// templating step of its own, so this is how a compose-time value (which
+// Keycloak issuer to log in against) reaches a bundle that was already
+// built before anyone knew the answer.
+window.__ENV__ = {
+  oidcIssuer: '${OIDC_ISSUER}',
+  oidcClientId: '${OIDC_CLIENT_ID}',
+};

--- a/apps/admin-console/src/app/admin-base-url.ts
+++ b/apps/admin-console/src/app/admin-base-url.ts
@@ -1,0 +1,13 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * Base URL of the Authorization Administration Service as seen from the
+ * browser, mirroring ADS_BASE_URL (platform-status/ads-base-url.ts): the
+ * console never talks to admin-service directly, nginx proxies this
+ * prefix to it so the backend stays on the internal compose network
+ * (§16.1).
+ */
+export const ADMIN_BASE_URL = new InjectionToken<string>('ADMIN_BASE_URL', {
+  providedIn: 'root',
+  factory: () => '/api/admin',
+});

--- a/apps/admin-console/src/app/app.config.ts
+++ b/apps/admin-console/src/app/app.config.ts
@@ -1,9 +1,17 @@
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import {
   ApplicationConfig,
   provideBrowserGlobalErrorListeners,
 } from '@angular/core';
+import { provideRouter } from '@angular/router';
+
+import { authInterceptor } from './auth/auth.interceptor';
+import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideBrowserGlobalErrorListeners(), provideHttpClient()],
+  providers: [
+    provideBrowserGlobalErrorListeners(),
+    provideHttpClient(withInterceptors([authInterceptor])),
+    provideRouter(appRoutes),
+  ],
 };

--- a/apps/admin-console/src/app/app.html
+++ b/apps/admin-console/src/app/app.html
@@ -1,1 +1,1 @@
-<app-platform-status></app-platform-status>
+<router-outlet></router-outlet>

--- a/apps/admin-console/src/app/app.routes.ts
+++ b/apps/admin-console/src/app/app.routes.ts
@@ -1,0 +1,19 @@
+import { Route } from '@angular/router';
+
+import { authGuard } from './auth/auth.guard';
+import { Callback } from './auth/callback';
+import { RoleMatrix } from './role-matrix/role-matrix';
+import { Shell } from './shell/shell';
+
+export const appRoutes: Route[] = [
+  { path: 'callback', component: Callback },
+  {
+    path: '',
+    component: Shell,
+    canActivate: [authGuard],
+    children: [
+      { path: '', redirectTo: 'role-matrix', pathMatch: 'full' },
+      { path: 'role-matrix', component: RoleMatrix },
+    ],
+  },
+];

--- a/apps/admin-console/src/app/app.spec.ts
+++ b/apps/admin-console/src/app/app.spec.ts
@@ -4,13 +4,12 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { Router, provideRouter } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
 
 import { App } from './app';
 import { appRoutes } from './app.routes';
 import { AuthService } from './auth/auth.service';
-import { provideRouter } from '@angular/router';
 
 describe('App', () => {
   it('redirects an authenticated administrator from / to the role matrix, inside the shell', async () => {

--- a/apps/admin-console/src/app/app.spec.ts
+++ b/apps/admin-console/src/app/app.spec.ts
@@ -1,33 +1,66 @@
-import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
 
 import { App } from './app';
+import { appRoutes } from './app.routes';
+import { AuthService } from './auth/auth.service';
+import { provideRouter } from '@angular/router';
 
 describe('App', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  it('redirects an authenticated administrator from / to the role matrix, inside the shell', async () => {
+    TestBed.configureTestingModule({
       imports: [App],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
-    }).compileComponents();
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter(appRoutes),
+        {
+          provide: AuthService,
+          useValue: {
+            isAuthenticated: () => true,
+            claims: () => ({ tenantId: 'tenant-a', hospitalId: 'hospital-1', username: 'admin' }),
+            login: vi.fn(),
+            logout: vi.fn(),
+          },
+        },
+      ],
+    });
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/');
+    const httpMock = TestBed.inject(HttpTestingController);
+    httpMock.expectOne('/api/admin/authz/resources').flush({ resources: [], rootPolicyRevision: 'root-v1.4.0' });
+
+    expect(TestBed.inject(Router).url).toEqual('/role-matrix');
+    expect(
+      harness.routeNativeElement?.querySelector('[data-testid="nav-role-matrix"]'),
+    ).toBeTruthy();
   });
 
-  it('renders the platform status as its landing view', async () => {
-    const fixture = TestBed.createComponent(App);
-    fixture.detectChanges();
+  it('starts login rather than reaching any guarded route when there is no session', async () => {
+    const login = vi.fn();
+    TestBed.configureTestingModule({
+      imports: [App],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter(appRoutes),
+        {
+          provide: AuthService,
+          useValue: { isAuthenticated: () => false, claims: () => null, login, logout: vi.fn() },
+        },
+      ],
+    });
 
-    TestBed.inject(HttpTestingController)
-      .expectOne('/api/ads/healthz')
-      .flush({ status: 'ok' });
-    await fixture.whenStable();
-    fixture.detectChanges();
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/');
 
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(
-      compiled.querySelector('[data-testid="ads-status"]')?.textContent,
-    ).toContain('healthy');
+    expect(login).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/admin-console/src/app/app.ts
+++ b/apps/admin-console/src/app/app.ts
@@ -1,8 +1,13 @@
 import { Component } from '@angular/core';
-import { PlatformStatus } from './platform-status/platform-status';
+import { RouterOutlet } from '@angular/router';
 
+/**
+ * The application root: hosts the router outlet only. The shell (nav,
+ * identity, logout) and the platform-status readout both live behind
+ * routes now (issue #16), rather than being wired directly here.
+ */
 @Component({
-  imports: [PlatformStatus],
+  imports: [RouterOutlet],
   selector: 'app-root',
   templateUrl: './app.html',
 })

--- a/apps/admin-console/src/app/auth/auth.guard.spec.ts
+++ b/apps/admin-console/src/app/auth/auth.guard.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+
+import { authGuard } from './auth.guard';
+import { AuthService } from './auth.service';
+
+describe('authGuard', () => {
+  it('allows navigation once AuthService reports an authenticated session', () => {
+    const auth = { isAuthenticated: () => true, login: vi.fn() };
+    TestBed.configureTestingModule({ providers: [{ provide: AuthService, useValue: auth }] });
+
+    const result = TestBed.runInInjectionContext(() =>
+      authGuard({} as never, {} as never),
+    );
+
+    expect(result).toBe(true);
+    expect(auth.login).not.toHaveBeenCalled();
+  });
+
+  it('starts login and refuses navigation when there is no session yet', () => {
+    const auth = { isAuthenticated: () => false, login: vi.fn().mockResolvedValue(undefined) };
+    TestBed.configureTestingModule({ providers: [{ provide: AuthService, useValue: auth }] });
+
+    const result = TestBed.runInInjectionContext(() =>
+      authGuard({} as never, {} as never),
+    );
+
+    expect(result).toBe(false);
+    expect(auth.login).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/admin-console/src/app/auth/auth.guard.ts
+++ b/apps/admin-console/src/app/auth/auth.guard.ts
@@ -1,0 +1,18 @@
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+
+import { AuthService } from './auth.service';
+
+/**
+ * Refuses navigation to any route it guards until AuthService has an
+ * access token, sending the browser to Keycloak instead. Every route but
+ * /callback is guarded (§9's "OIDC login").
+ */
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  if (auth.isAuthenticated()) {
+    return true;
+  }
+  void auth.login();
+  return false;
+};

--- a/apps/admin-console/src/app/auth/auth.interceptor.spec.ts
+++ b/apps/admin-console/src/app/auth/auth.interceptor.spec.ts
@@ -1,0 +1,65 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from './auth.service';
+import { authInterceptor } from './auth.interceptor';
+
+describe('authInterceptor', () => {
+  it('attaches a bearer token to an /api/ call when one is available', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: { accessToken: () => 'a-token' } },
+      ],
+    });
+
+    TestBed.inject(HttpClient).get('/api/admin/authz/resources').subscribe();
+
+    const request = TestBed.inject(HttpTestingController).expectOne(
+      '/api/admin/authz/resources',
+    );
+    expect(request.request.headers.get('Authorization')).toEqual('Bearer a-token');
+  });
+
+  it('leaves a request with no token unmodified', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: { accessToken: () => null } },
+      ],
+    });
+
+    TestBed.inject(HttpClient).get('/api/admin/authz/resources').subscribe();
+
+    const request = TestBed.inject(HttpTestingController).expectOne(
+      '/api/admin/authz/resources',
+    );
+    expect(request.request.headers.has('Authorization')).toBe(false);
+  });
+
+  it('never attaches a token to a request outside /api/', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: { accessToken: () => 'a-token' } },
+      ],
+    });
+
+    TestBed.inject(HttpClient)
+      .post('http://localhost:8081/realms/cerbos-poc/protocol/openid-connect/token', {})
+      .subscribe();
+
+    const request = TestBed.inject(HttpTestingController).expectOne(
+      'http://localhost:8081/realms/cerbos-poc/protocol/openid-connect/token',
+    );
+    expect(request.request.headers.has('Authorization')).toBe(false);
+  });
+});

--- a/apps/admin-console/src/app/auth/auth.interceptor.ts
+++ b/apps/admin-console/src/app/auth/auth.interceptor.ts
@@ -1,0 +1,25 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+
+import { AuthService } from './auth.service';
+
+/**
+ * Attaches the console's own access token to every call the browser makes
+ * to the server (§16.1: the browser holds only its own token, never an IdP
+ * admin credential). Requests to the identity provider itself - the token
+ * exchange and the authorize/logout redirects - never go through
+ * HttpClient with this interceptor attached to them in the same way the
+ * redirects are full navigations, and the token exchange in AuthService
+ * intentionally carries no Authorization header of its own.
+ */
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  if (!req.url.startsWith('/api/')) {
+    return next(req);
+  }
+  const auth = inject(AuthService);
+  const token = auth.accessToken();
+  if (!token) {
+    return next(req);
+  }
+  return next(req.clone({ setHeaders: { Authorization: `Bearer ${token}` } }));
+};

--- a/apps/admin-console/src/app/auth/auth.service.spec.ts
+++ b/apps/admin-console/src/app/auth/auth.service.spec.ts
@@ -1,0 +1,151 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from './auth.service';
+import { OIDC_CONFIG } from './oidc-config';
+import { REDIRECT } from './redirect';
+
+function fakeJwt(payload: Record<string, unknown>): string {
+  const encode = (value: unknown) =>
+    btoa(JSON.stringify(value)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `${encode({ alg: 'RS256' })}.${encode(payload)}.signature`;
+}
+
+describe('AuthService', () => {
+  let httpMock: HttpTestingController;
+  let redirectSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    redirectSpy = vi.fn();
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: OIDC_CONFIG,
+          useValue: {
+            issuer: 'http://localhost:8081/realms/cerbos-poc',
+            clientId: 'patient-app',
+            redirectUri: 'http://localhost:4200/callback',
+          },
+        },
+        { provide: REDIRECT, useValue: redirectSpy },
+      ],
+    });
+    httpMock = TestBed.inject(HttpTestingController);
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('is not authenticated before any token is set', () => {
+    const auth = TestBed.inject(AuthService);
+    expect(auth.isAuthenticated()).toBe(false);
+    expect(auth.accessToken()).toBeNull();
+  });
+
+  it('redirects to the authorization endpoint with a PKCE challenge and stores the verifier and state', async () => {
+    const auth = TestBed.inject(AuthService);
+    await auth.login();
+
+    expect(redirectSpy).toHaveBeenCalledTimes(1);
+    const url = new URL(redirectSpy.mock.calls[0][0] as string);
+    expect(url.origin + url.pathname).toEqual(
+      'http://localhost:8081/realms/cerbos-poc/protocol/openid-connect/auth',
+    );
+    expect(url.searchParams.get('response_type')).toEqual('code');
+    expect(url.searchParams.get('client_id')).toEqual('patient-app');
+    expect(url.searchParams.get('code_challenge_method')).toEqual('S256');
+    expect(url.searchParams.get('code_challenge')).toBeTruthy();
+    expect(url.searchParams.get('state')).toEqual(sessionStorage.getItem('admin-console:pkce-state'));
+    expect(sessionStorage.getItem('admin-console:pkce-verifier')).toBeTruthy();
+  });
+
+  it('exchanges the code for a token and becomes authenticated on a matching state', async () => {
+    const auth = TestBed.inject(AuthService);
+    await auth.login();
+    const state = sessionStorage.getItem('admin-console:pkce-state')!;
+
+    const token = fakeJwt({
+      sub: 'admin-1',
+      preferred_username: 'admin',
+      tenant_id: 'tenant-a',
+      hospital_id: 'hospital-1',
+      resource_access: { 'patient-app': { roles: ['administrator'] } },
+    });
+
+    const promise = auth.handleCallback('auth-code-1', state);
+    httpMock
+      .expectOne('http://localhost:8081/realms/cerbos-poc/protocol/openid-connect/token')
+      .flush({ access_token: token });
+
+    expect(await promise).toBe(true);
+    expect(auth.isAuthenticated()).toBe(true);
+    expect(auth.accessToken()).toEqual(token);
+    expect(auth.claims()?.tenantId).toEqual('tenant-a');
+    expect(auth.claims()?.hospitalId).toEqual('hospital-1');
+  });
+
+  it('refuses a callback whose state does not match the one login stored', async () => {
+    const auth = TestBed.inject(AuthService);
+    await auth.login();
+
+    const result = await auth.handleCallback('auth-code-1', 'a-forged-state');
+
+    expect(result).toBe(false);
+    expect(auth.isAuthenticated()).toBe(false);
+    httpMock.expectNone('http://localhost:8081/realms/cerbos-poc/protocol/openid-connect/token');
+  });
+
+  it('deletes the stored verifier and state after one callback attempt, matching or not', async () => {
+    const auth = TestBed.inject(AuthService);
+    await auth.login();
+
+    await auth.handleCallback('auth-code-1', 'a-forged-state');
+
+    expect(sessionStorage.getItem('admin-console:pkce-verifier')).toBeNull();
+    expect(sessionStorage.getItem('admin-console:pkce-state')).toBeNull();
+  });
+
+  it('returns false when the token exchange itself fails', async () => {
+    const auth = TestBed.inject(AuthService);
+    await auth.login();
+    const state = sessionStorage.getItem('admin-console:pkce-state')!;
+
+    const promise = auth.handleCallback('auth-code-1', state);
+    httpMock
+      .expectOne('http://localhost:8081/realms/cerbos-poc/protocol/openid-connect/token')
+      .flush({ error: 'invalid_grant' }, { status: 400, statusText: 'Bad Request' });
+
+    expect(await promise).toBe(false);
+    expect(auth.isAuthenticated()).toBe(false);
+  });
+
+  it('clears the token and redirects to the end-session endpoint on logout', async () => {
+    const auth = TestBed.inject(AuthService);
+    await auth.login();
+    const state = sessionStorage.getItem('admin-console:pkce-state')!;
+    const promise = auth.handleCallback(
+      'auth-code-1',
+      state,
+    );
+    httpMock
+      .expectOne('http://localhost:8081/realms/cerbos-poc/protocol/openid-connect/token')
+      .flush({ access_token: fakeJwt({ sub: 'admin-1' }) });
+    await promise;
+
+    auth.logout();
+
+    expect(auth.isAuthenticated()).toBe(false);
+    const url = new URL(redirectSpy.mock.calls[1][0] as string);
+    expect(url.origin + url.pathname).toEqual(
+      'http://localhost:8081/realms/cerbos-poc/protocol/openid-connect/logout',
+    );
+  });
+});

--- a/apps/admin-console/src/app/auth/auth.service.ts
+++ b/apps/admin-console/src/app/auth/auth.service.ts
@@ -1,0 +1,117 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+import { OIDC_CONFIG } from './oidc-config';
+import { deriveCodeChallenge, generateCodeVerifier, generateState } from './pkce';
+import { REDIRECT } from './redirect';
+import { TokenClaims, decodeAccessToken } from './token-claims';
+
+const VERIFIER_KEY = 'admin-console:pkce-verifier';
+const STATE_KEY = 'admin-console:pkce-state';
+
+/**
+ * The Admin Console's OIDC login (§9's "Admin Console shell, navigation
+ * and OIDC login", issue #16), an Authorization Code + PKCE flow against
+ * Keycloak.
+ *
+ * The access token lives only in this service's own in-memory signal,
+ * never in localStorage or sessionStorage - only the ephemeral PKCE
+ * verifier and state survive the redirect round trip, in sessionStorage,
+ * and both are deleted the moment the callback consumes them. Every
+ * administrative call still goes through the server (§16.1); this token
+ * only authenticates the browser to the Administration Service and the
+ * ADS, never to the identity provider's own admin API.
+ */
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(OIDC_CONFIG);
+  private readonly redirect = inject(REDIRECT);
+
+  private readonly accessTokenSignal = signal<string | null>(null);
+  private readonly claimsSignal = signal<TokenClaims | null>(null);
+
+  readonly isAuthenticated = computed(() => this.accessTokenSignal() !== null);
+  readonly claims = this.claimsSignal.asReadonly();
+
+  accessToken(): string | null {
+    return this.accessTokenSignal();
+  }
+
+  /** Redirects the browser to Keycloak's authorization endpoint. */
+  async login(): Promise<void> {
+    const verifier = generateCodeVerifier();
+    const state = generateState();
+    const challenge = await deriveCodeChallenge(verifier);
+
+    sessionStorage.setItem(VERIFIER_KEY, verifier);
+    sessionStorage.setItem(STATE_KEY, state);
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: this.config.clientId,
+      redirect_uri: this.config.redirectUri,
+      scope: 'openid',
+      state,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+    });
+    this.redirect(`${this.config.issuer}/protocol/openid-connect/auth?${params}`);
+  }
+
+  /**
+   * Completes the flow after Keycloak redirects back to /callback with a
+   * code and the state this session started with. Returns false - and
+   * leaves the caller unauthenticated - for a state mismatch (a forged or
+   * replayed callback) rather than throwing, so the callback route can
+   * show a plain "log in again" prompt instead of an error page.
+   */
+  async handleCallback(code: string, state: string): Promise<boolean> {
+    const expectedState = sessionStorage.getItem(STATE_KEY);
+    const verifier = sessionStorage.getItem(VERIFIER_KEY);
+    sessionStorage.removeItem(STATE_KEY);
+    sessionStorage.removeItem(VERIFIER_KEY);
+
+    if (!expectedState || !verifier || state !== expectedState) {
+      return false;
+    }
+
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: this.config.clientId,
+      redirect_uri: this.config.redirectUri,
+      code,
+      code_verifier: verifier,
+    });
+
+    try {
+      const response = await firstValueFrom(
+        this.http.post<{ access_token: string }>(
+          `${this.config.issuer}/protocol/openid-connect/token`,
+          body.toString(),
+          { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+        ),
+      );
+      this.setAccessToken(response.access_token);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  logout(): void {
+    this.accessTokenSignal.set(null);
+    this.claimsSignal.set(null);
+    const params = new URLSearchParams({
+      client_id: this.config.clientId,
+      post_logout_redirect_uri: window.location.origin,
+    });
+    this.redirect(`${this.config.issuer}/protocol/openid-connect/logout?${params}`);
+  }
+
+  private setAccessToken(token: string): void {
+    this.accessTokenSignal.set(token);
+    this.claimsSignal.set(decodeAccessToken(token, this.config.clientId));
+  }
+}

--- a/apps/admin-console/src/app/auth/callback.spec.ts
+++ b/apps/admin-console/src/app/auth/callback.spec.ts
@@ -1,0 +1,63 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+
+import { AuthService } from './auth.service';
+import { Callback } from './callback';
+
+describe('Callback', () => {
+  function setUp(queryParams: Record<string, string>, handleCallback = vi.fn()) {
+    TestBed.configureTestingModule({
+      imports: [Callback],
+      providers: [
+        provideLocationMocks(),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { queryParamMap: convertToParamMap(queryParams) },
+          },
+        },
+        { provide: AuthService, useValue: { handleCallback, login: vi.fn() } },
+      ],
+    });
+    return { handleCallback };
+  }
+
+  it('exchanges the code and state for a token, then navigates to the shell', async () => {
+    const handleCallback = vi.fn().mockResolvedValue(true);
+    setUp({ code: 'auth-code-1', state: 'state-1' }, handleCallback);
+
+    const fixture = TestBed.createComponent(Callback);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(handleCallback).toHaveBeenCalledWith('auth-code-1', 'state-1');
+    expect(TestBed.inject(Router).url).toEqual('/');
+  });
+
+  it('shows a retry prompt when the exchange fails', async () => {
+    setUp({ code: 'auth-code-1', state: 'state-1' }, vi.fn().mockResolvedValue(false));
+
+    const fixture = TestBed.createComponent(Callback);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="callback-failed"]'),
+    ).toBeTruthy();
+  });
+
+  it('shows a retry prompt when Keycloak redirected back with no code', async () => {
+    setUp({});
+
+    const fixture = TestBed.createComponent(Callback);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="callback-failed"]'),
+    ).toBeTruthy();
+  });
+});

--- a/apps/admin-console/src/app/auth/callback.ts
+++ b/apps/admin-console/src/app/auth/callback.ts
@@ -1,0 +1,52 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { AuthService } from './auth.service';
+
+/**
+ * The route Keycloak redirects back to after login. Exchanges the
+ * authorization code for a token and moves on to the shell, or shows a
+ * plain retry prompt on failure - never a stack trace, since a stale
+ * bookmark to this URL or a replayed callback are both routine.
+ */
+@Component({
+  standalone: true,
+  template: `
+    @if (failed()) {
+      <p data-testid="callback-failed">
+        Login could not be completed. <button type="button" (click)="retry()">Try again</button>
+      </p>
+    } @else {
+      <p data-testid="callback-pending">Completing login…</p>
+    }
+  `,
+})
+export class Callback implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly auth = inject(AuthService);
+
+  protected readonly failed = signal(false);
+
+  async ngOnInit(): Promise<void> {
+    const params = this.route.snapshot.queryParamMap;
+    const code = params.get('code');
+    const state = params.get('state');
+
+    if (!code || !state) {
+      this.failed.set(true);
+      return;
+    }
+
+    const ok = await this.auth.handleCallback(code, state);
+    if (!ok) {
+      this.failed.set(true);
+      return;
+    }
+    await this.router.navigateByUrl('/');
+  }
+
+  retry(): void {
+    void this.auth.login();
+  }
+}

--- a/apps/admin-console/src/app/auth/oidc-config.ts
+++ b/apps/admin-console/src/app/auth/oidc-config.ts
@@ -1,0 +1,40 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * OIDC client configuration for the Admin Console's login (§7.1, §9.1).
+ *
+ * The console is the "browser-facing client" (patient-app) §7.1 describes
+ * as public and holding no administrative permission of any kind - the
+ * same client every other browser-facing surface on this port uses.
+ */
+export interface OidcConfig {
+  /** The Keycloak issuer, e.g. http://localhost:8081/realms/cerbos-poc. */
+  issuer: string;
+  clientId: string;
+  /** Where Keycloak redirects back to after login. */
+  redirectUri: string;
+}
+
+/**
+ * Runtime overrides rendered by docker-entrypoint.d/30-render-env-js.sh from
+ * OIDC_ISSUER and OIDC_CLIENT_ID (see assets/env.template.js). Absent in a
+ * local `nx serve` or in unit tests, where the compose-matching defaults
+ * below apply instead.
+ */
+interface RuntimeEnv {
+  oidcIssuer?: string;
+  oidcClientId?: string;
+}
+
+function runtimeEnv(): RuntimeEnv {
+  return (window as unknown as { __ENV__?: RuntimeEnv }).__ENV__ ?? {};
+}
+
+export const OIDC_CONFIG = new InjectionToken<OidcConfig>('OIDC_CONFIG', {
+  providedIn: 'root',
+  factory: () => ({
+    issuer: runtimeEnv().oidcIssuer || 'http://localhost:8081/realms/cerbos-poc',
+    clientId: runtimeEnv().oidcClientId || 'patient-app',
+    redirectUri: `${window.location.origin}/callback`,
+  }),
+});

--- a/apps/admin-console/src/app/auth/pkce.spec.ts
+++ b/apps/admin-console/src/app/auth/pkce.spec.ts
@@ -1,0 +1,41 @@
+import {
+  deriveCodeChallenge,
+  generateCodeVerifier,
+  generateState,
+} from './pkce';
+
+describe('pkce', () => {
+  it('generates a code verifier using only the RFC 7636 unreserved character set', () => {
+    const verifier = generateCodeVerifier();
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier).toMatch(/^[A-Za-z0-9\-._~]+$/);
+  });
+
+  it('generates a different code verifier on every call', () => {
+    expect(generateCodeVerifier()).not.toEqual(generateCodeVerifier());
+  });
+
+  it('generates a different state value on every call', () => {
+    expect(generateState()).not.toEqual(generateState());
+  });
+
+  it('derives the same code challenge for the same verifier', async () => {
+    const verifier = generateCodeVerifier();
+    const first = await deriveCodeChallenge(verifier);
+    const second = await deriveCodeChallenge(verifier);
+    expect(first).toEqual(second);
+  });
+
+  it('derives a code challenge with no base64 padding or URL-unsafe characters', async () => {
+    const challenge = await deriveCodeChallenge('a-known-verifier-value');
+    expect(challenge).not.toContain('=');
+    expect(challenge).not.toContain('+');
+    expect(challenge).not.toContain('/');
+  });
+
+  it('derives different challenges for different verifiers', async () => {
+    const a = await deriveCodeChallenge('verifier-one');
+    const b = await deriveCodeChallenge('verifier-two');
+    expect(a).not.toEqual(b);
+  });
+});

--- a/apps/admin-console/src/app/auth/pkce.ts
+++ b/apps/admin-console/src/app/auth/pkce.ts
@@ -1,0 +1,49 @@
+/**
+ * PKCE (RFC 7636) helpers for the Admin Console's OIDC login (§9's "Admin
+ * Console shell, navigation and OIDC login", issue #16).
+ *
+ * The console is a public client (§7.1: "Public, so it holds no secret"):
+ * it has no client secret to protect the authorization code exchange, so
+ * PKCE is what stands in for one. Everything here is pure and testable
+ * without a network call or a real browser redirect.
+ */
+
+const CODE_VERIFIER_LENGTH = 64;
+const UNRESERVED_CHARS =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+
+/** Generates a cryptographically random RFC 7636 code_verifier. */
+export function generateCodeVerifier(): string {
+  const bytes = new Uint8Array(CODE_VERIFIER_LENGTH);
+  crypto.getRandomValues(bytes);
+  let verifier = '';
+  for (const byte of bytes) {
+    verifier += UNRESERVED_CHARS[byte % UNRESERVED_CHARS.length];
+  }
+  return verifier;
+}
+
+/** Generates an opaque random state/nonce value for CSRF protection. */
+export function generateState(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+/**
+ * Derives the S256 code_challenge from a code_verifier: base64url(sha256(verifier)),
+ * per RFC 7636 §4.2.
+ */
+export async function deriveCodeChallenge(verifier: string): Promise<string> {
+  const encoded = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', encoded);
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}

--- a/apps/admin-console/src/app/auth/redirect.ts
+++ b/apps/admin-console/src/app/auth/redirect.ts
@@ -1,0 +1,13 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * The one seam between AuthService and a real browser navigation.
+ *
+ * jsdom's `window.location.assign` cannot be reassigned or spied on
+ * directly (it is a non-configurable platform property), so this
+ * InjectionToken is what a test overrides instead of touching `window`.
+ */
+export const REDIRECT = new InjectionToken<(url: string) => void>('REDIRECT', {
+  providedIn: 'root',
+  factory: () => (url: string) => window.location.assign(url),
+});

--- a/apps/admin-console/src/app/auth/token-claims.spec.ts
+++ b/apps/admin-console/src/app/auth/token-claims.spec.ts
@@ -1,0 +1,46 @@
+import { decodeAccessToken } from './token-claims';
+
+function fakeJwt(payload: Record<string, unknown>): string {
+  const encode = (value: unknown) =>
+    btoa(JSON.stringify(value)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `${encode({ alg: 'RS256', typ: 'JWT' })}.${encode(payload)}.signature`;
+}
+
+describe('decodeAccessToken', () => {
+  it('extracts the tenant, hospital and client roles from a token', () => {
+    const token = fakeJwt({
+      sub: 'user-1',
+      preferred_username: 'doctor',
+      tenant_id: 'tenant-a',
+      hospital_id: 'hospital-1',
+      exp: 1893456000,
+      resource_access: { 'patient-app': { roles: ['doctor'] } },
+    });
+
+    const claims = decodeAccessToken(token, 'patient-app');
+
+    expect(claims.subject).toEqual('user-1');
+    expect(claims.username).toEqual('doctor');
+    expect(claims.tenantId).toEqual('tenant-a');
+    expect(claims.hospitalId).toEqual('hospital-1');
+    expect(claims.roles).toEqual(['doctor']);
+    expect(claims.expiresAt).toEqual(1893456000);
+  });
+
+  it('reads only the configured client role claim, never another client', () => {
+    const token = fakeJwt({
+      resource_access: {
+        'patient-app': { roles: ['doctor'] },
+        'another-app': { roles: ['administrator'] },
+      },
+    });
+
+    const claims = decodeAccessToken(token, 'patient-app');
+
+    expect(claims.roles).toEqual(['doctor']);
+  });
+
+  it('rejects a value that is not a three-segment JWT', () => {
+    expect(() => decodeAccessToken('not-a-jwt', 'patient-app')).toThrow();
+  });
+});

--- a/apps/admin-console/src/app/auth/token-claims.ts
+++ b/apps/admin-console/src/app/auth/token-claims.ts
@@ -1,0 +1,43 @@
+/**
+ * The subset of an access token's claims the console reads for display
+ * purposes (§16.1's tenant_id/hospital_id claims, §7.3's client role
+ * claim). Nothing here is a security decision: the backend independently
+ * verifies every claim on every request regardless of what the browser
+ * decoded.
+ */
+export interface TokenClaims {
+  subject: string;
+  username: string;
+  tenantId: string;
+  hospitalId: string;
+  roles: string[];
+  expiresAt: number;
+}
+
+/** Decodes a JWT's payload without verifying its signature. */
+export function decodeAccessToken(token: string, clientId: string): TokenClaims {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('not a JWT: expected three dot-separated segments');
+  }
+  const payload = JSON.parse(base64UrlDecode(parts[1])) as Record<string, unknown>;
+
+  const resourceAccess = (payload['resource_access'] ?? {}) as Record<
+    string,
+    { roles?: string[] }
+  >;
+
+  return {
+    subject: String(payload['sub'] ?? ''),
+    username: String(payload['preferred_username'] ?? ''),
+    tenantId: String(payload['tenant_id'] ?? ''),
+    hospitalId: String(payload['hospital_id'] ?? ''),
+    roles: resourceAccess[clientId]?.roles ?? [],
+    expiresAt: Number(payload['exp'] ?? 0),
+  };
+}
+
+function base64UrlDecode(segment: string): string {
+  const padded = segment.replace(/-/g, '+').replace(/_/g, '/');
+  return atob(padded);
+}

--- a/apps/admin-console/src/app/role-matrix/role-matrix-api.ts
+++ b/apps/admin-console/src/app/role-matrix/role-matrix-api.ts
@@ -1,0 +1,102 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ADMIN_BASE_URL } from '../admin-base-url';
+import { ADS_BASE_URL } from '../platform-status/ads-base-url';
+
+/** A role as the identity directory reports it (§7.5, §9.2). */
+export interface RoleRef {
+  /**
+   * The stable identifier the role matrix persists against. Empty when
+   * the directory could not resolve exactly one canonical role for this
+   * entry - an inherited, composite, or otherwise ambiguous IdP role
+   * (§9.2's "Show inherited or composite IdP roles as informational
+   * context" and the role matrix module's "flag an unresolved canonical
+   * role for remediation"): the console's own display metadata is the
+   * only signal it has for either case, so both share one treatment
+   * here.
+   */
+  canonicalId: string;
+  externalId: string;
+  name: string;
+  description: string;
+}
+
+export interface RoleSearchResult {
+  items: RoleRef[];
+}
+
+export interface ActionEntry {
+  key: string;
+  displayName: string;
+  context: string;
+}
+
+export interface ResourceEntry {
+  resourceKey: string;
+  displayName: string;
+  domain: string;
+  actions: ActionEntry[];
+}
+
+export interface ResourceCatalog {
+  resources: ResourceEntry[];
+  rootPolicyRevision: string;
+}
+
+export interface PermissionRow {
+  resourceKey: string;
+  actionKey: string;
+  enabled: boolean;
+  validFrom: string;
+  validUntil?: string;
+}
+
+export interface RoleMatrix {
+  permissions: PermissionRow[];
+  revision: number;
+}
+
+export interface SaveResult {
+  revision: number;
+}
+
+/** Thrown by save() on a 409, carrying nothing else: the caller already
+ * has everything it needs to offer a reload. */
+export class StaleRevisionError extends Error {}
+
+@Injectable({ providedIn: 'root' })
+export class RoleMatrixApi {
+  private readonly http = inject(HttpClient);
+  private readonly adsBaseUrl = inject(ADS_BASE_URL);
+  private readonly adminBaseUrl = inject(ADMIN_BASE_URL);
+
+  searchRoles(query: string): Observable<RoleSearchResult> {
+    return this.http.get<RoleSearchResult>(`${this.adsBaseUrl}/internal/directory/roles`, {
+      params: query ? { query } : {},
+    });
+  }
+
+  getResourceCatalog(): Observable<ResourceCatalog> {
+    return this.http.get<ResourceCatalog>(`${this.adminBaseUrl}/authz/resources`);
+  }
+
+  getRoleMatrix(tenant: string, role: string): Observable<RoleMatrix> {
+    return this.http.get<RoleMatrix>(
+      `${this.adminBaseUrl}/authz/tenants/${tenant}/roles/${role}/permissions`,
+    );
+  }
+
+  saveRoleMatrix(
+    tenant: string,
+    role: string,
+    expectedRevision: number,
+    permissions: PermissionRow[],
+  ): Observable<SaveResult> {
+    return this.http.put<SaveResult>(
+      `${this.adminBaseUrl}/authz/tenants/${tenant}/roles/${role}/permissions`,
+      { expectedRevision, permissions },
+    );
+  }
+}

--- a/apps/admin-console/src/app/role-matrix/role-matrix.css
+++ b/apps/admin-console/src/app/role-matrix/role-matrix.css
@@ -1,0 +1,26 @@
+.error {
+  color: #b00020;
+}
+
+.unresolved {
+  color: #b00020;
+  font-style: italic;
+}
+
+.informational {
+  color: #666;
+  font-size: 0.85em;
+}
+
+.checkbox-note {
+  font-style: italic;
+  color: #444;
+}
+
+.domain-group {
+  margin-bottom: 0.5rem;
+}
+
+fieldset {
+  margin: 0.25rem 0;
+}

--- a/apps/admin-console/src/app/role-matrix/role-matrix.html
+++ b/apps/admin-console/src/app/role-matrix/role-matrix.html
@@ -1,0 +1,93 @@
+<section class="role-picker">
+  <h1>Role matrix</h1>
+  <p data-testid="tenant-scope">Tenant: {{ tenant() }}</p>
+
+  <label>
+    Search roles
+    <input
+      type="text"
+      data-testid="role-search-input"
+      [(ngModel)]="roleQuery"
+      (ngModelChange)="searchRoles()"
+    />
+  </label>
+  @if (roleSearchError()) {
+    <p data-testid="role-search-error" class="error">{{ roleSearchError() }}</p>
+  }
+
+  <ul data-testid="role-search-results">
+    @for (role of roles(); track role.externalId) {
+      <li>
+        @if (canSelect(role)) {
+          <button type="button" data-testid="role-option" (click)="selectRole(role)">
+            {{ role.name }}
+            @if (role.name !== role.canonicalId) {
+              <span class="informational">(persists as {{ role.canonicalId }})</span>
+            }
+          </button>
+        } @else {
+          <span data-testid="role-unresolved" class="unresolved">
+            {{ role.name || role.externalId }} - unresolved canonical role, needs remediation
+          </span>
+        }
+      </li>
+    }
+  </ul>
+</section>
+
+@if (loadError()) {
+  <p data-testid="load-error" class="error">{{ loadError() }}</p>
+}
+
+@if (selectedRole(); as role) {
+  <section class="matrix" data-testid="matrix">
+    <h2>{{ role.name }}</h2>
+    <p class="checkbox-note">
+      A cleared checkbox means no grant - it is never an explicit deny.
+    </p>
+
+    <label>
+      Filter resources and actions
+      <input
+        type="text"
+        data-testid="resource-filter-input"
+        [(ngModel)]="resourceFilter"
+      />
+    </label>
+
+    @if (staleRevision()) {
+      <p data-testid="stale-revision-error" class="error">
+        Someone else saved this role matrix since it was loaded.
+        <button type="button" data-testid="reload-button" (click)="reload()">Reload</button>
+      </p>
+    }
+    @if (saveError()) {
+      <p data-testid="save-error" class="error">{{ saveError() }}</p>
+    }
+
+    @for (group of domains(); track group.domain) {
+      <details class="domain-group" [attr.data-testid]="'domain-' + group.domain" [open]="resourceFilter() !== ''">
+        <summary>{{ group.domain }}</summary>
+        @for (resource of group.resources; track resource.resourceKey) {
+          <fieldset [attr.data-testid]="'resource-' + resource.resourceKey">
+            <legend>{{ resource.displayName }}</legend>
+            @for (action of resource.actions; track action.key) {
+              <label [attr.data-testid]="'action-' + resource.resourceKey + '-' + action.key">
+                <input
+                  type="checkbox"
+                  [checked]="isEnabled(resource.resourceKey, action.key)"
+                  (change)="toggle(resource.resourceKey, action.key)"
+                />
+                {{ action.displayName }}
+              </label>
+            }
+          </fieldset>
+        }
+      </details>
+    }
+
+    <button type="button" data-testid="save-button" [disabled]="saving()" (click)="save()">
+      Save
+    </button>
+  </section>
+}

--- a/apps/admin-console/src/app/role-matrix/role-matrix.spec.ts
+++ b/apps/admin-console/src/app/role-matrix/role-matrix.spec.ts
@@ -1,0 +1,205 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from '../auth/auth.service';
+import { RoleMatrix } from './role-matrix';
+
+function setUp() {
+  TestBed.configureTestingModule({
+    imports: [RoleMatrix],
+    providers: [
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      {
+        provide: AuthService,
+        useValue: { claims: () => ({ tenantId: 'tenant-a', hospitalId: 'hospital-1' }) },
+      },
+    ],
+  });
+  return TestBed.inject(HttpTestingController);
+}
+
+const patientRecordCatalog = {
+  resources: [
+    {
+      resourceKey: 'patient_record',
+      displayName: 'Patient record',
+      domain: 'clinical',
+      actions: [
+        { key: 'read', displayName: 'View patient', context: 'INSTANCE' },
+        { key: 'delete', displayName: 'Delete patient', context: 'INSTANCE' },
+      ],
+    },
+    {
+      resourceKey: 'installation_config',
+      displayName: 'Installation config',
+      domain: 'platform',
+      actions: [{ key: 'read', displayName: 'View config', context: 'INSTANCE' }],
+    },
+  ],
+  rootPolicyRevision: 'root-v1.4.0',
+};
+
+describe('RoleMatrix', () => {
+  it('loads the resource catalog on construction, through the admin-service proxy', () => {
+    const httpMock = setUp();
+    TestBed.createComponent(RoleMatrix);
+
+    httpMock.expectOne('/api/admin/authz/resources').flush(patientRecordCatalog);
+    httpMock.verify();
+  });
+
+  it('flags an unresolved role and does not allow selecting it', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(RoleMatrix);
+    httpMock.expectOne('/api/admin/authz/resources').flush(patientRecordCatalog);
+
+    fixture.componentInstance.roleQuery.set('doctor');
+    const searchPromise = fixture.componentInstance.searchRoles();
+    httpMock.expectOne('/api/ads/internal/directory/roles?query=doctor').flush({
+      items: [{ canonicalId: '', externalId: 'composite-doctor', name: 'Composite doctor', description: '' }],
+    });
+    await searchPromise;
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="role-unresolved"]')?.textContent,
+    ).toContain('unresolved canonical role, needs remediation');
+    expect(fixture.nativeElement.querySelector('[data-testid="role-option"]')).toBeNull();
+  });
+
+  it('shows a resolvable role as selectable and distinguishes its informational display name', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(RoleMatrix);
+    httpMock.expectOne('/api/admin/authz/resources').flush(patientRecordCatalog);
+
+    fixture.componentInstance.roleQuery.set('doctor');
+    const searchPromise = fixture.componentInstance.searchRoles();
+    httpMock.expectOne('/api/ads/internal/directory/roles?query=doctor').flush({
+      items: [{ canonicalId: 'kc:cerbos-poc:patient-app:doctor', externalId: 'doctor', name: 'Doctor', description: '' }],
+    });
+    await searchPromise;
+    fixture.detectChanges();
+
+    const option = fixture.nativeElement.querySelector('[data-testid="role-option"]') as HTMLElement;
+    expect(option).toBeTruthy();
+    expect(option.textContent).toContain('Doctor');
+    expect(option.textContent).toContain('persists as kc:cerbos-poc:patient-app:doctor');
+  });
+
+  it('loads the full matrix for a selected role and renders its current grants', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(RoleMatrix);
+    httpMock.expectOne('/api/admin/authz/resources').flush(patientRecordCatalog);
+
+    const selectPromise = fixture.componentInstance.selectRole({
+      canonicalId: 'kc:cerbos-poc:patient-app:doctor', externalId: 'doctor', name: 'Doctor', description: '',
+    });
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/roles/kc:cerbos-poc:patient-app:doctor/permissions')
+      .flush({
+        permissions: [
+          { resourceKey: 'patient_record', actionKey: 'read', enabled: true, validFrom: '2026-01-01T00:00:00Z' },
+        ],
+        revision: 4,
+      });
+    await selectPromise;
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.isEnabled('patient_record', 'read')).toBe(true);
+    expect(fixture.componentInstance.isEnabled('patient_record', 'delete')).toBe(false);
+    expect(fixture.componentInstance.expectedRevision()).toEqual(4);
+
+    const matrix = fixture.nativeElement.querySelector('[data-testid="matrix"]');
+    expect(matrix).toBeTruthy();
+  });
+
+  it('filters resources by a search term across resource, action and domain names', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(RoleMatrix);
+    httpMock.expectOne('/api/admin/authz/resources').flush(patientRecordCatalog);
+
+    const selectPromise = fixture.componentInstance.selectRole({
+      canonicalId: 'role-doctor', externalId: 'doctor', name: 'Doctor', description: '',
+    });
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/roles/role-doctor/permissions')
+      .flush({ permissions: [], revision: 0 });
+    await selectPromise;
+
+    fixture.componentInstance.resourceFilter.set('installation');
+    fixture.detectChanges();
+
+    const domains = fixture.componentInstance.domains();
+    expect(domains).toHaveLength(1);
+    expect(domains[0].resources.map((r) => r.resourceKey)).toEqual(['installation_config']);
+  });
+
+  it('toggling a checkbox never produces an explicit deny row - a cleared checkbox is simply absent', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(RoleMatrix);
+    httpMock.expectOne('/api/admin/authz/resources').flush(patientRecordCatalog);
+
+    const selectPromise = fixture.componentInstance.selectRole({
+      canonicalId: 'role-doctor', externalId: 'doctor', name: 'Doctor', description: '',
+    });
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/roles/role-doctor/permissions')
+      .flush({
+        permissions: [{ resourceKey: 'patient_record', actionKey: 'read', enabled: true, validFrom: '2026-01-01T00:00:00Z' }],
+        revision: 1,
+      });
+    await selectPromise;
+
+    fixture.componentInstance.toggle('patient_record', 'read');
+    expect(fixture.componentInstance.isEnabled('patient_record', 'read')).toBe(false);
+
+    fixture.componentInstance.toggle('patient_record', 'delete');
+    expect(fixture.componentInstance.isEnabled('patient_record', 'delete')).toBe(true);
+  });
+
+  it('shows an actionable error offering reload on a stale revision, keeping pending edits intact', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(RoleMatrix);
+    httpMock.expectOne('/api/admin/authz/resources').flush(patientRecordCatalog);
+
+    const selectPromise = fixture.componentInstance.selectRole({
+      canonicalId: 'role-doctor', externalId: 'doctor', name: 'Doctor', description: '',
+    });
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/roles/role-doctor/permissions')
+      .flush({ permissions: [], revision: 0 });
+    await selectPromise;
+
+    fixture.componentInstance.toggle('patient_record', 'read');
+    const savePromise = fixture.componentInstance.save();
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/roles/role-doctor/permissions')
+      .flush({ error: 'stale' }, { status: 409, statusText: 'Conflict' });
+    await savePromise;
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="stale-revision-error"]'),
+    ).toBeTruthy();
+    // The pending edit survives the conflict - nothing silently reset it.
+    expect(fixture.componentInstance.isEnabled('patient_record', 'read')).toBe(true);
+  });
+
+  it('sends every administrative call through the server-side proxy, never to the identity provider directly from here', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(RoleMatrix);
+    httpMock.expectOne('/api/admin/authz/resources').flush(patientRecordCatalog);
+
+    fixture.componentInstance.roleQuery.set('doctor');
+    const searchPromise = fixture.componentInstance.searchRoles();
+    const roleReq = httpMock.expectOne('/api/ads/internal/directory/roles?query=doctor');
+    expect(roleReq.request.url.startsWith('/api/')).toBe(true);
+    roleReq.flush({ items: [] });
+    await searchPromise;
+  });
+});

--- a/apps/admin-console/src/app/role-matrix/role-matrix.ts
+++ b/apps/admin-console/src/app/role-matrix/role-matrix.ts
@@ -1,0 +1,212 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { firstValueFrom } from 'rxjs';
+
+import { AuthService } from '../auth/auth.service';
+import {
+  PermissionRow,
+  ResourceEntry,
+  RoleMatrixApi,
+  RoleRef,
+} from './role-matrix-api';
+
+interface DomainGroup {
+  domain: string;
+  resources: ResourceEntry[];
+}
+
+/**
+ * The role permission matrix screen (§9.1, §9.2, issue #16): select a
+ * tenant-scoped role, browse and search the full resource catalog, and
+ * enable/disable resource-action grants with an expected-revision guard.
+ */
+@Component({
+  standalone: true,
+  imports: [FormsModule],
+  selector: 'app-role-matrix',
+  templateUrl: './role-matrix.html',
+  styleUrl: './role-matrix.css',
+})
+export class RoleMatrix {
+  private readonly api = inject(RoleMatrixApi);
+  private readonly auth = inject(AuthService);
+
+  /**
+   * The role matrix is tenant-scoped by the administrator's own token
+   * (§9.4's authority check); there is nothing to "select" here beyond
+   * what the token already names.
+   */
+  readonly tenant = computed(() => this.auth.claims()?.tenantId ?? '');
+
+  readonly roleQuery = signal('');
+  readonly roles = signal<RoleRef[]>([]);
+  readonly roleSearchError = signal<string | null>(null);
+
+  readonly selectedRole = signal<RoleRef | null>(null);
+  readonly resources = signal<ResourceEntry[]>([]);
+  readonly resourceFilter = signal('');
+
+  /** Keyed by `${resourceKey}:${actionKey}`, the checkbox grid's own state. */
+  private readonly permissionsByKey = signal<Map<string, PermissionRow>>(new Map());
+  readonly expectedRevision = signal(0);
+
+  readonly loadError = signal<string | null>(null);
+  readonly saving = signal(false);
+  readonly staleRevision = signal(false);
+  readonly saveError = signal<string | null>(null);
+
+  readonly domains = computed<DomainGroup[]>(() => {
+    const filter = this.resourceFilter().trim().toLowerCase();
+    const byDomain = new Map<string, ResourceEntry[]>();
+    for (const resource of this.resources()) {
+      if (filter && !this.matchesFilter(resource, filter)) {
+        continue;
+      }
+      const domain = resource.domain || 'other';
+      const group = byDomain.get(domain) ?? [];
+      group.push(resource);
+      byDomain.set(domain, group);
+    }
+    return Array.from(byDomain.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([domain, resources]) => ({ domain, resources }));
+  });
+
+  constructor() {
+    void this.loadResourceCatalog();
+  }
+
+  private matchesFilter(resource: ResourceEntry, filter: string): boolean {
+    if (
+      resource.resourceKey.toLowerCase().includes(filter) ||
+      resource.displayName.toLowerCase().includes(filter) ||
+      resource.domain.toLowerCase().includes(filter)
+    ) {
+      return true;
+    }
+    return resource.actions.some(
+      (action) =>
+        action.key.toLowerCase().includes(filter) ||
+        action.displayName.toLowerCase().includes(filter),
+    );
+  }
+
+  private async loadResourceCatalog(): Promise<void> {
+    try {
+      const catalog = await firstValueFrom(this.api.getResourceCatalog());
+      this.resources.set(catalog.resources);
+    } catch {
+      this.loadError.set('The resource catalog could not be loaded.');
+    }
+  }
+
+  async searchRoles(): Promise<void> {
+    this.roleSearchError.set(null);
+    try {
+      const result = await firstValueFrom(this.api.searchRoles(this.roleQuery()));
+      this.roles.set(result.items);
+    } catch {
+      this.roleSearchError.set('Role search failed.');
+    }
+  }
+
+  /**
+   * An unresolved role (§9.2) has no stable identifier to persist
+   * assignments against, so it is never selectable here - only flagged.
+   */
+  canSelect(role: RoleRef): boolean {
+    return role.canonicalId !== '';
+  }
+
+  async selectRole(role: RoleRef): Promise<void> {
+    if (!this.canSelect(role)) {
+      return;
+    }
+    this.selectedRole.set(role);
+    this.saveError.set(null);
+    this.staleRevision.set(false);
+    await this.reloadMatrix();
+  }
+
+  private async reloadMatrix(): Promise<void> {
+    const role = this.selectedRole();
+    if (!role) {
+      return;
+    }
+    this.loadError.set(null);
+    try {
+      const matrix = await firstValueFrom(this.api.getRoleMatrix(this.tenant(), role.canonicalId));
+      const byKey = new Map<string, PermissionRow>();
+      for (const row of matrix.permissions) {
+        byKey.set(`${row.resourceKey}:${row.actionKey}`, row);
+      }
+      this.permissionsByKey.set(byKey);
+      this.expectedRevision.set(matrix.revision);
+      this.staleRevision.set(false);
+    } catch {
+      this.loadError.set("This role's permissions could not be loaded.");
+    }
+  }
+
+  isEnabled(resourceKey: string, actionKey: string): boolean {
+    return this.permissionsByKey().get(`${resourceKey}:${actionKey}`)?.enabled ?? false;
+  }
+
+  /**
+   * Flips one checkbox. A cleared checkbox means no grant, never an
+   * explicit deny (§8.3, §9.2) - toggling off simply removes this role's
+   * contribution; it never creates a row that denies.
+   */
+  toggle(resourceKey: string, actionKey: string): void {
+    const byKey = new Map(this.permissionsByKey());
+    const key = `${resourceKey}:${actionKey}`;
+    const existing = byKey.get(key);
+    byKey.set(key, {
+      resourceKey,
+      actionKey,
+      enabled: !(existing?.enabled ?? false),
+      validFrom: existing?.validFrom ?? new Date().toISOString(),
+      validUntil: existing?.validUntil,
+    });
+    this.permissionsByKey.set(byKey);
+  }
+
+  async save(): Promise<void> {
+    const role = this.selectedRole();
+    if (!role) {
+      return;
+    }
+    this.saving.set(true);
+    this.saveError.set(null);
+    try {
+      const result = await firstValueFrom(
+        this.api.saveRoleMatrix(
+          this.tenant(),
+          role.canonicalId,
+          this.expectedRevision(),
+          Array.from(this.permissionsByKey().values()),
+        ),
+      );
+      this.expectedRevision.set(result.revision);
+      this.staleRevision.set(false);
+    } catch (err) {
+      if (err instanceof HttpErrorResponse && err.status === 409) {
+        // §9.2's "actionable error offering reload": the pending edits in
+        // permissionsByKey are left exactly as the administrator made
+        // them. Nothing here refetches or clears them - only an explicit
+        // reload() call does, and only because the administrator asked
+        // for it.
+        this.staleRevision.set(true);
+      } else {
+        this.saveError.set('Saving the role matrix failed.');
+      }
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  async reload(): Promise<void> {
+    await this.reloadMatrix();
+  }
+}

--- a/apps/admin-console/src/app/shell/shell.css
+++ b/apps/admin-console/src/app/shell/shell.css
@@ -1,0 +1,13 @@
+.shell-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.shell-identity {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}

--- a/apps/admin-console/src/app/shell/shell.html
+++ b/apps/admin-console/src/app/shell/shell.html
@@ -1,0 +1,16 @@
+<header class="shell-header">
+  <nav>
+    <a routerLink="/role-matrix" data-testid="nav-role-matrix">Role matrix</a>
+  </nav>
+  @if (auth.claims(); as claims) {
+    <div class="shell-identity" data-testid="shell-identity">
+      <span>{{ claims.username }}</span>
+      <span>{{ claims.tenantId }} / {{ claims.hospitalId }}</span>
+      <button type="button" (click)="logout()" data-testid="logout">Log out</button>
+    </div>
+  }
+</header>
+<app-platform-status></app-platform-status>
+<main>
+  <router-outlet></router-outlet>
+</main>

--- a/apps/admin-console/src/app/shell/shell.spec.ts
+++ b/apps/admin-console/src/app/shell/shell.spec.ts
@@ -1,0 +1,71 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from '../auth/auth.service';
+import { Shell } from './shell';
+
+describe('Shell', () => {
+  it('shows the logged-in identity and logs out on demand', () => {
+    const logout = vi.fn();
+    TestBed.configureTestingModule({
+      imports: [Shell],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: AuthService,
+          useValue: {
+            claims: () => ({
+              subject: 'admin-1',
+              username: 'admin',
+              tenantId: 'tenant-a',
+              hospitalId: 'hospital-1',
+              roles: [],
+              expiresAt: 0,
+            }),
+            logout,
+          },
+        },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(Shell);
+    fixture.detectChanges();
+    TestBed.inject(HttpTestingController).expectOne('/api/ads/healthz').flush({ status: 'ok' });
+
+    const identity = fixture.nativeElement.querySelector(
+      '[data-testid="shell-identity"]',
+    ) as HTMLElement;
+    expect(identity.textContent).toContain('admin');
+    expect(identity.textContent).toContain('tenant-a / hospital-1');
+
+    (fixture.nativeElement.querySelector('[data-testid="logout"]') as HTMLButtonElement).click();
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows no identity block before login completes', () => {
+    TestBed.configureTestingModule({
+      imports: [Shell],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: { claims: () => null, logout: vi.fn() } },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(Shell);
+    fixture.detectChanges();
+    TestBed.inject(HttpTestingController).expectOne('/api/ads/healthz').flush({ status: 'ok' });
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="shell-identity"]'),
+    ).toBeNull();
+  });
+});

--- a/apps/admin-console/src/app/shell/shell.ts
+++ b/apps/admin-console/src/app/shell/shell.ts
@@ -1,0 +1,26 @@
+import { Component, inject } from '@angular/core';
+import { RouterLink, RouterOutlet } from '@angular/router';
+
+import { AuthService } from '../auth/auth.service';
+import { PlatformStatus } from '../platform-status/platform-status';
+
+/**
+ * The Admin Console's shell and navigation (§9's "Admin Console shell,
+ * navigation and OIDC login", issue #16). Only the Role matrix module is
+ * routed yet; the other §9.1 modules join the nav as their own issues land.
+ * Carries the platform-status readout that used to be the whole app.
+ */
+@Component({
+  standalone: true,
+  imports: [RouterLink, RouterOutlet, PlatformStatus],
+  selector: 'app-shell',
+  templateUrl: './shell.html',
+  styleUrl: './shell.css',
+})
+export class Shell {
+  protected readonly auth = inject(AuthService);
+
+  logout(): void {
+    this.auth.logout();
+  }
+}

--- a/apps/admin-console/src/index.html
+++ b/apps/admin-console/src/index.html
@@ -8,6 +8,9 @@
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
   <body>
+    <!-- Rendered by docker-entrypoint.d/30-render-env-js.sh at container
+         start; see assets/env.template.js for why. -->
+    <script src="assets/env.js"></script>
     <app-root></app-root>
   </body>
 </html>

--- a/apps/admin-service/cmd/admin-service/main.go
+++ b/apps/admin-service/cmd/admin-service/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/catalogapi"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/config"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/server"
@@ -38,6 +39,12 @@ func main() {
 	catalog, err := capabilitycatalog.LoadActiveCatalogDir(cfg.CatalogDir)
 	if err != nil {
 		logger.Error("could not load the active resource/action catalog", slog.Any("error", err))
+		os.Exit(1)
+	}
+
+	resourceCatalog, err := capabilitycatalog.LoadResourceCatalogDir(cfg.CatalogDir)
+	if err != nil {
+		logger.Error("could not load the resource catalog for the browser", slog.Any("error", err))
 		os.Exit(1)
 	}
 
@@ -69,6 +76,10 @@ func main() {
 			Catalog:                 catalog,
 			HighRiskActions:         cfg.HighRiskActions,
 			DefaultHighRiskValidity: cfg.HighRiskOverrideValidity,
+		},
+		Catalog: &catalogapi.Handler{
+			Resources:          resourceCatalog,
+			RootPolicyRevision: cfg.RootPolicyRevision,
 		},
 	})
 

--- a/apps/admin-service/internal/catalogapi/catalogapi.go
+++ b/apps/admin-service/internal/catalogapi/catalogapi.go
@@ -1,0 +1,59 @@
+// Package catalogapi serves GET /admin/authz/resources (§9.4): the
+// administration-facing resource/action catalog and the current root
+// policy revision, the data the Admin Console's resource catalog and role
+// matrix modules render (§9.1, §9.2).
+package catalogapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+)
+
+// Handler serves the resource catalog endpoint.
+type Handler struct {
+	// Resources is loaded once at startup from the same catalog directory
+	// the write path validates permission leaves against (§12.2) - the
+	// browser never gets a second, divergent copy of the catalog.
+	Resources          []capabilitycatalog.ResourceEntry
+	RootPolicyRevision string
+}
+
+type resourceView struct {
+	ResourceKey string                          `json:"resourceKey"`
+	DisplayName string                          `json:"displayName"`
+	Domain      string                          `json:"domain"`
+	Actions     []capabilitycatalog.ActionEntry `json:"actions"`
+}
+
+// Read handles GET /admin/authz/resources.
+func (h *Handler) Read(w http.ResponseWriter, r *http.Request) {
+	if _, ok := tokenauth.From(r.Context()); !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	views := make([]resourceView, 0, len(h.Resources))
+	for _, entry := range h.Resources {
+		views = append(views, resourceView{
+			ResourceKey: entry.ResourceKey, DisplayName: entry.DisplayName,
+			Domain: entry.Domain, Actions: entry.Actions,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"resources":          views,
+		"rootPolicyRevision": h.RootPolicyRevision,
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}

--- a/apps/admin-service/internal/catalogapi/catalogapi_test.go
+++ b/apps/admin-service/internal/catalogapi/catalogapi_test.go
@@ -1,0 +1,63 @@
+package catalogapi_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/catalogapi"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+)
+
+func TestReadRequiresAVerifiedIdentity(t *testing.T) {
+	handler := &catalogapi.Handler{}
+	rec := httptest.NewRecorder()
+	handler.Read(rec, httptest.NewRequest(http.MethodGet, "/admin/authz/resources", nil))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestReadReturnsTheCatalogAndRootPolicyRevision(t *testing.T) {
+	handler := &catalogapi.Handler{
+		Resources: []capabilitycatalog.ResourceEntry{
+			{
+				ResourceKey: "patient_record", DisplayName: "Patient record", Domain: "clinical",
+				Actions: []capabilitycatalog.ActionEntry{
+					{Key: "read", DisplayName: "View patient", Context: "INSTANCE"},
+				},
+			},
+		},
+		RootPolicyRevision: "root-v1.4.0",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/authz/resources", nil)
+	req = req.WithContext(tokenauth.WithIdentity(req.Context(), tokenauth.Identity{PrincipalID: "admin-1"}))
+	rec := httptest.NewRecorder()
+	handler.Read(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if !contains(rec.Body.String(), `"resourceKey":"patient_record"`) {
+		t.Errorf("body = %s, want patient_record", rec.Body.String())
+	}
+	if !contains(rec.Body.String(), `"rootPolicyRevision":"root-v1.4.0"`) {
+		t.Errorf("body = %s, want the root policy revision", rec.Body.String())
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/apps/admin-service/internal/config/config.go
+++ b/apps/admin-service/internal/config/config.go
@@ -24,6 +24,10 @@ type Config struct {
 	// loaded from - the same per-pod-mounted release tree Cerbos and the
 	// ADS read policies and UI capabilities from (§13.1).
 	CatalogDir string
+	// RootPolicyRevision is the immutable root-policy tag currently served
+	// (§9.4's "current root revision"), e.g. "root-v1.4.0". Mirrors the
+	// ADS's own config field of the same name and default.
+	RootPolicyRevision string
 
 	// KafkaBrokers are the Kafka (or Redpanda) bootstrap addresses the
 	// outbox publisher loop writes PermissionChanged to (§10).
@@ -52,11 +56,12 @@ type LookupFunc func(key string) (string, bool)
 // service names used by the walking skeleton.
 func FromEnv(lookup LookupFunc) Config {
 	return Config{
-		HTTPAddr:     valueOr(lookup, "ADMIN_SERVICE_HTTP_ADDR", ":8081"),
-		PostgresAddr: valueOr(lookup, "POSTGRES_ADDR", "postgres:5432"),
-		PostgresDSN:  valueOr(lookup, "ASSIGNMENTSTORE_POSTGRES_DSN", ""),
-		IdPAddr:      valueOr(lookup, "IDP_ADDR", "keycloak:8080"),
-		CatalogDir:   valueOr(lookup, "AUTHORIZATION_CATALOG_DIR", "/etc/cerbos-catalog/resources"),
+		HTTPAddr:           valueOr(lookup, "ADMIN_SERVICE_HTTP_ADDR", ":8081"),
+		PostgresAddr:       valueOr(lookup, "POSTGRES_ADDR", "postgres:5432"),
+		PostgresDSN:        valueOr(lookup, "ASSIGNMENTSTORE_POSTGRES_DSN", ""),
+		IdPAddr:            valueOr(lookup, "IDP_ADDR", "keycloak:8080"),
+		CatalogDir:         valueOr(lookup, "AUTHORIZATION_CATALOG_DIR", "/etc/cerbos-catalog/resources"),
+		RootPolicyRevision: valueOr(lookup, "ROOT_POLICY_REVISION", "root-v1.4.0"),
 
 		KafkaBrokers:          splitOr(lookup, "KAFKA_BROKERS", []string{"redpanda:9092"}),
 		KafkaTopic:            valueOr(lookup, "KAFKA_PERMISSION_CHANGED_TOPIC", "permission-changed"),

--- a/apps/admin-service/internal/rolematrix/handler.go
+++ b/apps/admin-service/internal/rolematrix/handler.go
@@ -22,6 +22,7 @@ import (
 // Store is the narrow slice of assignmentstore.Store this handler needs.
 type Store interface {
 	RolePermission(ctx context.Context, key assignmentstore.RolePermissionKey) (assignmentstore.RolePermission, bool, error)
+	RolePermissionsForRole(ctx context.Context, tenantID, roleExternalID string) ([]assignmentstore.RolePermission, error)
 	SaveRoleMatrix(ctx context.Context, write assignmentstore.RoleMatrixWrite) (int64, error)
 	PermissionRevision(ctx context.Context, tenantID string) (assignmentstore.PermissionRevision, bool, error)
 }
@@ -252,6 +253,69 @@ func (h *Handler) CurrentRevision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"revision": revision.Revision})
+}
+
+// permissionView is one row of a GET .../permissions response.
+type permissionView struct {
+	ResourceKey string     `json:"resourceKey"`
+	ActionKey   string     `json:"actionKey"`
+	Enabled     bool       `json:"enabled"`
+	ValidFrom   time.Time  `json:"validFrom"`
+	ValidUntil  *time.Time `json:"validUntil,omitempty"`
+}
+
+// Read handles GET /admin/authz/tenants/{tenant}/roles/{role}/permissions
+// (§9.4): the role matrix screen's read, returning every permission row
+// the role carries exactly as stored, alongside the tenant's current
+// revision so the caller has the expectedRevision its next Save needs.
+func (h *Handler) Read(w http.ResponseWriter, r *http.Request) {
+	identity, ok := tokenauth.From(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	tenant := r.PathValue("tenant")
+	role := r.PathValue("role")
+	if err := authority.Validate(
+		authority.Principal{TenantID: identity.TenantID, HospitalID: identity.HospitalID},
+		tenant, ""); err != nil {
+		writeError(w, http.StatusForbidden, "you do not have authority over this tenant")
+		return
+	}
+
+	permissions, err := h.Store.RolePermissionsForRole(r.Context(), tenant, role)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "reading the role's permissions failed")
+		return
+	}
+
+	revision, found, err := h.Store.PermissionRevision(r.Context(), tenant)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "reading the permission revision failed")
+		return
+	}
+	currentRevision := int64(0)
+	if found {
+		currentRevision = revision.Revision
+	}
+
+	views := make([]permissionView, 0, len(permissions))
+	for _, permission := range permissions {
+		view := permissionView{
+			ResourceKey: permission.Key.ResourceKey, ActionKey: permission.Key.ActionKey,
+			Enabled: permission.Enabled, ValidFrom: permission.ValidFrom,
+		}
+		if !permission.ValidUntil.IsZero() {
+			validUntil := permission.ValidUntil
+			view.ValidUntil = &validUntil
+		}
+		views = append(views, view)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"permissions": views,
+		"revision":    currentRevision,
+	})
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {

--- a/apps/admin-service/internal/rolematrix/handler_test.go
+++ b/apps/admin-service/internal/rolematrix/handler_test.go
@@ -38,6 +38,16 @@ func (f *fakeStore) RolePermission(_ context.Context, key assignmentstore.RolePe
 	return permission, found, nil
 }
 
+func (f *fakeStore) RolePermissionsForRole(_ context.Context, tenantID, roleExternalID string) ([]assignmentstore.RolePermission, error) {
+	var found []assignmentstore.RolePermission
+	for _, permission := range f.permissions {
+		if permission.Key.TenantID == tenantID && permission.Key.RoleExternalID == roleExternalID {
+			found = append(found, permission)
+		}
+	}
+	return found, nil
+}
+
 func (f *fakeStore) SaveRoleMatrix(_ context.Context, write assignmentstore.RoleMatrixWrite) (int64, error) {
 	f.lastWrite = write
 	if f.saveErr != nil {
@@ -344,6 +354,72 @@ func TestSaveAppendsOnePermissionChangedEventPerTouchedPermission(t *testing.T) 
 	}
 	if update.Enabled {
 		t.Error("the update event reads enabled=true, want false (it was revoked)")
+	}
+}
+
+// Read must return every permission row a role carries, exactly as
+// stored, alongside the tenant's current revision (§9.4's role matrix
+// screen).
+func TestReadReturnsEveryPermissionRowAndTheCurrentRevision(t *testing.T) {
+	store := newFakeStore()
+	store.permissions[permissionKeyString(assignmentstore.RolePermissionKey{
+		TenantID: "tenant-a", RoleExternalID: "role-doctor", ResourceKey: "patient_record", ActionKey: "read",
+	})] = assignmentstore.RolePermission{
+		Key: assignmentstore.RolePermissionKey{
+			TenantID: "tenant-a", RoleExternalID: "role-doctor", ResourceKey: "patient_record", ActionKey: "read",
+		},
+		Enabled: true, ValidFrom: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), Revision: 3,
+	}
+	store.permissions[permissionKeyString(assignmentstore.RolePermissionKey{
+		TenantID: "tenant-a", RoleExternalID: "role-nurse", ResourceKey: "patient_record", ActionKey: "read",
+	})] = assignmentstore.RolePermission{
+		Key: assignmentstore.RolePermissionKey{
+			TenantID: "tenant-a", RoleExternalID: "role-nurse", ResourceKey: "patient_record", ActionKey: "read",
+		},
+		Enabled: true, Revision: 1,
+	}
+	store.revisions["tenant-a"] = 3
+	handler := newHandler(store, newFakeCatalog())
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/authz/tenants/tenant-a/roles/role-doctor/permissions", nil)
+	req.SetPathValue("tenant", "tenant-a")
+	req.SetPathValue("role", "role-doctor")
+	req = req.WithContext(tokenauth.WithIdentity(req.Context(), adminOf("tenant-a")))
+
+	rec := httptest.NewRecorder()
+	handler.Read(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	body := decodeResponse(t, rec)
+	if body["revision"] != float64(3) {
+		t.Errorf("revision = %v, want 3", body["revision"])
+	}
+	permissions, ok := body["permissions"].([]any)
+	if !ok || len(permissions) != 1 {
+		t.Fatalf("permissions = %v, want exactly role-doctor's one row", body["permissions"])
+	}
+	row := permissions[0].(map[string]any)
+	if row["resourceKey"] != "patient_record" || row["actionKey"] != "read" {
+		t.Errorf("row = %v, want patient_record/read", row)
+	}
+}
+
+func TestReadRejectsAnAdministratorFromAnotherTenant(t *testing.T) {
+	store := newFakeStore()
+	handler := newHandler(store, newFakeCatalog())
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/authz/tenants/tenant-a/roles/role-doctor/permissions", nil)
+	req.SetPathValue("tenant", "tenant-a")
+	req.SetPathValue("role", "role-doctor")
+	req = req.WithContext(tokenauth.WithIdentity(req.Context(), adminOf("tenant-b")))
+
+	rec := httptest.NewRecorder()
+	handler.Read(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/apps/admin-service/internal/server/server.go
+++ b/apps/admin-service/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/catalogapi"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/useroverride"
@@ -43,6 +44,10 @@ type Config struct {
 	// UserOverride serves the user-override endpoints. Nil means the
 	// routes are not registered.
 	UserOverride *useroverride.Handler
+
+	// Catalog serves the resource catalog endpoint. Nil means the route
+	// is not registered.
+	Catalog *catalogapi.Handler
 }
 
 // New builds the Administration Service HTTP handler.
@@ -59,6 +64,8 @@ func New(cfg Config) http.Handler {
 		if cfg.RoleMatrix != nil {
 			mux.Handle("PUT /admin/authz/tenants/{tenant}/roles/{role}/permissions",
 				authenticated(cfg.RoleMatrix.Save))
+			mux.Handle("GET /admin/authz/tenants/{tenant}/roles/{role}/permissions",
+				authenticated(cfg.RoleMatrix.Read))
 			mux.Handle("GET /admin/authz/tenants/{tenant}/permission-revision",
 				authenticated(cfg.RoleMatrix.CurrentRevision))
 		}
@@ -67,6 +74,9 @@ func New(cfg Config) http.Handler {
 				authenticated(cfg.UserOverride.Save))
 			mux.Handle("GET /admin/authz/tenants/{tenant}/hospitals/{hospital}/users/{user}/overrides",
 				authenticated(cfg.UserOverride.Read))
+		}
+		if cfg.Catalog != nil {
+			mux.Handle("GET /admin/authz/resources", authenticated(cfg.Catalog.Read))
 		}
 	}
 

--- a/apps/admin-service/internal/server/server_test.go
+++ b/apps/admin-service/internal/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/catalogapi"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/server"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/useroverride"
@@ -68,6 +69,27 @@ func TestUserOverrideRoutesRequireABearerToken(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
 		"/admin/authz/tenants/tenant-a/hospitals/hospital-1/users/user-1/overrides?resource=patient_record", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 with no bearer token", rec.Code)
+	}
+}
+
+func TestCatalogRouteIsAbsentWithoutACatalogHandler(t *testing.T) {
+	handler := server.New(server.Config{})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/authz/resources", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 when no catalog handler is configured", rec.Code)
+	}
+}
+
+func TestCatalogRouteRequiresABearerToken(t *testing.T) {
+	handler := server.New(server.Config{
+		Verifier: fakeVerifier{},
+		Catalog:  &catalogapi.Handler{},
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/authz/resources", nil))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401 with no bearer token", rec.Code)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,10 +259,15 @@ services:
     build:
       context: .
       dockerfile: apps/admin-console/Dockerfile
+    environment:
+      OIDC_ISSUER: "${KEYCLOAK_HOSTNAME:-http://localhost:8081}/realms/${IDP_REALM:-cerbos-poc}"
+      OIDC_CLIENT_ID: "${IDP_CLIENT_ID:-patient-app}"
     ports:
       - "${ADMIN_CONSOLE_PORT:-4200}:80"
     depends_on:
       ads:
+        condition: service_healthy
+      admin-service:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1/index.html"]

--- a/libs/assignmentstore/oraclestore/oraclestore.go
+++ b/libs/assignmentstore/oraclestore/oraclestore.go
@@ -196,6 +196,44 @@ func (s *Store) ActiveRolePermissions(ctx context.Context, query assignmentstore
 	return permissions, nil
 }
 
+// RolePermissionsForRole reads every permission row a role carries across
+// every resource, unfiltered by validity or enabled state (§9.2's role
+// matrix screen).
+func (s *Store) RolePermissionsForRole(ctx context.Context, tenantID, roleExternalID string) ([]assignmentstore.RolePermission, error) {
+	const query = `
+		SELECT resource_key, action_key, enabled, valid_from, valid_until, revision
+		FROM role_permission
+		WHERE tenant_id = :1 AND role_external_id = :2`
+
+	rows, err := s.db.QueryContext(ctx, query, tenantID, roleExternalID)
+	if err != nil {
+		return nil, fmt.Errorf("oraclestore: reading a role's permissions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var permissions []assignmentstore.RolePermission
+	for rows.Next() {
+		permission := assignmentstore.RolePermission{
+			Key: assignmentstore.RolePermissionKey{TenantID: tenantID, RoleExternalID: roleExternalID},
+		}
+		var enabled int64
+		var validUntil *time.Time
+		if err := rows.Scan(&permission.Key.ResourceKey, &permission.Key.ActionKey,
+			&enabled, &permission.ValidFrom, &validUntil, &permission.Revision); err != nil {
+			return nil, fmt.Errorf("oraclestore: scanning a role permission: %w", err)
+		}
+		permission.Enabled = enabled != 0
+		if validUntil != nil {
+			permission.ValidUntil = *validUntil
+		}
+		permissions = append(permissions, permission)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("oraclestore: reading a role's permissions: %w", err)
+	}
+	return permissions, nil
+}
+
 // SaveUserOverride inserts or updates one override on its §8.2 key.
 func (s *Store) SaveUserOverride(ctx context.Context, override assignmentstore.UserOverride) error {
 	const statement = `

--- a/libs/assignmentstore/postgresstore/postgresstore.go
+++ b/libs/assignmentstore/postgresstore/postgresstore.go
@@ -149,6 +149,42 @@ func (s *Store) ActiveRolePermissions(ctx context.Context, query assignmentstore
 	return permissions, nil
 }
 
+// RolePermissionsForRole reads every permission row a role carries across
+// every resource, unfiltered by validity or enabled state (§9.2's role
+// matrix screen).
+func (s *Store) RolePermissionsForRole(ctx context.Context, tenantID, roleExternalID string) ([]assignmentstore.RolePermission, error) {
+	const query = `
+		SELECT resource_key, action_key, enabled, valid_from, valid_until, revision
+		FROM role_permission
+		WHERE tenant_id = $1 AND role_external_id = $2`
+
+	rows, err := s.pool.Query(ctx, query, tenantID, roleExternalID)
+	if err != nil {
+		return nil, fmt.Errorf("postgresstore: reading a role's permissions: %w", err)
+	}
+	defer rows.Close()
+
+	var permissions []assignmentstore.RolePermission
+	for rows.Next() {
+		permission := assignmentstore.RolePermission{
+			Key: assignmentstore.RolePermissionKey{TenantID: tenantID, RoleExternalID: roleExternalID},
+		}
+		var validUntil *time.Time
+		if err := rows.Scan(&permission.Key.ResourceKey, &permission.Key.ActionKey,
+			&permission.Enabled, &permission.ValidFrom, &validUntil, &permission.Revision); err != nil {
+			return nil, fmt.Errorf("postgresstore: scanning a role permission: %w", err)
+		}
+		if validUntil != nil {
+			permission.ValidUntil = *validUntil
+		}
+		permissions = append(permissions, permission)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("postgresstore: reading a role's permissions: %w", err)
+	}
+	return permissions, nil
+}
+
 // endOrNull maps the zero instant to a database NULL. A grant with no planned
 // end is the ordinary case, and storing year zero instead would make it look
 // like a grant that expired before it began.

--- a/libs/assignmentstore/store.go
+++ b/libs/assignmentstore/store.go
@@ -295,6 +295,13 @@ type Store interface {
 	// nothing" and "denies" are different facts (§8.3).
 	ActiveRolePermissions(ctx context.Context, query ActiveRolePermissionQuery) ([]RolePermission, error)
 
+	// RolePermissionsForRole reads every permission row a role carries
+	// across every resource, regardless of validity window or enabled
+	// state (§9.2's role matrix screen: an administrator editing a role
+	// needs to see a disabled or expired grant exactly as stored, not
+	// filtered the way a live decision would filter it).
+	RolePermissionsForRole(ctx context.Context, tenantID, roleExternalID string) ([]RolePermission, error)
+
 	SaveUserOverride(ctx context.Context, override UserOverride) error
 	UserOverride(ctx context.Context, key UserOverrideKey) (UserOverride, bool, error)
 

--- a/libs/assignmentstore/storecontract/contract.go
+++ b/libs/assignmentstore/storecontract/contract.go
@@ -93,6 +93,9 @@ func Run(t *testing.T, newStore Factory) {
 	t.Run("a role permission with no end date stays active", func(t *testing.T) {
 		assertOpenEndedRolePermission(t, newStore(t))
 	})
+	t.Run("RolePermissionsForRole reads every row for a role, unfiltered by validity or enabled state", func(t *testing.T) {
+		assertRolePermissionsForRole(t, newStore(t))
+	})
 	t.Run("the active user overrides for one principal and resource are read in one call", func(t *testing.T) {
 		assertActiveUserOverrides(t, newStore(t))
 	})
@@ -269,6 +272,64 @@ func assertOpenEndedRolePermission(t *testing.T, store assignmentstore.Store) {
 	}
 	if len(active) != 1 {
 		t.Fatalf("an open-ended grant resolved %d permissions, want 1", len(active))
+	}
+}
+
+// RolePermissionsForRole is the role matrix screen's read: everything a
+// role carries, exactly as stored, including a disabled row and one whose
+// validity window has already closed - neither of which ActiveRolePermissions
+// would return.
+func assertRolePermissionsForRole(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "role_permission")
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	save := func(resource, action string, enabled bool, from, until time.Time) {
+		t.Helper()
+		if err := store.SaveRolePermission(ctx, assignmentstore.RolePermission{
+			Key: assignmentstore.RolePermissionKey{
+				TenantID: "tenant-a", RoleExternalID: "role-doctor",
+				ResourceKey: resource, ActionKey: action,
+			},
+			Enabled: enabled, ValidFrom: from, ValidUntil: until, Revision: 1,
+		}); err != nil {
+			t.Fatalf("saving %s/%s: %v", resource, action, err)
+		}
+	}
+
+	save("patient_record", "read", true, now.AddDate(-1, 0, 0), time.Time{})
+	save("patient_record", "delete", false, now.AddDate(-1, 0, 0), time.Time{})
+	save("medication_request", "read", true, now.AddDate(-2, 0, 0), now.AddDate(-1, 0, 0))
+	// A different role's row must never appear.
+	if err := store.SaveRolePermission(ctx, assignmentstore.RolePermission{
+		Key: assignmentstore.RolePermissionKey{
+			TenantID: "tenant-a", RoleExternalID: "role-nurse",
+			ResourceKey: "patient_record", ActionKey: "read",
+		},
+		Enabled: true, ValidFrom: now.AddDate(-1, 0, 0), Revision: 1,
+	}); err != nil {
+		t.Fatalf("saving role-nurse's row: %v", err)
+	}
+
+	found, err := store.RolePermissionsForRole(ctx, "tenant-a", "role-doctor")
+	if err != nil {
+		t.Fatalf("RolePermissionsForRole: %v", err)
+	}
+	if len(found) != 3 {
+		t.Fatalf("got %d permissions, want 3 (all of role-doctor's rows, none of role-nurse's)", len(found))
+	}
+
+	byAction := make(map[string]assignmentstore.RolePermission, len(found))
+	for _, permission := range found {
+		byAction[permission.Key.ResourceKey+"/"+permission.Key.ActionKey] = permission
+	}
+	if disabled, ok := byAction["patient_record/delete"]; !ok || disabled.Enabled {
+		t.Errorf("patient_record/delete = %+v, want present and disabled", disabled)
+	}
+	if expired, ok := byAction["medication_request/read"]; !ok || expired.ValidUntil.IsZero() {
+		t.Errorf("medication_request/read = %+v, want present with its expiry intact", expired)
 	}
 }
 

--- a/libs/capabilitycatalog/loader.go
+++ b/libs/capabilitycatalog/loader.go
@@ -57,10 +57,36 @@ func LoadDefinitionsDir(dir string) ([]UiCapabilityDefinition, error) {
 // source (§6.1), which is also the "active resource catalog" permission
 // leaves are validated against.
 type catalogResourceEntry struct {
-	Resource string `yaml:"resource"`
-	Actions  []struct {
-		Key string `yaml:"key"`
+	Resource    string `yaml:"resource"`
+	Version     string `yaml:"version"`
+	DisplayName string `yaml:"displayName"`
+	Domain      string `yaml:"domain"`
+	Actions     []struct {
+		Key         string `yaml:"key"`
+		DisplayName string `yaml:"displayName"`
+		Context     string `yaml:"context"`
 	} `yaml:"actions"`
+}
+
+// ActionEntry is one action a resource declares in the administration-facing
+// catalog (§9.1's "Resource catalog" module, §9.2's "actions grouped by
+// collection, instance and workflow context").
+type ActionEntry struct {
+	Key         string `json:"key"`
+	DisplayName string `json:"displayName"`
+	Context     string `json:"context"`
+}
+
+// ResourceEntry is one resource's full administration-facing catalog entry:
+// everything the Admin Console's resource catalog and role matrix modules
+// need to render and let an administrator search, without knowing the file
+// format underneath.
+type ResourceEntry struct {
+	ResourceKey string        `json:"resourceKey"`
+	Version     string        `json:"version"`
+	DisplayName string        `json:"displayName"`
+	Domain      string        `json:"domain"`
+	Actions     []ActionEntry `json:"actions"`
 }
 
 // LoadActiveCatalogDir builds an ActiveCatalog from every *.yaml file
@@ -95,4 +121,49 @@ func LoadActiveCatalogDir(dir string) (*ActiveCatalog, error) {
 	}
 
 	return catalog, nil
+}
+
+// LoadResourceCatalogDir reads every *.yaml file directly under dir
+// (deploy/cerbos/catalog/resources) into a key-sorted slice of
+// ResourceEntry, the shape the Admin Console's resource catalog and role
+// matrix modules serve to the browser (§9.1, §9.4's
+// "GET /admin/authz/resources").
+//
+// Sorting keeps the response deterministic regardless of directory
+// iteration order, the same reason LoadDefinitionsDir sorts its result.
+func LoadResourceCatalogDir(dir string) ([]ResourceEntry, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", dir, err)
+	}
+
+	var all []ResourceEntry
+	for _, file := range entries {
+		if file.IsDir() || filepath.Ext(file.Name()) != ".yaml" {
+			continue
+		}
+		path := filepath.Join(dir, file.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", path, err)
+		}
+		var e catalogResourceEntry
+		if err := yaml.Unmarshal(raw, &e); err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, err)
+		}
+		if e.Resource == "" {
+			return nil, fmt.Errorf("%s: catalog entry has no resource key", path)
+		}
+		actions := make([]ActionEntry, 0, len(e.Actions))
+		for _, a := range e.Actions {
+			actions = append(actions, ActionEntry{Key: a.Key, DisplayName: a.DisplayName, Context: a.Context})
+		}
+		all = append(all, ResourceEntry{
+			ResourceKey: e.Resource, Version: e.Version,
+			DisplayName: e.DisplayName, Domain: e.Domain, Actions: actions,
+		})
+	}
+
+	sort.Slice(all, func(i, j int) bool { return all[i].ResourceKey < all[j].ResourceKey })
+	return all, nil
 }

--- a/libs/capabilitycatalog/loader_test.go
+++ b/libs/capabilitycatalog/loader_test.go
@@ -53,6 +53,47 @@ func TestLoadActiveCatalogDirBuildsResourceActionPairs(t *testing.T) {
 	}
 }
 
+func TestLoadResourceCatalogDirReadsDisplayMetadata(t *testing.T) {
+	entries, err := capabilitycatalog.LoadResourceCatalogDir(filepath.Join("testdata", "catalog"))
+	if err != nil {
+		t.Fatalf("LoadResourceCatalogDir: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+
+	byKey := make(map[string]capabilitycatalog.ResourceEntry, len(entries))
+	for _, entry := range entries {
+		byKey[entry.ResourceKey] = entry
+	}
+
+	patient, ok := byKey["patient_record"]
+	if !ok {
+		t.Fatal("patient_record entry is missing")
+	}
+	if patient.DisplayName != "Patient record" || patient.Domain != "clinical" {
+		t.Errorf("patient_record = %+v, want displayName=Patient record domain=clinical", patient)
+	}
+	if len(patient.Actions) != 2 {
+		t.Fatalf("patient_record has %d actions, want 2", len(patient.Actions))
+	}
+	if patient.Actions[0].Key != "read" || patient.Actions[0].DisplayName != "View patient" || patient.Actions[0].Context != "INSTANCE" {
+		t.Errorf("patient_record.Actions[0] = %+v, want key=read displayName='View patient' context=INSTANCE", patient.Actions[0])
+	}
+}
+
+func TestLoadResourceCatalogDirIsSortedByResourceKey(t *testing.T) {
+	entries, err := capabilitycatalog.LoadResourceCatalogDir(filepath.Join("testdata", "catalog"))
+	if err != nil {
+		t.Fatalf("LoadResourceCatalogDir: %v", err)
+	}
+	for i := 1; i < len(entries); i++ {
+		if entries[i-1].ResourceKey >= entries[i].ResourceKey {
+			t.Fatalf("entries are not sorted: %q before %q", entries[i-1].ResourceKey, entries[i].ResourceKey)
+		}
+	}
+}
+
 func TestLoadedDefinitionsValidateAgainstLoadedCatalog(t *testing.T) {
 	defs, err := capabilitycatalog.LoadDefinitionsDir(filepath.Join("testdata", "definitions"))
 	if err != nil {


### PR DESCRIPTION
## What changed

Implements §9.1/§9.2's Admin Console shell, OIDC login and role permission
matrix module.

### Frontend (`apps/admin-console`)

- **`src/app/auth`**: `pkce.ts` (RFC 7636 helpers, Web Crypto-based),
  `AuthService` (Authorization Code + PKCE against Keycloak, in-memory-only
  access token, token exchange, logout), `authGuard`, `authInterceptor`
  (attaches the bearer token to every `/api/` call), and the `/callback`
  route component.
- **`src/app/shell`**: nav + the logged-in identity readout (decoded from
  the token's own claims, display only — the backend independently
  re-verifies everything).
- **`src/app/role-matrix`**: search roles via the ADS's
  `/internal/directory/roles` (the `IdentityDirectory` port), browse the
  resource catalog grouped by domain with a text filter, edit checkboxes,
  save with an expected-revision guard, and a stale-revision conflict that
  offers reload without discarding pending edits.
- **Runtime OIDC config**: `assets/env.template.js` is rendered into
  `assets/env.js` by a new `docker-entrypoint.d/30-render-env-js.sh`, the
  same `envsubst` mechanism the image already uses for
  `nginx.conf.template` — a static Angular build has no server-side
  templating step of its own to pick up a compose-time issuer URL.
- **`nginx.conf.template`**: added `/api/admin/ → admin-service:8081`,
  mirroring the existing `/api/ads/` proxy.

### Backend additions this screen needed (none of the prior issues delivered them)

- **`GET /admin/authz/tenants/{t}/roles/{r}/permissions`**
  (`rolematrix.Read`): the role matrix screen's read. Backed by a new
  `assignmentstore.Store.RolePermissionsForRole` method, implemented for
  both Postgres and Oracle with a contract test — returns every row a role
  carries, unfiltered by validity or enabled state, since an administrator
  editing a role needs to see a disabled or expired grant exactly as
  stored (mirrors how `ActiveUserOverrides` differs from a raw read).
- **`GET /admin/authz/resources`** (`catalogapi.Handler`): the
  administration-facing resource/action catalog and current root policy
  revision, backed by a new `capabilitycatalog.LoadResourceCatalogDir`.

## Acceptance criteria

- [x] An administrator can select a tenant and role and see the full
      matrix for that role — tenant comes from the token (§9.4's authority
      model is tenant-scoped per administrator); role search + selection +
      `getRoleMatrix` render the full permission grid.
- [x] The matrix remains navigable at full catalog scale — resources are
      grouped into collapsed `<details>` per domain (native, zero-JS
      collapse/expand), so the DOM cost of an unfiltered catalog stays
      bounded to what's actually open.
- [x] Search and filter locate a resource without scrolling the full
      catalog — the filter matches resource key, display name, domain, and
      action names, and auto-expands matching domain groups.
- [x] The UI states explicitly that a cleared checkbox means no grant, not
      deny — a literal sentence above the grid (`role-matrix.html`'s
      `checkbox-note`).
- [x] Saving with a stale revision shows an actionable error offering
      reload and loses no user input silently — a 409 sets
      `staleRevision()` only; the pending edits in `permissionsByKey`
      are untouched until `reload()` is explicitly called.
      `TestSaveShowsAnActionableErrorOnAStaleRevision...` in
      `role-matrix.spec.ts` asserts the toggle survives the conflict.
- [x] Inherited and composite IdP roles are visibly distinguished from
      directly assigned canonical roles / an unresolved canonical role is
      flagged with a remediation prompt — see **Design notes** below for
      why both ACs share one mechanism given the current directory
      response shape.
- [x] Every administrative call is server-side; no IdP admin credential
      reaches the browser — every call in `role-matrix-api.ts` goes
      through `/api/admin/` or `/api/ads/`; the only calls this app makes
      directly to Keycloak are the browser's *own* login redirect and
      token exchange (standard OIDC public-client PKCE), never anything
      carrying the backend's service-account credential.

## Design notes

- **Why "inherited/composite" and "unresolved" share one signal.** The
  directory adapter (`libs/idpdirectory/keycloak`) sets a role's
  `CanonicalID` only when canonical-identifier resolution produces exactly
  one match; zero or multiple matches both leave it empty. That is the
  *only* signal this response shape currently carries for "this role isn't
  a simple, directly-assignable canonical role." Building a genuinely
  separate composite-vs-unresolved distinction would mean extending
  `idpdirectory.RoleRef` and the Keycloak adapter — out of this issue's
  declared scope (blocked by #6, not reopening it). The console treats
  every non-canonical entry as informational-only and not selectable,
  which satisfies both AC wordings honestly without overclaiming a
  distinction the data doesn't make.
- **No role/effective-result preview on this screen.** Unlike the user
  override screen (issue #15), the role matrix edits `role_permission`
  rows directly with no override or mandatory-rule combination — so there
  is nothing to preview here, and nothing that could look like a second
  precedence implementation.
- **PKCE over a third-party OIDC library.** A hand-rolled, ~100-line PKCE
  flow keeps every piece unit-testable (Web Crypto-based `pkce.ts`, a pure
  `token-claims.ts` decoder, an `AuthService` whose only untestable seam —
  `window.location.assign` — is behind the `REDIRECT` injection token)
  without adding a dependency whose internals are opaque to the test
  suite.

## Verification

- `nx test admin-console` — 38 tests, all green (auth: 27, shell: 2,
  role-matrix: 8, app: 2, platform-status: 2 — some overlap counted once).
- `nx lint admin-console` — 0 errors, 3 warnings (non-null assertions in
  test fixtures only).
- `nx build admin-console --configuration=production` — succeeds.
- `docker build -f apps/admin-console/Dockerfile .` — succeeds; manually
  ran every `docker-entrypoint.d/*.sh` script inside the built image and
  confirmed `assets/env.js` renders the injected `OIDC_ISSUER`/
  `OIDC_CLIENT_ID` correctly.
- `bash scripts/go.sh apps/admin-service test ./...`,
  `libs/assignmentstore test ./...`, `libs/capabilitycatalog test ./...`,
  `tests/architecture test ./...` — all green.
- **Live PostgreSQL**: `docker compose up -d postgres`,
  `scripts/liquibase.sh postgres update`,
  `scripts/tests/store-contract.sh postgres` — green, including the new
  `RolePermissionsForRole` contract case.
- `gofmt -l` over touched Go trees, `docker compose config -q` — clean.
- Oracle dual-dialect run deferred for the same resource reason as PR #41
  (insufficient free RAM to bring up Oracle Free alongside Postgres in
  this environment); the Oracle adapter change mirrors Postgres 1:1.

Closes #16


Closes #16
