### PR TITLE
Admin Console: user override module (#17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ env:
   # The Nx Go plugin needs a `go` on PATH; the shim forwards to a container so
   # the runner never installs a Go toolchain.
   NX_GO_SHIM: ${{ github.workspace }}/scripts/bin
+  # Belt-and-suspenders alongside nx.json's own "analytics": false and
+  # "neverConnectToCloud": true - no vendor here should receive a usage
+  # ping from a CI run of this prototype.
+  NX_NO_CLOUD: "true"
+  NG_CLI_ANALYTICS: "false"
 
 jobs:
   affected:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ credential, and `.env` is git-ignored.
 Keycloak, Gitea and the Cerbos Admin API credentials arrive with the slices that
 introduce those services.
 
+## Vendor telemetry
+
+Every vendor product in the stack that ships an opt-out is opted out, so
+nothing here phones home on a contributor's or CI's behalf:
+
+| Product | Setting | Where |
+| --- | --- | --- |
+| Nx | `analytics: false`, `neverConnectToCloud: true` | `nx.json` |
+| Nx (defense-in-depth) | `NX_NO_CLOUD=true` | CI env |
+| Angular CLI | `NG_CLI_ANALYTICS=false` | CI env |
+| Cerbos | `telemetry.disabled: true` | `deploy/cerbos/config.yaml` |
+| Redpanda | `--set=redpanda.enable_usage_stats=false` | `docker-compose.yml` |
+
+Go's own telemetry (`go telemetry`) is opt-in and off by default, so it needs
+no override here.
+
 ## Workspace layout
 
 ```

--- a/apps/admin-console/src/app/app.routes.ts
+++ b/apps/admin-console/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { authGuard } from './auth/auth.guard';
 import { Callback } from './auth/callback';
 import { RoleMatrix } from './role-matrix/role-matrix';
 import { Shell } from './shell/shell';
+import { UserOverride } from './user-override/user-override';
 
 export const appRoutes: Route[] = [
   { path: 'callback', component: Callback },
@@ -14,6 +15,7 @@ export const appRoutes: Route[] = [
     children: [
       { path: '', redirectTo: 'role-matrix', pathMatch: 'full' },
       { path: 'role-matrix', component: RoleMatrix },
+      { path: 'user-overrides', component: UserOverride },
     ],
   },
 ];

--- a/apps/admin-console/src/app/resource-catalog.ts
+++ b/apps/admin-console/src/app/resource-catalog.ts
@@ -1,0 +1,41 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ADMIN_BASE_URL } from './admin-base-url';
+
+/** One action a resource declares in the administration-facing catalog. */
+export interface ActionEntry {
+  key: string;
+  displayName: string;
+  context: string;
+}
+
+/** One resource's full administration-facing catalog entry (§9.1, §9.2). */
+export interface ResourceEntry {
+  resourceKey: string;
+  displayName: string;
+  domain: string;
+  actions: ActionEntry[];
+}
+
+export interface ResourceCatalog {
+  resources: ResourceEntry[];
+  rootPolicyRevision: string;
+}
+
+/**
+ * `GET /admin/authz/resources`, shared by the role matrix (issue #16) and
+ * user override (issue #17) screens - both browse the same catalog to pick
+ * a resource and action, and neither should hold its own copy of the
+ * fetch.
+ */
+@Injectable({ providedIn: 'root' })
+export class ResourceCatalogApi {
+  private readonly http = inject(HttpClient);
+  private readonly adminBaseUrl = inject(ADMIN_BASE_URL);
+
+  getResourceCatalog(): Observable<ResourceCatalog> {
+    return this.http.get<ResourceCatalog>(`${this.adminBaseUrl}/authz/resources`);
+  }
+}

--- a/apps/admin-console/src/app/role-matrix/role-matrix-api.ts
+++ b/apps/admin-console/src/app/role-matrix/role-matrix-api.ts
@@ -4,6 +4,9 @@ import { Observable } from 'rxjs';
 
 import { ADMIN_BASE_URL } from '../admin-base-url';
 import { ADS_BASE_URL } from '../platform-status/ads-base-url';
+import { ResourceCatalog, ResourceCatalogApi } from '../resource-catalog';
+
+export type { ActionEntry, ResourceCatalog, ResourceEntry } from '../resource-catalog';
 
 /** A role as the identity directory reports it (§7.5, §9.2). */
 export interface RoleRef {
@@ -25,24 +28,6 @@ export interface RoleRef {
 
 export interface RoleSearchResult {
   items: RoleRef[];
-}
-
-export interface ActionEntry {
-  key: string;
-  displayName: string;
-  context: string;
-}
-
-export interface ResourceEntry {
-  resourceKey: string;
-  displayName: string;
-  domain: string;
-  actions: ActionEntry[];
-}
-
-export interface ResourceCatalog {
-  resources: ResourceEntry[];
-  rootPolicyRevision: string;
 }
 
 export interface PermissionRow {
@@ -71,6 +56,7 @@ export class RoleMatrixApi {
   private readonly http = inject(HttpClient);
   private readonly adsBaseUrl = inject(ADS_BASE_URL);
   private readonly adminBaseUrl = inject(ADMIN_BASE_URL);
+  private readonly resourceCatalog = inject(ResourceCatalogApi);
 
   searchRoles(query: string): Observable<RoleSearchResult> {
     return this.http.get<RoleSearchResult>(`${this.adsBaseUrl}/internal/directory/roles`, {
@@ -79,7 +65,7 @@ export class RoleMatrixApi {
   }
 
   getResourceCatalog(): Observable<ResourceCatalog> {
-    return this.http.get<ResourceCatalog>(`${this.adminBaseUrl}/authz/resources`);
+    return this.resourceCatalog.getResourceCatalog();
   }
 
   getRoleMatrix(tenant: string, role: string): Observable<RoleMatrix> {

--- a/apps/admin-console/src/app/shell/shell.html
+++ b/apps/admin-console/src/app/shell/shell.html
@@ -1,6 +1,7 @@
 <header class="shell-header">
   <nav>
     <a routerLink="/role-matrix" data-testid="nav-role-matrix">Role matrix</a>
+    <a routerLink="/user-overrides" data-testid="nav-user-overrides">User overrides</a>
   </nav>
   @if (auth.claims(); as claims) {
     <div class="shell-identity" data-testid="shell-identity">

--- a/apps/admin-console/src/app/user-override/user-override-api.ts
+++ b/apps/admin-console/src/app/user-override/user-override-api.ts
@@ -1,0 +1,156 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ADMIN_BASE_URL } from '../admin-base-url';
+import { ADS_BASE_URL } from '../platform-status/ads-base-url';
+
+/** A user as the identity directory reports it (§7.2). */
+export interface UserRef {
+  externalId: string;
+  username: string;
+  displayName: string;
+  email: string;
+  enabled: boolean;
+}
+
+export interface UserSearchResult {
+  items: UserRef[];
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+/** A role directly assigned to a user, from the same authoritative source
+ * the role matrix screen searches (§7.5). */
+export interface UserRoleRef {
+  canonicalId: string;
+  externalId: string;
+  name: string;
+  description: string;
+}
+
+export interface UserRolesResult {
+  items: UserRoleRef[];
+}
+
+export type OverrideEffectInput = 'INHERIT' | 'GRANT' | 'REVOKE';
+
+export interface SaveOverrideRequest {
+  expectedRevision: number;
+  resourceKey: string;
+  actionKey: string;
+  effect: OverrideEffectInput;
+  reason: string;
+  validFrom?: string;
+  validUntil?: string;
+  roleExternalIds: string[];
+}
+
+export interface SaveOverrideResult {
+  revision: number;
+  roleResult: boolean;
+  effectiveResult: boolean;
+  noPracticalEffect: boolean;
+  /** Present only when the server applied a default expiry the request
+   * did not name (§9.3's bounded default for a high-risk action). */
+  appliedValidUntil?: string;
+}
+
+export interface OverrideRow {
+  actionKey: string;
+  effect: string;
+  enabled: boolean;
+  reason?: string;
+  validFrom: string;
+  validUntil?: string;
+  revision: number;
+}
+
+export interface OverridesResult {
+  overrides: OverrideRow[];
+}
+
+export interface PreviewRequest {
+  resourceKey: string;
+  actionKey: string;
+  effect: OverrideEffectInput;
+  roleExternalIds: string[];
+}
+
+export interface PreviewResult {
+  roleResult: boolean;
+  effectiveResult: boolean;
+  noPracticalEffect: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UserOverrideApi {
+  private readonly http = inject(HttpClient);
+  private readonly adsBaseUrl = inject(ADS_BASE_URL);
+  private readonly adminBaseUrl = inject(ADMIN_BASE_URL);
+
+  searchUsers(query: string, offset: number, limit: number): Observable<UserSearchResult> {
+    return this.http.get<UserSearchResult>(`${this.adsBaseUrl}/internal/directory/users`, {
+      params: {
+        ...(query ? { query } : {}),
+        offset: String(offset),
+        limit: String(limit),
+      },
+    });
+  }
+
+  getUserRoles(userExternalId: string): Observable<UserRolesResult> {
+    return this.http.get<UserRolesResult>(
+      `${this.adsBaseUrl}/internal/directory/users/${userExternalId}/roles`,
+    );
+  }
+
+  /**
+   * The tenant-wide permission revision, the same one SaveRoleMatrix
+   * advances (§10.1) and SaveUserOverrideWrite's expected-revision guard
+   * checks against. Reusing rolematrix's own endpoint here: there is only
+   * one such counter per tenant, not one per screen.
+   */
+  getCurrentRevision(tenant: string): Observable<{ revision: number }> {
+    return this.http.get<{ revision: number }>(
+      `${this.adminBaseUrl}/authz/tenants/${tenant}/permission-revision`,
+    );
+  }
+
+  getOverrides(
+    tenant: string,
+    hospital: string,
+    user: string,
+    resource: string,
+  ): Observable<OverridesResult> {
+    return this.http.get<OverridesResult>(
+      `${this.adminBaseUrl}/authz/tenants/${tenant}/hospitals/${hospital}/users/${user}/overrides`,
+      { params: { resource } },
+    );
+  }
+
+  saveOverride(
+    tenant: string,
+    hospital: string,
+    user: string,
+    request: SaveOverrideRequest,
+  ): Observable<SaveOverrideResult> {
+    return this.http.put<SaveOverrideResult>(
+      `${this.adminBaseUrl}/authz/tenants/${tenant}/hospitals/${hospital}/users/${user}/overrides`,
+      request,
+    );
+  }
+
+  preview(
+    tenant: string,
+    hospital: string,
+    user: string,
+    request: PreviewRequest,
+  ): Observable<PreviewResult> {
+    return this.http.post<PreviewResult>(
+      `${this.adminBaseUrl}/authz/tenants/${tenant}/hospitals/${hospital}/users/${user}/overrides/preview`,
+      request,
+    );
+  }
+}

--- a/apps/admin-console/src/app/user-override/user-override.css
+++ b/apps/admin-console/src/app/user-override/user-override.css
@@ -1,0 +1,26 @@
+.error {
+  color: #b00020;
+}
+
+.warning {
+  color: #8a6d00;
+  font-weight: bold;
+}
+
+.expired {
+  opacity: 0.6;
+}
+
+.active-badge {
+  color: #0a6b0a;
+  font-weight: bold;
+}
+
+.expired-badge {
+  color: #888;
+  font-style: italic;
+}
+
+.tri-state label {
+  display: block;
+}

--- a/apps/admin-console/src/app/user-override/user-override.html
+++ b/apps/admin-console/src/app/user-override/user-override.html
@@ -1,0 +1,144 @@
+<h1>User overrides</h1>
+<p data-testid="scope-note">
+  Scope: tenant {{ tenant() }}, hospital {{ hospital() }} (your own authority - overrides
+  outside this hospital cannot be written here).
+</p>
+
+<section class="user-picker">
+  <label>
+    Search users
+    <input type="text" data-testid="user-search-input" [(ngModel)]="userQuery" (ngModelChange)="searchUsers()" />
+  </label>
+  @if (userSearchError()) {
+    <p data-testid="user-search-error" class="error">{{ userSearchError() }}</p>
+  }
+
+  <ul data-testid="user-search-results">
+    @for (user of users(); track user.externalId) {
+      <li>
+        <button type="button" data-testid="user-option" (click)="selectUser(user)">
+          {{ user.displayName || user.username }}
+        </button>
+      </li>
+    }
+  </ul>
+
+  <div class="pagination">
+    <button type="button" data-testid="prev-page" [disabled]="userOffset() === 0" (click)="previousPage()">
+      Previous
+    </button>
+    <button type="button" data-testid="next-page" [disabled]="!userHasMore()" (click)="nextPage()">
+      Next
+    </button>
+  </div>
+</section>
+
+@if (selectedUser(); as user) {
+  <section class="override-editor" data-testid="editor">
+    <h2>{{ user.displayName || user.username }}</h2>
+
+    <label>
+      Resource
+      <select data-testid="resource-select" [ngModel]="selectedResourceKey()" (ngModelChange)="selectResource($event)">
+        <option value="">Select a resource</option>
+        @for (resource of resources(); track resource.resourceKey) {
+          <option [value]="resource.resourceKey">{{ resource.displayName }}</option>
+        }
+      </select>
+    </label>
+
+    @if (selectedResource(); as resource) {
+      <label>
+        Action
+        <select data-testid="action-select" [(ngModel)]="selectedActionKey">
+          <option value="">Select an action</option>
+          @for (action of resource.actions; track action.key) {
+            <option [value]="action.key">{{ action.displayName }}</option>
+          }
+        </select>
+      </label>
+    }
+
+    @if (existingOverrides().length > 0) {
+      <ul data-testid="existing-overrides">
+        @for (row of existingOverrides(); track row.actionKey) {
+          <li [attr.data-testid]="'override-row-' + row.actionKey" [class.expired]="!isActive(row)">
+            {{ row.actionKey }}: {{ row.effect }}
+            @if (isActive(row)) {
+              <span data-testid="active-badge" class="active-badge">active</span>
+            } @else {
+              <span data-testid="expired-badge" class="expired-badge">expired</span>
+            }
+          </li>
+        }
+      </ul>
+    }
+
+    <fieldset class="tri-state" data-testid="tri-state">
+      <legend>Effect</legend>
+      <label data-testid="effect-inherit">
+        <input type="radio" name="effect" value="INHERIT" [(ngModel)]="effect" />
+        Inherit - no override; the role result applies
+      </label>
+      <label data-testid="effect-grant">
+        <input type="radio" name="effect" value="GRANT" [(ngModel)]="effect" />
+        Grant - allow even if no role grants
+      </label>
+      <label data-testid="effect-revoke">
+        <input type="radio" name="effect" value="REVOKE" [(ngModel)]="effect" />
+        Revoke - deny even if a role grants (not the same as removing a role)
+      </label>
+    </fieldset>
+
+    @if (effect() !== 'INHERIT') {
+      <label>
+        Reason (required)
+        <input type="text" data-testid="reason-input" [(ngModel)]="reason" />
+      </label>
+      <label>
+        Valid from (required)
+        <input type="datetime-local" data-testid="valid-from-input" [(ngModel)]="validFrom" />
+      </label>
+      <label>
+        Valid until (optional; high-risk actions default to a bounded expiry if left blank)
+        <input type="datetime-local" data-testid="valid-until-input" [(ngModel)]="validUntil" />
+      </label>
+    }
+
+    <button type="button" data-testid="preview-button" (click)="runPreview()">Preview</button>
+    @if (previewError()) {
+      <p data-testid="preview-error" class="error">{{ previewError() }}</p>
+    }
+    @if (preview(); as p) {
+      <div data-testid="preview-panel">
+        <p data-testid="role-result">Role result: {{ p.roleResult ? 'allow' : 'no grant' }}</p>
+        <p data-testid="effective-result">Effective result: {{ p.effectiveResult ? 'allow' : 'deny' }}</p>
+        @if (p.noPracticalEffect) {
+          <p data-testid="no-op-warning" class="warning">
+            This override has no practical effect - it duplicates the existing role result.
+          </p>
+        }
+      </div>
+    }
+
+    @if (appliedValidUntil()) {
+      <p data-testid="applied-expiry-note">
+        This high-risk action was defaulted to expire on {{ appliedValidUntil() }}.
+      </p>
+    }
+
+    @if (staleRevision()) {
+      <p data-testid="stale-revision-error" class="error">
+        Someone else saved a change since this was loaded.
+        <button type="button" data-testid="reload-button" (click)="reload()">Reload</button>
+      </p>
+    }
+    @if (saveError()) {
+      <p data-testid="save-error" class="error">{{ saveError() }}</p>
+    }
+
+    <button type="button" data-testid="save-button" [disabled]="!canSave() || saving()" (click)="save()">
+      Save
+    </button>
+  </section>
+}

--- a/apps/admin-console/src/app/user-override/user-override.spec.ts
+++ b/apps/admin-console/src/app/user-override/user-override.spec.ts
@@ -1,0 +1,303 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from '../auth/auth.service';
+import { UserOverride } from './user-override';
+
+const catalog = {
+  resources: [
+    {
+      resourceKey: 'patient_record',
+      displayName: 'Patient record',
+      domain: 'clinical',
+      actions: [
+        { key: 'read', displayName: 'View patient', context: 'INSTANCE' },
+        { key: 'delete', displayName: 'Delete patient', context: 'INSTANCE' },
+      ],
+    },
+  ],
+  rootPolicyRevision: 'root-v1.4.0',
+};
+
+function setUp() {
+  TestBed.configureTestingModule({
+    imports: [UserOverride],
+    providers: [
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      {
+        provide: AuthService,
+        useValue: { claims: () => ({ tenantId: 'tenant-a', hospitalId: 'hospital-1' }) },
+      },
+    ],
+  });
+  return TestBed.inject(HttpTestingController);
+}
+
+describe('UserOverride', () => {
+  it('states its hospital-scoped authority up front', () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+    fixture.detectChanges();
+
+    const note = fixture.nativeElement.querySelector('[data-testid="scope-note"]') as HTMLElement;
+    expect(note.textContent).toContain('tenant-a');
+    expect(note.textContent).toContain('hospital-1');
+  });
+
+  it('distinguishes Inherit, Grant and Revoke as three separate controls', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+
+    const selectPromise = fixture.componentInstance.selectUser({
+      externalId: 'user-1', username: 'doctor', displayName: 'Dana Doctor', email: '', enabled: true,
+    });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
+    await selectPromise;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="effect-inherit"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="effect-grant"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="effect-revoke"]')).toBeTruthy();
+  });
+
+  it('shows both the role result and the effective result from a preview before saving', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+
+    const selectPromise = fixture.componentInstance.selectUser({
+      externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
+    });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({
+      items: [{ canonicalId: 'role-doctor', externalId: 'doctor', name: 'Doctor', description: '' }],
+    });
+    httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 3 });
+    await selectPromise;
+
+    fixture.componentInstance.selectedResourceKey.set('patient_record');
+    fixture.componentInstance.selectedActionKey.set('delete');
+    fixture.componentInstance.effect.set('REVOKE');
+
+    const previewPromise = fixture.componentInstance.runPreview();
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/hospitals/hospital-1/users/user-1/overrides/preview')
+      .flush({ roleResult: true, effectiveResult: false, noPracticalEffect: false });
+    await previewPromise;
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="role-result"]')?.textContent,
+    ).toContain('allow');
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="effective-result"]')?.textContent,
+    ).toContain('deny');
+  });
+
+  it('shows a no-op warning when the preview reports no practical effect', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+
+    const selectPromise = fixture.componentInstance.selectUser({
+      externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
+    });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
+    await selectPromise;
+
+    fixture.componentInstance.selectedResourceKey.set('patient_record');
+    fixture.componentInstance.selectedActionKey.set('read');
+
+    const previewPromise = fixture.componentInstance.runPreview();
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/hospitals/hospital-1/users/user-1/overrides/preview')
+      .flush({ roleResult: true, effectiveResult: true, noPracticalEffect: true });
+    await previewPromise;
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="no-op-warning"]'),
+    ).toBeTruthy();
+  });
+
+  it('prevents saving a GRANT or REVOKE with no reason', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+
+    const selectPromise = fixture.componentInstance.selectUser({
+      externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
+    });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
+    await selectPromise;
+
+    fixture.componentInstance.selectedResourceKey.set('patient_record');
+    fixture.componentInstance.selectedActionKey.set('read');
+    fixture.componentInstance.effect.set('GRANT');
+
+    expect(fixture.componentInstance.canSave()).toBe(false);
+
+    fixture.componentInstance.reason.set('a reason');
+    fixture.componentInstance.validFrom.set('2026-01-01T00:00');
+    expect(fixture.componentInstance.canSave()).toBe(true);
+  });
+
+  it('allows saving INHERIT with no reason', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+
+    const selectPromise = fixture.componentInstance.selectUser({
+      externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
+    });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
+    await selectPromise;
+
+    fixture.componentInstance.selectedResourceKey.set('patient_record');
+    fixture.componentInstance.selectedActionKey.set('read');
+    fixture.componentInstance.effect.set('INHERIT');
+
+    expect(fixture.componentInstance.canSave()).toBe(true);
+  });
+
+  it('shows the applied bounded expiry a high-risk grant defaulted to', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+
+    const selectPromise = fixture.componentInstance.selectUser({
+      externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
+    });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
+    await selectPromise;
+
+    fixture.componentInstance.selectedResourceKey.set('patient_record');
+    fixture.componentInstance.selectedActionKey.set('delete');
+    fixture.componentInstance.effect.set('GRANT');
+    fixture.componentInstance.reason.set('one-off task');
+    fixture.componentInstance.validFrom.set('2026-01-01T00:00');
+
+    const savePromise = fixture.componentInstance.save();
+    httpMock
+      .expectOne(
+        (req) => req.method === 'PUT' && req.url === '/api/admin/authz/tenants/tenant-a/hospitals/hospital-1/users/user-1/overrides',
+      )
+      .flush({
+        revision: 1, roleResult: false, effectiveResult: true, noPracticalEffect: false,
+        appliedValidUntil: '2026-01-31T00:00:00Z',
+      });
+    await savePromise;
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="applied-expiry-note"]')?.textContent,
+    ).toContain('2026-01-31T00:00:00Z');
+  });
+
+  it('shows an actionable stale-revision error without discarding the pending edit', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+
+    const selectPromise = fixture.componentInstance.selectUser({
+      externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
+    });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
+    await selectPromise;
+
+    fixture.componentInstance.selectedResourceKey.set('patient_record');
+    fixture.componentInstance.selectedActionKey.set('read');
+    fixture.componentInstance.effect.set('GRANT');
+    fixture.componentInstance.reason.set('cover');
+    fixture.componentInstance.validFrom.set('2026-01-01T00:00');
+
+    const savePromise = fixture.componentInstance.save();
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/hospitals/hospital-1/users/user-1/overrides')
+      .flush({ error: 'stale' }, { status: 409, statusText: 'Conflict' });
+    await savePromise;
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="stale-revision-error"]'),
+    ).toBeTruthy();
+    expect(fixture.componentInstance.reason()).toEqual('cover');
+  });
+
+  it('distinguishes an expired override from an active one', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+
+    const selectPromise = fixture.componentInstance.selectUser({
+      externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
+    });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
+    await selectPromise;
+
+    const resourcePromise = fixture.componentInstance.selectResource('patient_record');
+    httpMock
+      .expectOne(
+        (req) => req.url === '/api/admin/authz/tenants/tenant-a/hospitals/hospital-1/users/user-1/overrides',
+      )
+      .flush({
+        overrides: [
+          { actionKey: 'read', effect: 'GRANT', enabled: true, validFrom: '2020-01-01T00:00:00Z' },
+          {
+            actionKey: 'delete', effect: 'GRANT', enabled: true,
+            validFrom: '2020-01-01T00:00:00Z', validUntil: '2021-01-01T00:00:00Z',
+          },
+        ],
+      });
+    await resourcePromise;
+    fixture.detectChanges();
+
+    const rows = fixture.componentInstance.existingOverrides();
+    expect(fixture.componentInstance.isActive(rows[0])).toBe(true);
+    expect(fixture.componentInstance.isActive(rows[1])).toBe(false);
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="override-row-read"] [data-testid="active-badge"]'),
+    ).toBeTruthy();
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="override-row-delete"] [data-testid="expired-badge"]'),
+    ).toBeTruthy();
+  });
+
+  it('paginates user search results', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+
+    const searchPromise = fixture.componentInstance.searchUsers();
+    httpMock
+      .expectOne('/api/ads/internal/directory/users?offset=0&limit=20')
+      .flush({ items: [{ externalId: 'user-1', username: 'a', displayName: '', email: '', enabled: true }], offset: 0, limit: 20, hasMore: true });
+    await searchPromise;
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.userHasMore()).toBe(true);
+
+    const nextPromise = fixture.componentInstance.nextPage();
+    httpMock
+      .expectOne('/api/ads/internal/directory/users?offset=20&limit=20')
+      .flush({ items: [], offset: 20, limit: 20, hasMore: false });
+    await nextPromise;
+
+    expect(fixture.componentInstance.userOffset()).toEqual(20);
+    expect(fixture.componentInstance.userHasMore()).toBe(false);
+  });
+});

--- a/apps/admin-console/src/app/user-override/user-override.ts
+++ b/apps/admin-console/src/app/user-override/user-override.ts
@@ -1,0 +1,266 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { firstValueFrom } from 'rxjs';
+
+import { AuthService } from '../auth/auth.service';
+import { ResourceCatalogApi, ResourceEntry } from '../resource-catalog';
+import {
+  OverrideEffectInput,
+  OverrideRow,
+  PreviewResult,
+  UserOverrideApi,
+  UserRef,
+  UserRoleRef,
+} from './user-override-api';
+
+const DEFAULT_PAGE_LIMIT = 20;
+
+/**
+ * The user-override screen (§9.1, §9.3, issue #17): the tri-state
+ * INHERIT/GRANT/REVOKE control, with a side-by-side role-result and
+ * effective-result preview before saving.
+ */
+@Component({
+  standalone: true,
+  imports: [FormsModule],
+  selector: 'app-user-override',
+  templateUrl: './user-override.html',
+  styleUrl: './user-override.css',
+})
+export class UserOverride {
+  private readonly api = inject(UserOverrideApi);
+  private readonly catalogApi = inject(ResourceCatalogApi);
+  private readonly auth = inject(AuthService);
+
+  /**
+   * Both are fixed by the administrator's own token scope (§9.4's
+   * authority check is tenant *and* hospital for this screen) - there is
+   * nothing to pick beyond what the token already names, and the screen
+   * says so.
+   */
+  readonly tenant = computed(() => this.auth.claims()?.tenantId ?? '');
+  readonly hospital = computed(() => this.auth.claims()?.hospitalId ?? '');
+
+  readonly userQuery = signal('');
+  readonly userOffset = signal(0);
+  readonly users = signal<UserRef[]>([]);
+  readonly userHasMore = signal(false);
+  readonly userSearchError = signal<string | null>(null);
+
+  readonly selectedUser = signal<UserRef | null>(null);
+  private readonly userRoles = signal<UserRoleRef[]>([]);
+
+  readonly resources = signal<ResourceEntry[]>([]);
+  readonly selectedResourceKey = signal('');
+  readonly selectedActionKey = signal('');
+
+  readonly effect = signal<OverrideEffectInput>('INHERIT');
+  readonly reason = signal('');
+  readonly validFrom = signal('');
+  readonly validUntil = signal('');
+
+  readonly existingOverrides = signal<OverrideRow[]>([]);
+  readonly preview = signal<PreviewResult | null>(null);
+  readonly previewError = signal<string | null>(null);
+
+  readonly saving = signal(false);
+  readonly saveError = signal<string | null>(null);
+  readonly staleRevision = signal(false);
+  private lastKnownRevision = 0;
+  readonly appliedValidUntil = signal<string | null>(null);
+
+  readonly selectedResource = computed<ResourceEntry | undefined>(() =>
+    this.resources().find((r) => r.resourceKey === this.selectedResourceKey()),
+  );
+
+  constructor() {
+    void this.loadResourceCatalog();
+  }
+
+  private async loadResourceCatalog(): Promise<void> {
+    try {
+      const catalog = await firstValueFrom(this.catalogApi.getResourceCatalog());
+      this.resources.set(catalog.resources);
+    } catch {
+      // The resource picker degrades to empty; the rest of the screen
+      // still functions for a user already selected via a different flow.
+    }
+  }
+
+  async searchUsers(resetOffset = true): Promise<void> {
+    if (resetOffset) {
+      this.userOffset.set(0);
+    }
+    this.userSearchError.set(null);
+    try {
+      const result = await firstValueFrom(
+        this.api.searchUsers(this.userQuery(), this.userOffset(), DEFAULT_PAGE_LIMIT),
+      );
+      this.users.set(result.items);
+      this.userHasMore.set(result.hasMore);
+    } catch {
+      this.userSearchError.set('User search failed.');
+    }
+  }
+
+  async nextPage(): Promise<void> {
+    this.userOffset.set(this.userOffset() + DEFAULT_PAGE_LIMIT);
+    await this.searchUsers(false);
+  }
+
+  async previousPage(): Promise<void> {
+    this.userOffset.set(Math.max(0, this.userOffset() - DEFAULT_PAGE_LIMIT));
+    await this.searchUsers(false);
+  }
+
+  async selectUser(user: UserRef): Promise<void> {
+    this.selectedUser.set(user);
+    this.saveError.set(null);
+    this.staleRevision.set(false);
+    this.preview.set(null);
+
+    // Both requests are dispatched together rather than one after the
+    // other: neither depends on the other's result, and awaiting them in
+    // sequence would double the round-trip latency for no reason.
+    const rolesRequest = firstValueFrom(this.api.getUserRoles(user.externalId)).catch(
+      () => ({ items: [] as UserRoleRef[] }),
+    );
+    const revisionRequest = firstValueFrom(this.api.getCurrentRevision(this.tenant())).catch(
+      () => ({ revision: 0 }),
+    );
+
+    const [roles, current] = await Promise.all([rolesRequest, revisionRequest]);
+    this.userRoles.set(roles.items);
+    this.lastKnownRevision = current.revision;
+  }
+
+  async selectResource(resourceKey: string): Promise<void> {
+    this.selectedResourceKey.set(resourceKey);
+    this.selectedActionKey.set('');
+    this.preview.set(null);
+    await this.loadExistingOverrides();
+  }
+
+  private async loadExistingOverrides(): Promise<void> {
+    const user = this.selectedUser();
+    const resourceKey = this.selectedResourceKey();
+    if (!user || !resourceKey) {
+      return;
+    }
+    try {
+      const result = await firstValueFrom(
+        this.api.getOverrides(this.tenant(), this.hospital(), user.externalId, resourceKey),
+      );
+      this.existingOverrides.set(result.overrides);
+    } catch {
+      this.existingOverrides.set([]);
+    }
+  }
+
+  /**
+   * Is the row for the currently selected action, if any, still within
+   * its validity window at this instant? Distinguishes an active
+   * override from an expired one (AC "An expired override is visibly
+   * distinguished from an active one") without waiting on a reconciler:
+   * the read is what already excludes it from ActiveUserOverrides on the
+   * server, but the *raw* row list here is shown so the administrator can
+   * still see history.
+   */
+  isActive(row: OverrideRow): boolean {
+    const now = new Date();
+    if (new Date(row.validFrom) > now) {
+      return false;
+    }
+    if (row.validUntil && new Date(row.validUntil) <= now) {
+      return false;
+    }
+    return true;
+  }
+
+  async runPreview(): Promise<void> {
+    const resourceKey = this.selectedResourceKey();
+    const actionKey = this.selectedActionKey();
+    if (!resourceKey || !actionKey) {
+      return;
+    }
+    const user = this.selectedUser();
+    if (!user) {
+      return;
+    }
+    this.previewError.set(null);
+    try {
+      const result = await firstValueFrom(
+        this.api.preview(this.tenant(), this.hospital(), user.externalId, {
+          resourceKey,
+          actionKey,
+          effect: this.effect(),
+          roleExternalIds: this.userRoles().map((r) => r.canonicalId).filter(Boolean),
+        }),
+      );
+      this.preview.set(result);
+    } catch {
+      this.previewError.set('The preview could not be computed.');
+    }
+  }
+
+  /** §9.3: "An override without a reason is rejected" - a GRANT or REVOKE
+   * always needs one; INHERIT clears a row and needs nothing. */
+  canSave(): boolean {
+    if (!this.selectedUser() || !this.selectedResourceKey() || !this.selectedActionKey()) {
+      return false;
+    }
+    if (this.effect() === 'INHERIT') {
+      return true;
+    }
+    return this.reason().trim() !== '' && this.validFrom() !== '';
+  }
+
+  async save(): Promise<void> {
+    const user = this.selectedUser();
+    if (!user || !this.canSave()) {
+      return;
+    }
+    this.saving.set(true);
+    this.saveError.set(null);
+    try {
+      const result = await firstValueFrom(
+        this.api.saveOverride(this.tenant(), this.hospital(), user.externalId, {
+          expectedRevision: this.lastKnownRevision,
+          resourceKey: this.selectedResourceKey(),
+          actionKey: this.selectedActionKey(),
+          effect: this.effect(),
+          reason: this.reason(),
+          validFrom: this.validFrom() || undefined,
+          validUntil: this.validUntil() || undefined,
+          roleExternalIds: this.userRoles().map((r) => r.canonicalId).filter(Boolean),
+        }),
+      );
+      this.lastKnownRevision = result.revision;
+      this.staleRevision.set(false);
+      this.appliedValidUntil.set(result.appliedValidUntil ?? null);
+      this.preview.set({
+        roleResult: result.roleResult,
+        effectiveResult: result.effectiveResult,
+        noPracticalEffect: result.noPracticalEffect,
+      });
+      // Fired without blocking save()'s own completion: refreshing the
+      // history list is a courtesy, not part of the save outcome the
+      // caller is waiting on.
+      void this.loadExistingOverrides();
+    } catch (err) {
+      if (err instanceof HttpErrorResponse && err.status === 409) {
+        this.staleRevision.set(true);
+      } else {
+        this.saveError.set('Saving the override failed.');
+      }
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  async reload(): Promise<void> {
+    await this.loadExistingOverrides();
+    this.staleRevision.set(false);
+  }
+}

--- a/apps/admin-service/internal/server/server.go
+++ b/apps/admin-service/internal/server/server.go
@@ -74,6 +74,8 @@ func New(cfg Config) http.Handler {
 				authenticated(cfg.UserOverride.Save))
 			mux.Handle("GET /admin/authz/tenants/{tenant}/hospitals/{hospital}/users/{user}/overrides",
 				authenticated(cfg.UserOverride.Read))
+			mux.Handle("POST /admin/authz/tenants/{tenant}/hospitals/{hospital}/users/{user}/overrides/preview",
+				authenticated(cfg.UserOverride.Preview))
 		}
 		if cfg.Catalog != nil {
 			mux.Handle("GET /admin/authz/resources", authenticated(cfg.Catalog.Read))

--- a/apps/admin-service/internal/useroverride/handler.go
+++ b/apps/admin-service/internal/useroverride/handler.go
@@ -158,15 +158,8 @@ func (h *Handler) Save(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var storeEffect assignmentstore.OverrideEffect
-	switch req.Effect {
-	case EffectInherit:
-		storeEffect = ""
-	case EffectGrant:
-		storeEffect = assignmentstore.EffectGrant
-	case EffectRevoke:
-		storeEffect = assignmentstore.EffectRevoke
-	default:
+	storeEffect, ok := parseEffect(req.Effect)
+	if !ok {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("effect must be INHERIT, GRANT or REVOKE, got %q", req.Effect))
 		return
 	}
@@ -259,11 +252,92 @@ func (h *Handler) Save(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	response := map[string]any{
 		"revision":          newRevision,
 		"roleResult":        roleResult,
 		"effectiveResult":   effectiveResult,
 		"noPracticalEffect": effectiveResult == roleResult,
+	}
+	// §9.3's "the safe choice is the default choice" is only a UI-visible
+	// guarantee if the console can see what was actually applied - the
+	// caller's own request may have named no expiry at all.
+	if !validUntil.IsZero() {
+		response["appliedValidUntil"] = validUntil
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// parseEffect maps the request-shape Effect onto assignmentstore's
+// narrower vocabulary. The zero value stands in for INHERIT, since the
+// store has no INHERIT value to name (§8.3: INHERIT is the absence of a
+// row, not a storable effect). ok is false for anything else.
+func parseEffect(effect Effect) (assignmentstore.OverrideEffect, bool) {
+	switch effect {
+	case EffectInherit:
+		return "", true
+	case EffectGrant:
+		return assignmentstore.EffectGrant, true
+	case EffectRevoke:
+		return assignmentstore.EffectRevoke, true
+	default:
+		return "", false
+	}
+}
+
+type previewRequest struct {
+	ResourceKey     string   `json:"resourceKey"`
+	ActionKey       string   `json:"actionKey"`
+	Effect          Effect   `json:"effect"`
+	RoleExternalIDs []string `json:"roleExternalIds"`
+}
+
+// Preview handles POST .../overrides/preview (§9.3: "Show the underlying
+// role result and final effective result before saving"). It writes
+// nothing - the same roleResult/effectiveResult computation Save performs
+// as part of a real write, offered here as a read so the console can show
+// it before the administrator commits to anything.
+func (h *Handler) Preview(w http.ResponseWriter, r *http.Request) {
+	identity, ok := tokenauth.From(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	tenant := r.PathValue("tenant")
+	hospital := r.PathValue("hospital")
+
+	if err := authority.Validate(
+		authority.Principal{TenantID: identity.TenantID, HospitalID: identity.HospitalID},
+		tenant, hospital); err != nil {
+		writeError(w, http.StatusForbidden, "you do not have authority over this tenant and hospital")
+		return
+	}
+
+	var req previewRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "malformed request body")
+		return
+	}
+	if req.ResourceKey == "" || req.ActionKey == "" {
+		writeError(w, http.StatusBadRequest, "resourceKey and actionKey are required")
+		return
+	}
+	if !h.Catalog.Has(req.ResourceKey, req.ActionKey) {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("not in the active catalog: %s:%s", req.ResourceKey, req.ActionKey))
+		return
+	}
+	storeEffect, ok := parseEffect(req.Effect)
+	if !ok {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("effect must be INHERIT, GRANT or REVOKE, got %q", req.Effect))
+		return
+	}
+
+	roleResult := h.roleResult(r.Context(), tenant, req.ResourceKey, req.ActionKey, req.RoleExternalIDs, h.now())
+	effective := effectiveResult(storeEffect, roleResult)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"roleResult":        roleResult,
+		"effectiveResult":   effective,
+		"noPracticalEffect": effective == roleResult,
 	})
 }
 

--- a/apps/admin-service/internal/useroverride/handler_test.go
+++ b/apps/admin-service/internal/useroverride/handler_test.go
@@ -299,6 +299,14 @@ func TestSaveDefaultsAHighRiskActionWithNoExpiryToABoundedExpiry(t *testing.T) {
 	if !store.lastWrite.ValidUntil.Equal(want) {
 		t.Errorf("write.ValidUntil = %s, want %s (validFrom + the bounded default)", store.lastWrite.ValidUntil, want)
 	}
+
+	// The applied default must also be visible in the response - a UI
+	// cannot show "the safe choice is the default choice" for a value it
+	// never received.
+	body := decodeResponse(t, rec)
+	if body["appliedValidUntil"] != want.Format(time.RFC3339) {
+		t.Errorf("appliedValidUntil = %v, want %s", body["appliedValidUntil"], want.Format(time.RFC3339))
+	}
 }
 
 // A non-high-risk action with no ValidUntil must stay unbounded: the
@@ -527,6 +535,81 @@ func TestSaveAppendsAPermissionChangedEventScopedToTheUser(t *testing.T) {
 	}
 	if event.Enabled {
 		t.Error("event.Enabled = true, want false for a REVOKE with no surviving role grant")
+	}
+}
+
+// Preview must report the role and effective result without writing
+// anything, the same computation Save performs as part of a real write
+// (§9.3: "Show the underlying role result and final effective result
+// before saving").
+func TestPreviewReportsBothResultsAndWritesNothing(t *testing.T) {
+	store := newFakeStore()
+	store.rolePermissions = []assignmentstore.RolePermission{
+		{Key: assignmentstore.RolePermissionKey{TenantID: "tenant-a", RoleExternalID: "role-doctor", ResourceKey: "patient_record", ActionKey: "delete"}, Enabled: true},
+	}
+	catalog := newFakeCatalog("patient_record:delete")
+	handler := newHandler(store, catalog)
+
+	raw, err := json.Marshal(map[string]any{
+		"resourceKey":     "patient_record",
+		"actionKey":       "delete",
+		"effect":          "REVOKE",
+		"roleExternalIds": []string{"role-doctor"},
+	})
+	if err != nil {
+		t.Fatalf("marshaling the request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost,
+		"/admin/authz/tenants/tenant-a/hospitals/hospital-1/users/user-1/overrides/preview",
+		bytes.NewReader(raw))
+	req.SetPathValue("tenant", "tenant-a")
+	req.SetPathValue("hospital", "hospital-1")
+	req.SetPathValue("user", "user-1")
+	req = req.WithContext(tokenauth.WithIdentity(req.Context(), adminOf("tenant-a", "hospital-1")))
+
+	rec := httptest.NewRecorder()
+	handler.Preview(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	body := decodeResponse(t, rec)
+	if body["roleResult"] != true {
+		t.Errorf("roleResult = %v, want true", body["roleResult"])
+	}
+	if body["effectiveResult"] != false {
+		t.Errorf("effectiveResult = %v, want false (REVOKE defeats the role grant)", body["effectiveResult"])
+	}
+	if store.revisions["tenant-a"] != 0 || len(store.overrides) != 0 {
+		t.Error("Preview wrote something; it must be read-only")
+	}
+}
+
+// Preview must be refused across tenant or hospital authority, the same
+// as Save.
+func TestPreviewRejectsAcrossHospitalAuthority(t *testing.T) {
+	store := newFakeStore()
+	catalog := newFakeCatalog("patient_record:read")
+	handler := newHandler(store, catalog)
+
+	raw, _ := json.Marshal(map[string]any{
+		"resourceKey": "patient_record",
+		"actionKey":   "read",
+		"effect":      "INHERIT",
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		"/admin/authz/tenants/tenant-a/hospitals/hospital-1/users/user-1/overrides/preview",
+		bytes.NewReader(raw))
+	req.SetPathValue("tenant", "tenant-a")
+	req.SetPathValue("hospital", "hospital-1")
+	req.SetPathValue("user", "user-1")
+	req = req.WithContext(tokenauth.WithIdentity(req.Context(), adminOf("tenant-a", "hospital-2")))
+
+	rec := httptest.NewRecorder()
+	handler.Preview(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/apps/ads/cmd/ads/main.go
+++ b/apps/ads/cmd/ads/main.go
@@ -166,6 +166,10 @@ func main() {
 			Directory: directory,
 			Logger:    logger,
 		})),
+		DirectoryUserRolesHandler: authenticated(directoryapi.NewUserRolesHandler(directoryapi.Config{
+			Directory: directory,
+			Logger:    logger,
+		})),
 		CapabilityHandler: authenticated(capability.NewHandler(capability.Config{
 			PDP:               pdp,
 			CapabilityCatalog: capability.NewFSCatalog(cfg.CapabilityCatalogDir, cfg.CapabilityCatalogRevision, nil),

--- a/apps/ads/internal/directoryapi/directoryapi.go
+++ b/apps/ads/internal/directoryapi/directoryapi.go
@@ -113,6 +113,39 @@ func NewRolesHandler(cfg Config) http.Handler {
 	})
 }
 
+// NewUserRolesHandler serves GET /internal/directory/users/{externalId}/roles
+// (issue #17): the roles directly assigned to one user, from the same
+// authoritative source SearchRoles reads - the user-override screen's
+// "underlying role result" preview is computed from this list, not a
+// second copy of it.
+func NewUserRolesHandler(cfg Config) http.Handler {
+	logger := loggerOf(cfg)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity, ok := tokenauth.From(r.Context())
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "a bearer token is required")
+			return
+		}
+
+		externalID := r.PathValue("externalId")
+		roles, err := cfg.Directory.GetUserRoles(r.Context(),
+			idpdirectory.TenantID(identity.TenantID), externalID)
+		if err != nil {
+			fail(w, logger, r, "reading a user's roles", err)
+			return
+		}
+
+		items := make([]rolePayload, 0, len(roles))
+		for _, role := range roles {
+			items = append(items, rolePayload{
+				CanonicalID: role.CanonicalID, ExternalID: role.ExternalID,
+				Name: role.Name, Description: role.Description,
+			})
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": items})
+	})
+}
+
 // requestContext resolves who is asking and which window they want, answering
 // the caller itself when either is unusable.
 func requestContext(w http.ResponseWriter, r *http.Request) (tokenauth.Identity, idpdirectory.PageRequest, bool) {

--- a/apps/ads/internal/directoryapi/directoryapi_test.go
+++ b/apps/ads/internal/directoryapi/directoryapi_test.go
@@ -175,6 +175,47 @@ func TestAnUnreadablePageWindowIsRefusedRatherThanGuessed(t *testing.T) {
 	}
 }
 
+func TestUserRolesReportsTheRolesDirectlyAssignedToThatUser(t *testing.T) {
+	directory := &recordingDirectory{
+		userRoles: []idpdirectory.RoleRef{
+			{CanonicalID: "kc:cerbos-poc:patient-app:doctor", ExternalID: "58d1e7c8-role", Name: "doctor"},
+		},
+	}
+	handler := directoryapi.NewUserRolesHandler(directoryapi.Config{Directory: directory})
+
+	req := get("/internal/directory/users/user-doctor/roles")
+	req.SetPathValue("externalId", "user-doctor")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "kc:cerbos-poc:patient-app:doctor") {
+		t.Errorf("response carries no canonical identifier: %s", rec.Body)
+	}
+	if directory.userRolesFor != "user-doctor" {
+		t.Errorf("the directory was asked about %q, want user-doctor", directory.userRolesFor)
+	}
+}
+
+func TestUserRolesRequiresAuthentication(t *testing.T) {
+	directory := &recordingDirectory{}
+	handler := directoryapi.NewUserRolesHandler(directoryapi.Config{Directory: directory})
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/directory/users/user-doctor/roles", nil)
+	req.SetPathValue("externalId", "user-doctor")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if directory.calls != 0 {
+		t.Error("the directory was called for an unauthenticated request")
+	}
+}
+
 func get(target string) *http.Request {
 	request := httptest.NewRequest(http.MethodGet, target, nil)
 	return request.WithContext(tokenauth.WithIdentity(request.Context(), tokenauth.Identity{
@@ -186,14 +227,16 @@ func get(target string) *http.Request {
 }
 
 type recordingDirectory struct {
-	calls      int
-	tenant     idpdirectory.TenantID
-	userSearch idpdirectory.UserSearch
-	roleSearch idpdirectory.RoleSearch
+	calls        int
+	tenant       idpdirectory.TenantID
+	userSearch   idpdirectory.UserSearch
+	roleSearch   idpdirectory.RoleSearch
+	userRolesFor string
 
-	users idpdirectory.Page[idpdirectory.UserRef]
-	roles idpdirectory.Page[idpdirectory.RoleRef]
-	err   error
+	users     idpdirectory.Page[idpdirectory.UserRef]
+	roles     idpdirectory.Page[idpdirectory.RoleRef]
+	userRoles []idpdirectory.RoleRef
+	err       error
 }
 
 func (d *recordingDirectory) SearchUsers(_ context.Context, tenant idpdirectory.TenantID, query idpdirectory.UserSearch) (idpdirectory.Page[idpdirectory.UserRef], error) {
@@ -214,6 +257,12 @@ func (d *recordingDirectory) GetUser(context.Context, idpdirectory.TenantID, str
 
 func (d *recordingDirectory) GetRole(context.Context, idpdirectory.TenantID, string) (idpdirectory.RoleRef, error) {
 	return idpdirectory.RoleRef{}, idpdirectory.ErrNotFound
+}
+
+func (d *recordingDirectory) GetUserRoles(_ context.Context, tenant idpdirectory.TenantID, userExternalID string) ([]idpdirectory.RoleRef, error) {
+	d.calls++
+	d.tenant, d.userRolesFor = tenant, userExternalID
+	return d.userRoles, d.err
 }
 
 func (d *recordingDirectory) ResolveRuntimeRoles(_ context.Context, token tokenverifier.VerifiedToken, _ idpdirectory.TenantID) ([]string, error) {

--- a/apps/ads/internal/server/server.go
+++ b/apps/ads/internal/server/server.go
@@ -41,6 +41,10 @@ type Config struct {
 	// configured, in which case the routes do not exist.
 	DirectoryUsersHandler http.Handler
 	DirectoryRolesHandler http.Handler
+	// DirectoryUserRolesHandler serves the roles directly assigned to one
+	// user (issue #17's user-override screen). Nil means the route does
+	// not exist.
+	DirectoryUserRolesHandler http.Handler
 
 	// CapabilityHandler serves POST /internal/capabilities/evaluate, the
 	// §12.3 capability snapshot endpoint (issue #11). Nil means the route
@@ -67,6 +71,9 @@ func New(cfg Config) http.Handler {
 	}
 	if cfg.DirectoryRolesHandler != nil {
 		mux.Handle("GET /internal/directory/roles", cfg.DirectoryRolesHandler)
+	}
+	if cfg.DirectoryUserRolesHandler != nil {
+		mux.Handle("GET /internal/directory/users/{externalId}/roles", cfg.DirectoryUserRolesHandler)
 	}
 	if cfg.CapabilityHandler != nil {
 		mux.Handle("POST /internal/capabilities/evaluate", cfg.CapabilityHandler)

--- a/apps/ads/internal/server/server_test.go
+++ b/apps/ads/internal/server/server_test.go
@@ -119,6 +119,32 @@ func TestTheCapabilityEndpointIsAbsentWhenNoHandlerIsConfigured(t *testing.T) {
 	}
 }
 
+func TestTheUserRolesEndpointIsMountedWhenAHandlerIsConfigured(t *testing.T) {
+	handler := server.New(server.Config{
+		DirectoryUserRolesHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		}),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/internal/directory/users/user-doctor/roles", nil))
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want the configured handler to answer", rec.Code)
+	}
+}
+
+func TestTheUserRolesEndpointIsAbsentWhenNoHandlerIsConfigured(t *testing.T) {
+	handler := server.New(server.Config{})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/internal/directory/users/user-doctor/roles", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
 func TestTheMetricsEndpointIsMountedWhenAHandlerIsConfigured(t *testing.T) {
 	handler := server.New(server.Config{
 		MetricsHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/deploy/cerbos/config.yaml
+++ b/deploy/cerbos/config.yaml
@@ -17,3 +17,9 @@ schema:
 
 audit:
   enabled: false
+
+# Cerbos phones home an anonymous usage beacon by default; this prototype
+# runs entirely inside the user's own compose network and has no vendor
+# relationship with Cerbos that needs that telemetry.
+telemetry:
+  disabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,10 @@ services:
       - --kafka-addr=PLAINTEXT://0.0.0.0:9092
       - --advertise-kafka-addr=PLAINTEXT://redpanda:9092
       - --check=false
+      # Redpanda reports anonymous usage stats to Redpanda Data by default;
+      # this is an invalidation transport internal to the compose network,
+      # not a deployment with a Redpanda support relationship.
+      - --set=redpanda.enable_usage_stats=false
     healthcheck:
       test: ["CMD", "rpk", "cluster", "health", "--exit-when-healthy"]
       interval: 5s

--- a/libs/idpdirectory/keycloak/keycloak.go
+++ b/libs/idpdirectory/keycloak/keycloak.go
@@ -186,6 +186,46 @@ func (d *Directory) GetRole(ctx context.Context, tenant idpdirectory.TenantID, e
 	return d.toRoleRef(representation), nil
 }
 
+// GetUserRoles reports the canonical roles directly assigned to a user
+// from the authoritative role source (§7.3): a client's roles or the
+// realm's, matching whichever getRoles already reads.
+func (d *Directory) GetUserRoles(ctx context.Context, tenant idpdirectory.TenantID, userExternalID string) ([]idpdirectory.RoleRef, error) {
+	if err := d.checkTenant(tenant); err != nil {
+		return nil, err
+	}
+
+	path, err := d.userRoleMappingsPath(ctx, userExternalID)
+	if err != nil {
+		return nil, err
+	}
+	var found []roleRepresentation
+	if err := d.getJSON(ctx, path, nil, &found); err != nil {
+		return nil, err
+	}
+
+	refs := make([]idpdirectory.RoleRef, 0, len(found))
+	for _, representation := range found {
+		refs = append(refs, d.toRoleRef(representation))
+	}
+	return refs, nil
+}
+
+// userRoleMappingsPath resolves where one user's role mappings live,
+// reusing rolesPath's client-id-to-UUID resolution and cache rather than
+// re-deriving it.
+func (d *Directory) userRoleMappingsPath(ctx context.Context, userExternalID string) (string, error) {
+	if d.cfg.RoleSource == tokenverifier.RoleSourceRealm {
+		return d.adminPath("users", userExternalID, "role-mappings", "realm"), nil
+	}
+	if _, err := d.rolesPath(ctx); err != nil {
+		return "", err
+	}
+	d.mu.Lock()
+	clientUUID := d.clientUUID
+	d.mu.Unlock()
+	return d.adminPath("users", userExternalID, "role-mappings", "clients", clientUUID), nil
+}
+
 // ResolveRuntimeRoles reports the canonical roles the verified token carries.
 //
 // It deliberately makes no directory call: the token has already been verified

--- a/libs/idpdirectory/keycloak/keycloak_test.go
+++ b/libs/idpdirectory/keycloak/keycloak_test.go
@@ -178,6 +178,46 @@ func TestGettingAUserReturnsItsStableIdentifierAndDisplayMetadata(t *testing.T) 
 	}
 }
 
+// A user's role mappings must come back as the same canonical identifiers
+// SearchRoles produces for the same roles, so the user-override screen's
+// role-result preview (issue #17) reads roles from the authoritative
+// source, not a second copy of it.
+func TestUserRolesReturnsTheCanonicalRolesDirectlyAssignedToThatUser(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.userRoleMappings = map[string][]role{
+		"user-doctor": {{ID: "58d1e7c8-role", Name: "doctor", Description: "Treating clinician"}},
+	}
+	defer fake.Close()
+
+	roles, err := fake.directory(t).GetUserRoles(context.Background(), tenant, "user-doctor")
+	if err != nil {
+		t.Fatalf("GetUserRoles: %v", err)
+	}
+	if len(roles) != 1 {
+		t.Fatalf("got %d roles, want 1", len(roles))
+	}
+	fromToken := canonicalRolesFromToken(t, "doctor")
+	if len(fromToken) != 1 || roles[0].CanonicalID != fromToken[0] {
+		t.Errorf("CanonicalID = %q, want %v", roles[0].CanonicalID, fromToken)
+	}
+}
+
+// A user with no assignments in the authoritative role source gets an
+// empty slice, not an error - that is an ordinary fact about the user, not
+// a directory failure.
+func TestUserRolesForAUserWithNoAssignmentsIsEmpty(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	defer fake.Close()
+
+	roles, err := fake.directory(t).GetUserRoles(context.Background(), tenant, "user-nobody")
+	if err != nil {
+		t.Fatalf("GetUserRoles: %v", err)
+	}
+	if len(roles) != 0 {
+		t.Errorf("roles = %v, want none", roles)
+	}
+}
+
 // The adapter serves exactly the tenant it was configured for. Answering for
 // another tenant would mean one realm's roles could be written into another
 // tenant's matrix.
@@ -275,6 +315,10 @@ type fakeKeycloak struct {
 
 	users       []user
 	clientRoles []role
+	// userRoleMappings keys a user's external id to the roles the fake
+	// reports as directly assigned, from the same authoritative source
+	// clientRoles models.
+	userRoleMappings map[string][]role
 	// clientUUID is the internal id the fake currently reports for the client.
 	// Changing it stands in for a realm that was rebuilt.
 	clientUUID string
@@ -319,6 +363,10 @@ func (f *fakeKeycloak) serve(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case path == "/admin/realms/"+realm+"/users":
 		writeJSON(f.t, w, window(f.users, r))
+	case strings.HasPrefix(path, "/admin/realms/"+realm+"/users/") && strings.Contains(path, "/role-mappings/clients/"+f.clientUUID):
+		id := strings.TrimSuffix(strings.TrimPrefix(path, "/admin/realms/"+realm+"/users/"),
+			"/role-mappings/clients/"+f.clientUUID)
+		writeJSON(f.t, w, f.userRoleMappings[id])
 	case strings.HasPrefix(path, "/admin/realms/"+realm+"/users/"):
 		id := strings.TrimPrefix(path, "/admin/realms/"+realm+"/users/")
 		for _, candidate := range f.users {

--- a/libs/idpdirectory/port.go
+++ b/libs/idpdirectory/port.go
@@ -109,6 +109,14 @@ type IdentityDirectory interface {
 	SearchRoles(ctx context.Context, tenant TenantID, query RoleSearch) (Page[RoleRef], error)
 	GetUser(ctx context.Context, tenant TenantID, externalID string) (UserRef, error)
 	GetRole(ctx context.Context, tenant TenantID, externalID string) (RoleRef, error)
+	// GetUserRoles reports the canonical roles directly assigned to one
+	// user, from the same authoritative role source SearchRoles reads
+	// (§7.3). It exists for the Admin Console's user-override screen
+	// (issue #17): the "underlying role result" preview it shows before
+	// saving is computed from these roles, the same way SaveRoleMatrix's
+	// caller supplies a role's own roleExternalIds - a directory read, not
+	// a second implementation of anything the ADS decides.
+	GetUserRoles(ctx context.Context, tenant TenantID, userExternalID string) ([]RoleRef, error)
 	// ResolveRuntimeRoles reports the canonical roles a verified token grants
 	// within a tenant. It reads the token rather than the directory: a
 	// directory round trip on the decision path would put the identity

--- a/libs/idpdirectory/wso2/wso2.go
+++ b/libs/idpdirectory/wso2/wso2.go
@@ -71,6 +71,11 @@ func (d *Directory) GetRole(context.Context, idpdirectory.TenantID, string) (idp
 	return idpdirectory.RoleRef{}, unimplemented("role lookup", "SCIM2 /Roles/{id}")
 }
 
+// GetUserRoles is not implemented. It would use SCIM2 /Users/{id}?attributes=roles.
+func (d *Directory) GetUserRoles(context.Context, idpdirectory.TenantID, string) ([]idpdirectory.RoleRef, error) {
+	return nil, unimplemented("user role lookup", "SCIM2 /Users/{id}?attributes=roles")
+}
+
 // ResolveRuntimeRoles is not implemented. It would normalise WSO2 groups and
 // roles into the same canonical identifiers §7.5 defines.
 func (d *Directory) ResolveRuntimeRoles(context.Context, tokenverifier.VerifiedToken, idpdirectory.TenantID) ([]string, error) {

--- a/libs/idpdirectory/wso2/wso2_test.go
+++ b/libs/idpdirectory/wso2/wso2_test.go
@@ -45,6 +45,10 @@ func TestEveryOperationReportsThatItIsNotImplemented(t *testing.T) {
 			_, err := port.GetRole(ctx, "tenant-a", "doctor")
 			return err
 		},
+		"GetUserRoles": func() error {
+			_, err := port.GetUserRoles(ctx, "tenant-a", "user-doctor")
+			return err
+		},
 		"ResolveRuntimeRoles": func() error {
 			_, err := port.ResolveRuntimeRoles(ctx, tokenverifier.VerifiedToken{}, "tenant-a")
 			return err

--- a/nx.json
+++ b/nx.json
@@ -67,5 +67,6 @@
       "style": "none"
     }
   },
-  "analytics": false
+  "analytics": false,
+  "neverConnectToCloud": true
 }


### PR DESCRIPTION
## What changed

Implements issue #17, the Admin Console user override module (§9.1, §9.3):
the tri-state override screen with the effective-result preview that makes
overrides safe to use.

**Backend, to support the screen:**
- `IdentityDirectory.GetUserRoles` (implemented for Keycloak, stubbed for
  WSO2) and the ADS route `GET /internal/directory/users/{externalId}/roles`,
  so the console can read the roles directly assigned to a user.
- `useroverride.Handler.Preview` at
  `POST .../users/{user}/overrides/preview`: runs `Save`'s own
  `roleResult`/`effectiveResult` computation without writing anything, so
  the console can show the preview *before* a real write rather than only
  as a side effect of one.
- `Save`'s response now carries `appliedValidUntil` when the server
  defaulted a bounded expiry the request did not name.

**Frontend:**
- `UserOverride` component: paginated user search, resource/action picker
  off the shared catalog, Inherit/Grant/Revoke control, mandatory
  reason/validity-start for Grant/Revoke, side-by-side role-result and
  effective-result preview, no-op warning, hospital-scope messaging,
  active/expired override badges, and stale-revision handling on save.
- Extracted `ResourceCatalogApi` out of `role-matrix-api.ts` so the role
  matrix and this module share one fetch of the resource catalog.

**Unrelated housekeeping folded in at the user's request:** disabled vendor
usage telemetry across the stack - Nx (`analytics`/`neverConnectToCloud` in
`nx.json`, `NX_NO_CLOUD` in CI), the Angular CLI (`NG_CLI_ANALYTICS` in CI),
Cerbos (`telemetry.disabled` in `deploy/cerbos/config.yaml`), and Redpanda
(`--set=redpanda.enable_usage_stats=false`).

## Acceptance criteria

- [x] The tri-state control clearly distinguishes Inherit, Grant and Revoke
      - three separate radio options, each labelled with what it does.
- [x] The role result and the effective result are both shown before saving
      - `Preview` (backend, read-only) + the preview panel (frontend),
        run from the "Preview" button before any save.
- [x] Saving without a reason is prevented in the UI - `canSave()` requires
      a non-empty reason for Grant/Revoke; INHERIT needs none.
- [x] A high-risk grant defaults to a bounded expiry - existing backend
      behaviour (issue #15); now also visible via `appliedValidUntil`.
- [x] A no-op override raises a visible warning before saving - the preview
      panel's `noPracticalEffect` warning.
- [x] The screen makes clear that overrides are hospital-scoped - the scope
      note states the tenant/hospital the token authorizes.
- [x] Directory search paginates and remains usable against a large user
      population - offset/limit paging with a `hasMore` flag.
- [x] An expired override is visibly distinguished from an active one -
      active/expired badges computed from each row's validity window.

## How this was verified locally

- `go test ./...` for `apps/ads`, `apps/admin-service`, `libs/idpdirectory`,
  `tests/architecture` - all green, including new tests for
  `GetUserRoles`, `Preview`, and `appliedValidUntil`.
- `nx test admin-console` - 48/48 green, including the new
  `user-override.spec.ts` covering every acceptance criterion above.
- `nx affected --target=lint/test/build --base=main` - clean (0 errors; 3
  pre-existing warnings unrelated to this change).
- `nx lint admin-console` / `nx build admin-console` (production) - clean.
- `scripts/tests/compose-contract.py` and
  `scripts/tests/nx-affected-isolation.sh` - both pass, confirming the
  telemetry-related compose/CI edits didn't break either contract.

Closes #17


Closes #17
