### PR TITLE
Admin Console: resource catalog and capability impact modules (#18)

### DIFF
--- a/apps/admin-console/src/app/app.routes.ts
+++ b/apps/admin-console/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Route } from '@angular/router';
 
 import { authGuard } from './auth/auth.guard';
 import { Callback } from './auth/callback';
+import { ResourceCatalogBrowser } from './resource-catalog-browser/resource-catalog-browser';
 import { RoleMatrix } from './role-matrix/role-matrix';
 import { Shell } from './shell/shell';
 import { UserOverride } from './user-override/user-override';
@@ -16,6 +17,7 @@ export const appRoutes: Route[] = [
       { path: '', redirectTo: 'role-matrix', pathMatch: 'full' },
       { path: 'role-matrix', component: RoleMatrix },
       { path: 'user-overrides', component: UserOverride },
+      { path: 'resource-catalog', component: ResourceCatalogBrowser },
     ],
   },
 ];

--- a/apps/admin-console/src/app/capability-impact-api.ts
+++ b/apps/admin-console/src/app/capability-impact-api.ts
@@ -1,0 +1,36 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ADMIN_BASE_URL } from './admin-base-url';
+
+/** One composite UI capability that depends on a resource-action
+ * permission (§6.1, §9.1's capability impact module). */
+export interface CapabilityRef {
+  key: string;
+  module: string;
+  context: string;
+}
+
+export interface CapabilityImpactResult {
+  capabilities: CapabilityRef[];
+}
+
+/**
+ * `GET /admin/authz/resources/{resource}/actions/{action}/capabilities`
+ * (issue #18): every composite UI capability whose expression references
+ * a resource-action, shared by the resource catalog module's own impact
+ * view and the role matrix's pre-save impact preview - one read, not two
+ * copies of the same index.
+ */
+@Injectable({ providedIn: 'root' })
+export class CapabilityImpactApi {
+  private readonly http = inject(HttpClient);
+  private readonly adminBaseUrl = inject(ADMIN_BASE_URL);
+
+  getCapabilityImpact(resourceKey: string, actionKey: string): Observable<CapabilityImpactResult> {
+    return this.http.get<CapabilityImpactResult>(
+      `${this.adminBaseUrl}/authz/resources/${resourceKey}/actions/${actionKey}/capabilities`,
+    );
+  }
+}

--- a/apps/admin-console/src/app/resource-catalog-browser/resource-catalog-browser.css
+++ b/apps/admin-console/src/app/resource-catalog-browser/resource-catalog-browser.css
@@ -1,0 +1,12 @@
+.error {
+  color: #b00020;
+}
+
+.risk-badge {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: bold;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.25rem;
+  background: #eee;
+}

--- a/apps/admin-console/src/app/resource-catalog-browser/resource-catalog-browser.html
+++ b/apps/admin-console/src/app/resource-catalog-browser/resource-catalog-browser.html
@@ -1,0 +1,60 @@
+<h1>Resource catalog</h1>
+<p data-testid="catalog-revision">Root policy revision: {{ rootPolicyRevision() }}</p>
+
+@if (loadError()) {
+  <p data-testid="load-error" class="error">{{ loadError() }}</p>
+}
+
+<label>
+  Filter resources and actions
+  <input type="text" data-testid="filter-input" [(ngModel)]="filter" />
+</label>
+
+@for (group of domains(); track group.domain) {
+  <details class="domain-group" [attr.data-testid]="'domain-' + group.domain" [open]="filter() !== ''">
+    <summary>{{ group.domain }}</summary>
+    @for (resource of group.resources; track resource.resourceKey) {
+      <fieldset [attr.data-testid]="'resource-' + resource.resourceKey">
+        <legend>{{ resource.displayName }}</legend>
+        @for (action of resource.actions; track action.key) {
+          <button
+            type="button"
+            [attr.data-testid]="'action-' + resource.resourceKey + '-' + action.key"
+            (click)="selectAction(resource.resourceKey, action.key)"
+          >
+            {{ action.displayName }}
+            <span [attr.data-testid]="'risk-' + resource.resourceKey + '-' + action.key" class="risk-badge">
+              {{ action.risk }}
+            </span>
+          </button>
+        }
+      </fieldset>
+    }
+  </details>
+}
+
+@if (selectedActionKey()) {
+  <section class="capability-impact" data-testid="capability-impact">
+    <h2>Capabilities depending on {{ selectedResourceKey() }}:{{ selectedActionKey() }}</h2>
+
+    @if (impactLoading()) {
+      <p data-testid="impact-loading">Loading...</p>
+    }
+    @if (impactError()) {
+      <p data-testid="impact-error" class="error">{{ impactError() }}</p>
+    }
+    @if (impactCapabilities(); as capabilities) {
+      @if (capabilities.length > 0) {
+        <ul data-testid="impact-list">
+          @for (capability of capabilities; track capability.key) {
+            <li>{{ capability.key }} ({{ capability.module }})</li>
+          }
+        </ul>
+      } @else {
+        <p data-testid="impact-empty">
+          No composite capability depends on this resource-action.
+        </p>
+      }
+    }
+  </section>
+}

--- a/apps/admin-console/src/app/resource-catalog-browser/resource-catalog-browser.spec.ts
+++ b/apps/admin-console/src/app/resource-catalog-browser/resource-catalog-browser.spec.ts
@@ -1,0 +1,112 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ResourceCatalogBrowser } from './resource-catalog-browser';
+
+const catalog = {
+  resources: [
+    {
+      resourceKey: 'patient_record',
+      displayName: 'Patient record',
+      domain: 'clinical',
+      actions: [
+        { key: 'read', displayName: 'View patient', context: 'INSTANCE', risk: 'STANDARD' },
+        { key: 'delete', displayName: 'Delete patient', context: 'INSTANCE', risk: 'ELEVATED' },
+      ],
+    },
+    {
+      resourceKey: 'installation_config',
+      displayName: 'Installation config',
+      domain: 'platform',
+      actions: [{ key: 'read', displayName: 'View config', context: 'INSTANCE', risk: 'STANDARD' }],
+    },
+  ],
+  rootPolicyRevision: 'root-v1.4.0',
+};
+
+function setUp() {
+  TestBed.configureTestingModule({
+    imports: [ResourceCatalogBrowser],
+    providers: [provideHttpClient(), provideHttpClientTesting()],
+  });
+  return TestBed.inject(HttpTestingController);
+}
+
+describe('ResourceCatalogBrowser', () => {
+  it('is browsable with domain grouping, risk metadata and the current catalog revision', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(ResourceCatalogBrowser);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="catalog-revision"]')?.textContent,
+    ).toContain('root-v1.4.0');
+    expect(fixture.nativeElement.querySelector('[data-testid="domain-clinical"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="domain-platform"]')).toBeTruthy();
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="risk-patient_record-delete"]')?.textContent,
+    ).toContain('ELEVATED');
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="risk-patient_record-read"]')?.textContent,
+    ).toContain('STANDARD');
+  });
+
+  it('lists every capability depending on a selected resource-action', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(ResourceCatalogBrowser);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+    fixture.detectChanges();
+
+    const selectPromise = fixture.componentInstance.selectAction('patient_record', 'read');
+    httpMock
+      .expectOne('/api/admin/authz/resources/patient_record/actions/read/capabilities')
+      .flush({
+        capabilities: [
+          { key: 'patient.route.view', module: 'clinical', context: 'INSTANCE' },
+          { key: 'patient.component.summary', module: 'clinical', context: 'INSTANCE' },
+        ],
+      });
+    await selectPromise;
+    fixture.detectChanges();
+
+    const list = fixture.nativeElement.querySelector('[data-testid="impact-list"]') as HTMLElement;
+    expect(list.textContent).toContain('patient.route.view');
+    expect(list.textContent).toContain('patient.component.summary');
+  });
+
+  it('clearly shows a resource-action used by no capability, rather than an empty error', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(ResourceCatalogBrowser);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+    fixture.detectChanges();
+
+    const selectPromise = fixture.componentInstance.selectAction('patient_record', 'delete');
+    httpMock
+      .expectOne('/api/admin/authz/resources/patient_record/actions/delete/capabilities')
+      .flush({ capabilities: [] });
+    await selectPromise;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="impact-empty"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="impact-error"]')).toBeNull();
+  });
+
+  it('derives the impact index from the active catalog rather than a hardcoded list', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(ResourceCatalogBrowser);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+    fixture.detectChanges();
+
+    const selectPromise = fixture.componentInstance.selectAction('installation_config', 'read');
+    const req = httpMock.expectOne('/api/admin/authz/resources/installation_config/actions/read/capabilities');
+    expect(req.request.url.startsWith('/api/')).toBe(true);
+    req.flush({ capabilities: [] });
+    await selectPromise;
+  });
+});

--- a/apps/admin-console/src/app/resource-catalog-browser/resource-catalog-browser.ts
+++ b/apps/admin-console/src/app/resource-catalog-browser/resource-catalog-browser.ts
@@ -1,0 +1,103 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { firstValueFrom } from 'rxjs';
+
+import { CapabilityImpactApi, CapabilityRef } from '../capability-impact-api';
+import { ResourceCatalogApi, ResourceEntry } from '../resource-catalog';
+
+interface DomainGroup {
+  domain: string;
+  resources: ResourceEntry[];
+}
+
+/**
+ * The resource catalog and capability impact modules (§6.1, §9.1, issue
+ * #18): browse resources by domain with risk metadata and the current
+ * catalog revision, then select a resource-action to see every composite
+ * UI capability that depends on it.
+ */
+@Component({
+  standalone: true,
+  imports: [FormsModule],
+  selector: 'app-resource-catalog-browser',
+  templateUrl: './resource-catalog-browser.html',
+  styleUrl: './resource-catalog-browser.css',
+})
+export class ResourceCatalogBrowser {
+  private readonly catalogApi = inject(ResourceCatalogApi);
+  private readonly impactApi = inject(CapabilityImpactApi);
+
+  readonly resources = signal<ResourceEntry[]>([]);
+  readonly rootPolicyRevision = signal('');
+  readonly loadError = signal<string | null>(null);
+  readonly filter = signal('');
+
+  readonly selectedResourceKey = signal('');
+  readonly selectedActionKey = signal('');
+  readonly impactCapabilities = signal<CapabilityRef[] | null>(null);
+  readonly impactLoading = signal(false);
+  readonly impactError = signal<string | null>(null);
+
+  readonly domains = computed<DomainGroup[]>(() => {
+    const filter = this.filter().trim().toLowerCase();
+    const byDomain = new Map<string, ResourceEntry[]>();
+    for (const resource of this.resources()) {
+      if (filter && !this.matchesFilter(resource, filter)) {
+        continue;
+      }
+      const domain = resource.domain || 'other';
+      const group = byDomain.get(domain) ?? [];
+      group.push(resource);
+      byDomain.set(domain, group);
+    }
+    return Array.from(byDomain.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([domain, resources]) => ({ domain, resources }));
+  });
+
+  constructor() {
+    void this.loadCatalog();
+  }
+
+  private matchesFilter(resource: ResourceEntry, filter: string): boolean {
+    if (
+      resource.resourceKey.toLowerCase().includes(filter) ||
+      resource.displayName.toLowerCase().includes(filter) ||
+      resource.domain.toLowerCase().includes(filter)
+    ) {
+      return true;
+    }
+    return resource.actions.some(
+      (action) =>
+        action.key.toLowerCase().includes(filter) || action.displayName.toLowerCase().includes(filter),
+    );
+  }
+
+  private async loadCatalog(): Promise<void> {
+    try {
+      const catalog = await firstValueFrom(this.catalogApi.getResourceCatalog());
+      this.resources.set(catalog.resources);
+      this.rootPolicyRevision.set(catalog.rootPolicyRevision);
+    } catch {
+      this.loadError.set('The resource catalog could not be loaded.');
+    }
+  }
+
+  async selectAction(resourceKey: string, actionKey: string): Promise<void> {
+    this.selectedResourceKey.set(resourceKey);
+    this.selectedActionKey.set(actionKey);
+    this.impactCapabilities.set(null);
+    this.impactError.set(null);
+    this.impactLoading.set(true);
+    try {
+      const result = await firstValueFrom(this.impactApi.getCapabilityImpact(resourceKey, actionKey));
+      // §18's "clearly shown as such rather than as an empty error": an
+      // empty array is a valid, successful answer, not the absence of one.
+      this.impactCapabilities.set(result.capabilities);
+    } catch {
+      this.impactError.set('The capability impact could not be loaded.');
+    } finally {
+      this.impactLoading.set(false);
+    }
+  }
+}

--- a/apps/admin-console/src/app/resource-catalog.ts
+++ b/apps/admin-console/src/app/resource-catalog.ts
@@ -9,6 +9,9 @@ export interface ActionEntry {
   key: string;
   displayName: string;
   context: string;
+  /** STANDARD or ELEVATED (§6.1, issue #18's resource catalog risk
+   * metadata). */
+  risk: string;
 }
 
 /** One resource's full administration-facing catalog entry (§9.1, §9.2). */

--- a/apps/admin-console/src/app/role-matrix/role-matrix.html
+++ b/apps/admin-console/src/app/role-matrix/role-matrix.html
@@ -86,8 +86,44 @@
       </details>
     }
 
-    <button type="button" data-testid="save-button" [disabled]="saving()" (click)="save()">
-      Save
-    </button>
+    @if (impactPreview(); as preview) {
+      <section class="impact-preview" data-testid="impact-preview">
+        <h3>Impact preview</h3>
+        @for (row of preview; track row.resourceKey + ':' + row.actionKey) {
+          <div [attr.data-testid]="'impact-' + row.resourceKey + '-' + row.actionKey">
+            <strong>{{ row.resourceKey }}:{{ row.actionKey }}</strong>
+            @if (row.direction === 'enable') {
+              <span data-testid="impact-direction-enable">may become enabled:</span>
+            } @else {
+              <span data-testid="impact-direction-disable">may become disabled:</span>
+            }
+            @if (row.capabilities.length > 0) {
+              <ul>
+                @for (capability of row.capabilities; track capability.key) {
+                  <li>{{ capability.key }}</li>
+                }
+              </ul>
+            } @else {
+              <span data-testid="impact-none">no composite capability depends on this permission</span>
+            }
+          </div>
+        }
+        <button type="button" data-testid="confirm-save-button" [disabled]="saving()" (click)="confirmSave()">
+          Confirm save
+        </button>
+        <button type="button" data-testid="cancel-preview-button" (click)="cancelPreview()">
+          Cancel
+        </button>
+      </section>
+    } @else {
+      <button
+        type="button"
+        data-testid="save-button"
+        [disabled]="saving() || impactPreviewLoading()"
+        (click)="previewSave()"
+      >
+        Save
+      </button>
+    }
   </section>
 }

--- a/apps/admin-console/src/app/role-matrix/role-matrix.spec.ts
+++ b/apps/admin-console/src/app/role-matrix/role-matrix.spec.ts
@@ -30,15 +30,15 @@ const patientRecordCatalog = {
       displayName: 'Patient record',
       domain: 'clinical',
       actions: [
-        { key: 'read', displayName: 'View patient', context: 'INSTANCE' },
-        { key: 'delete', displayName: 'Delete patient', context: 'INSTANCE' },
+        { key: 'read', displayName: 'View patient', context: 'INSTANCE', risk: 'STANDARD' },
+        { key: 'delete', displayName: 'Delete patient', context: 'INSTANCE', risk: 'ELEVATED' },
       ],
     },
     {
       resourceKey: 'installation_config',
       displayName: 'Installation config',
       domain: 'platform',
-      actions: [{ key: 'read', displayName: 'View config', context: 'INSTANCE' }],
+      actions: [{ key: 'read', displayName: 'View config', context: 'INSTANCE', risk: 'STANDARD' }],
     },
   ],
   rootPolicyRevision: 'root-v1.4.0',
@@ -176,7 +176,7 @@ describe('RoleMatrix', () => {
     await selectPromise;
 
     fixture.componentInstance.toggle('patient_record', 'read');
-    const savePromise = fixture.componentInstance.save();
+    const savePromise = fixture.componentInstance.confirmSave();
     httpMock
       .expectOne('/api/admin/authz/tenants/tenant-a/roles/role-doctor/permissions')
       .flush({ error: 'stale' }, { status: 409, statusText: 'Conflict' });
@@ -188,6 +188,110 @@ describe('RoleMatrix', () => {
     ).toBeTruthy();
     // The pending edit survives the conflict - nothing silently reset it.
     expect(fixture.componentInstance.isEnabled('patient_record', 'read')).toBe(true);
+  });
+
+  it('shows an impact preview naming affected capabilities before saving, distinguishing enable from disable', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(RoleMatrix);
+    httpMock.expectOne('/api/admin/authz/resources').flush(patientRecordCatalog);
+
+    const selectPromise = fixture.componentInstance.selectRole({
+      canonicalId: 'role-doctor', externalId: 'doctor', name: 'Doctor', description: '',
+    });
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/roles/role-doctor/permissions')
+      .flush({
+        permissions: [{ resourceKey: 'patient_record', actionKey: 'read', enabled: true, validFrom: '2026-01-01T00:00:00Z' }],
+        revision: 1,
+      });
+    await selectPromise;
+
+    // read: enabled -> disabled. delete: disabled -> enabled.
+    fixture.componentInstance.toggle('patient_record', 'read');
+    fixture.componentInstance.toggle('patient_record', 'delete');
+
+    const previewPromise = fixture.componentInstance.previewSave();
+    httpMock
+      .expectOne('/api/admin/authz/resources/patient_record/actions/read/capabilities')
+      .flush({ capabilities: [{ key: 'patient.route.view', module: 'clinical', context: 'INSTANCE' }] });
+    httpMock
+      .expectOne('/api/admin/authz/resources/patient_record/actions/delete/capabilities')
+      .flush({ capabilities: [] });
+    await previewPromise;
+    fixture.detectChanges();
+
+    const preview = fixture.componentInstance.impactPreview();
+    expect(preview).toHaveLength(2);
+    const readRow = preview?.find((r) => r.actionKey === 'read');
+    const deleteRow = preview?.find((r) => r.actionKey === 'delete');
+    expect(readRow?.direction).toEqual('disable');
+    expect(readRow?.capabilities.map((c) => c.key)).toEqual(['patient.route.view']);
+    expect(deleteRow?.direction).toEqual('enable');
+    expect(deleteRow?.capabilities).toEqual([]);
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="impact-none"]')?.textContent,
+    ).toContain('no composite capability depends on this permission');
+
+    // Nothing was written to the server yet.
+    httpMock.expectNone('/api/admin/authz/tenants/tenant-a/roles/role-doctor/permissions');
+  });
+
+  it('confirming the preview performs the actual save', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(RoleMatrix);
+    httpMock.expectOne('/api/admin/authz/resources').flush(patientRecordCatalog);
+
+    const selectPromise = fixture.componentInstance.selectRole({
+      canonicalId: 'role-doctor', externalId: 'doctor', name: 'Doctor', description: '',
+    });
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/roles/role-doctor/permissions')
+      .flush({ permissions: [], revision: 0 });
+    await selectPromise;
+
+    fixture.componentInstance.toggle('patient_record', 'read');
+    const previewPromise = fixture.componentInstance.previewSave();
+    httpMock
+      .expectOne('/api/admin/authz/resources/patient_record/actions/read/capabilities')
+      .flush({ capabilities: [] });
+    await previewPromise;
+
+    const savePromise = fixture.componentInstance.confirmSave();
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/roles/role-doctor/permissions')
+      .flush({ revision: 1 });
+    await savePromise;
+
+    expect(fixture.componentInstance.expectedRevision()).toEqual(1);
+    expect(fixture.componentInstance.impactPreview()).toBeNull();
+  });
+
+  it('cancelling the preview writes nothing and keeps the pending edit', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(RoleMatrix);
+    httpMock.expectOne('/api/admin/authz/resources').flush(patientRecordCatalog);
+
+    const selectPromise = fixture.componentInstance.selectRole({
+      canonicalId: 'role-doctor', externalId: 'doctor', name: 'Doctor', description: '',
+    });
+    httpMock
+      .expectOne('/api/admin/authz/tenants/tenant-a/roles/role-doctor/permissions')
+      .flush({ permissions: [], revision: 0 });
+    await selectPromise;
+
+    fixture.componentInstance.toggle('patient_record', 'read');
+    const previewPromise = fixture.componentInstance.previewSave();
+    httpMock
+      .expectOne('/api/admin/authz/resources/patient_record/actions/read/capabilities')
+      .flush({ capabilities: [] });
+    await previewPromise;
+
+    fixture.componentInstance.cancelPreview();
+
+    expect(fixture.componentInstance.impactPreview()).toBeNull();
+    expect(fixture.componentInstance.isEnabled('patient_record', 'read')).toBe(true);
+    httpMock.expectNone('/api/admin/authz/tenants/tenant-a/roles/role-doctor/permissions');
   });
 
   it('sends every administrative call through the server-side proxy, never to the identity provider directly from here', async () => {

--- a/apps/admin-console/src/app/role-matrix/role-matrix.ts
+++ b/apps/admin-console/src/app/role-matrix/role-matrix.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { firstValueFrom } from 'rxjs';
 
 import { AuthService } from '../auth/auth.service';
+import { CapabilityImpactApi, CapabilityRef } from '../capability-impact-api';
 import {
   PermissionRow,
   ResourceEntry,
@@ -14,6 +15,21 @@ import {
 interface DomainGroup {
   domain: string;
   resources: ResourceEntry[];
+}
+
+/**
+ * One changed resource-action row's capability impact, computed before a
+ * save is committed (§9.2's "Show an impact preview listing composite UI
+ * capabilities that may become enabled or disabled").
+ */
+export interface ImpactPreviewRow {
+  resourceKey: string;
+  actionKey: string;
+  /** 'enable' if this row is being turned on, 'disable' if turned off -
+   * the direction determines which side of the preview it belongs on,
+   * not whether the capability's other requirements are also met. */
+  direction: 'enable' | 'disable';
+  capabilities: CapabilityRef[];
 }
 
 /**
@@ -31,6 +47,7 @@ interface DomainGroup {
 export class RoleMatrix {
   private readonly api = inject(RoleMatrixApi);
   private readonly auth = inject(AuthService);
+  private readonly capabilityImpactApi = inject(CapabilityImpactApi);
 
   /**
    * The role matrix is tenant-scoped by the administrator's own token
@@ -49,12 +66,20 @@ export class RoleMatrix {
 
   /** Keyed by `${resourceKey}:${actionKey}`, the checkbox grid's own state. */
   private readonly permissionsByKey = signal<Map<string, PermissionRow>>(new Map());
+  /** The same shape as loaded from the server, kept untouched so a save
+   * can diff "what changed" against it for the impact preview. */
+  private readonly loadedPermissionsByKey = signal<Map<string, PermissionRow>>(new Map());
   readonly expectedRevision = signal(0);
 
   readonly loadError = signal<string | null>(null);
   readonly saving = signal(false);
   readonly staleRevision = signal(false);
   readonly saveError = signal<string | null>(null);
+
+  /** Non-null once "Save" has computed what changed - the confirmation
+   * step §9.2 requires before a role matrix write actually commits. */
+  readonly impactPreview = signal<ImpactPreviewRow[] | null>(null);
+  readonly impactPreviewLoading = signal(false);
 
   readonly domains = computed<DomainGroup[]>(() => {
     const filter = this.resourceFilter().trim().toLowerCase();
@@ -142,8 +167,10 @@ export class RoleMatrix {
         byKey.set(`${row.resourceKey}:${row.actionKey}`, row);
       }
       this.permissionsByKey.set(byKey);
+      this.loadedPermissionsByKey.set(new Map(byKey));
       this.expectedRevision.set(matrix.revision);
       this.staleRevision.set(false);
+      this.impactPreview.set(null);
     } catch {
       this.loadError.set("This role's permissions could not be loaded.");
     }
@@ -170,9 +197,70 @@ export class RoleMatrix {
       validUntil: existing?.validUntil,
     });
     this.permissionsByKey.set(byKey);
+    // A further edit makes any already-computed preview stale - it would
+    // otherwise describe a save that no longer matches the checkbox grid.
+    this.impactPreview.set(null);
   }
 
-  async save(): Promise<void> {
+  /** Every resource-action row whose enabled state differs from what was
+   * loaded - the change set the impact preview and the save itself both
+   * act on. */
+  private changedRows(): PermissionRow[] {
+    const loaded = this.loadedPermissionsByKey();
+    const changed: PermissionRow[] = [];
+    for (const [key, row] of this.permissionsByKey()) {
+      if ((loaded.get(key)?.enabled ?? false) !== row.enabled) {
+        changed.push(row);
+      }
+    }
+    return changed;
+  }
+
+  /**
+   * Computes the capability impact of every changed row and holds it for
+   * confirmation - §9.2's "Show an impact preview ... before saving".
+   * Nothing is written to the server here.
+   */
+  async previewSave(): Promise<void> {
+    const role = this.selectedRole();
+    if (!role) {
+      return;
+    }
+    const changed = this.changedRows();
+    if (changed.length === 0) {
+      await this.confirmSave();
+      return;
+    }
+
+    this.impactPreviewLoading.set(true);
+    try {
+      const rows = await Promise.all(
+        changed.map(async (row): Promise<ImpactPreviewRow> => {
+          let capabilities: CapabilityRef[] = [];
+          try {
+            const result = await firstValueFrom(
+              this.capabilityImpactApi.getCapabilityImpact(row.resourceKey, row.actionKey),
+            );
+            capabilities = result.capabilities;
+          } catch {
+            // The preview degrades to "no known impact" for this row
+            // rather than blocking the whole preview on one failed read.
+          }
+          return {
+            resourceKey: row.resourceKey,
+            actionKey: row.actionKey,
+            direction: row.enabled ? 'enable' : 'disable',
+            capabilities,
+          };
+        }),
+      );
+      this.impactPreview.set(rows);
+    } finally {
+      this.impactPreviewLoading.set(false);
+    }
+  }
+
+  async confirmSave(): Promise<void> {
     const role = this.selectedRole();
     if (!role) {
       return;
@@ -189,7 +277,9 @@ export class RoleMatrix {
         ),
       );
       this.expectedRevision.set(result.revision);
+      this.loadedPermissionsByKey.set(new Map(this.permissionsByKey()));
       this.staleRevision.set(false);
+      this.impactPreview.set(null);
     } catch (err) {
       if (err instanceof HttpErrorResponse && err.status === 409) {
         // §9.2's "actionable error offering reload": the pending edits in
@@ -204,6 +294,10 @@ export class RoleMatrix {
     } finally {
       this.saving.set(false);
     }
+  }
+
+  cancelPreview(): void {
+    this.impactPreview.set(null);
   }
 
   async reload(): Promise<void> {

--- a/apps/admin-console/src/app/shell/shell.html
+++ b/apps/admin-console/src/app/shell/shell.html
@@ -2,6 +2,7 @@
   <nav>
     <a routerLink="/role-matrix" data-testid="nav-role-matrix">Role matrix</a>
     <a routerLink="/user-overrides" data-testid="nav-user-overrides">User overrides</a>
+    <a routerLink="/resource-catalog" data-testid="nav-resource-catalog">Resource catalog</a>
   </nav>
   @if (auth.claims(); as claims) {
     <div class="shell-identity" data-testid="shell-identity">

--- a/apps/admin-service/cmd/admin-service/main.go
+++ b/apps/admin-service/cmd/admin-service/main.go
@@ -48,6 +48,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	uiCapabilities, err := capabilitycatalog.LoadDefinitionsDir(cfg.CapabilityCatalogDir)
+	if err != nil {
+		logger.Error("could not load the UI capability catalog for the impact index", slog.Any("error", err))
+		os.Exit(1)
+	}
+
 	// The identity provider is selected here and nowhere else (§7.1), the
 	// same as every other service that verifies a token.
 	idpConfig, err := provider.FromEnv(os.LookupEnv)
@@ -80,6 +86,7 @@ func main() {
 		Catalog: &catalogapi.Handler{
 			Resources:          resourceCatalog,
 			RootPolicyRevision: cfg.RootPolicyRevision,
+			Capabilities:       uiCapabilities,
 		},
 	})
 

--- a/apps/admin-service/internal/catalogapi/catalogapi.go
+++ b/apps/admin-service/internal/catalogapi/catalogapi.go
@@ -12,13 +12,19 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
 )
 
-// Handler serves the resource catalog endpoint.
+// Handler serves the resource catalog and capability impact endpoints.
 type Handler struct {
 	// Resources is loaded once at startup from the same catalog directory
 	// the write path validates permission leaves against (§12.2) - the
 	// browser never gets a second, divergent copy of the catalog.
 	Resources          []capabilitycatalog.ResourceEntry
 	RootPolicyRevision string
+	// Capabilities is the full committed composite UI-capability set
+	// (issue #10), the same definitions the write path validates
+	// permission leaves against - CapabilityImpact is a read over this,
+	// never a second, hand-maintained index (§6.1: "must not use an
+	// action-to-UI-capability list as the authoritative mapping").
+	Capabilities []capabilitycatalog.UiCapabilityDefinition
 }
 
 type resourceView struct {
@@ -26,6 +32,12 @@ type resourceView struct {
 	DisplayName string                          `json:"displayName"`
 	Domain      string                          `json:"domain"`
 	Actions     []capabilitycatalog.ActionEntry `json:"actions"`
+}
+
+type capabilityView struct {
+	Key     string `json:"key"`
+	Module  string `json:"module"`
+	Context string `json:"context"`
 }
 
 // Read handles GET /admin/authz/resources.
@@ -46,6 +58,30 @@ func (h *Handler) Read(w http.ResponseWriter, r *http.Request) {
 		"resources":          views,
 		"rootPolicyRevision": h.RootPolicyRevision,
 	})
+}
+
+// CapabilityImpact handles
+// GET /admin/authz/resources/{resource}/actions/{action}/capabilities
+// (issue #18, §9.1): every composite UI capability whose expression
+// references the named resource-action, so the role matrix save flow can
+// show what changing this permission may affect before the change is
+// committed. Always 200 with a (possibly empty) list - a resource-action
+// nothing depends on is not an error condition.
+func (h *Handler) CapabilityImpact(w http.ResponseWriter, r *http.Request) {
+	if _, ok := tokenauth.From(r.Context()); !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	resource := r.PathValue("resource")
+	action := r.PathValue("action")
+	matches := capabilitycatalog.CapabilitiesReferencing(h.Capabilities, resource, action)
+
+	views := make([]capabilityView, 0, len(matches))
+	for _, m := range matches {
+		views = append(views, capabilityView{Key: m.Key, Module: m.Module, Context: m.Context})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"capabilities": views})
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {

--- a/apps/admin-service/internal/catalogapi/catalogapi_test.go
+++ b/apps/admin-service/internal/catalogapi/catalogapi_test.go
@@ -49,6 +49,78 @@ func TestReadReturnsTheCatalogAndRootPolicyRevision(t *testing.T) {
 	}
 }
 
+func TestCapabilityImpactRequiresAVerifiedIdentity(t *testing.T) {
+	handler := &catalogapi.Handler{}
+	req := httptest.NewRequest(http.MethodGet, "/admin/authz/resources/patient_record/actions/read/capabilities", nil)
+	req.SetPathValue("resource", "patient_record")
+	req.SetPathValue("action", "read")
+	rec := httptest.NewRecorder()
+	handler.CapabilityImpact(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+// Issue #18's "Selecting a resource-action lists every capability that
+// depends on it".
+func TestCapabilityImpactListsEveryDependentCapability(t *testing.T) {
+	handler := &catalogapi.Handler{
+		Capabilities: []capabilitycatalog.UiCapabilityDefinition{
+			{
+				Key: "patient.route.edit", Module: "clinical", Context: "INSTANCE",
+				Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+					{Permission: &capabilitycatalog.PermissionRequirement{Resource: "patient_record", Action: "update", TargetRef: "patient"}},
+				}},
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/authz/resources/patient_record/actions/update/capabilities", nil)
+	req.SetPathValue("resource", "patient_record")
+	req.SetPathValue("action", "update")
+	req = req.WithContext(tokenauth.WithIdentity(req.Context(), tokenauth.Identity{PrincipalID: "admin-1"}))
+	rec := httptest.NewRecorder()
+	handler.CapabilityImpact(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if !contains(rec.Body.String(), `"key":"patient.route.edit"`) {
+		t.Errorf("body = %s, want patient.route.edit", rec.Body.String())
+	}
+}
+
+// Issue #18's "A resource-action used by no capability is clearly shown
+// as such rather than as an empty error" - the response must still be
+// 200 with an empty list, never a 404.
+func TestCapabilityImpactReturnsAnEmptyListRatherThanAnErrorWhenNothingDepends(t *testing.T) {
+	handler := &catalogapi.Handler{
+		Capabilities: []capabilitycatalog.UiCapabilityDefinition{
+			{
+				Key: "patient.route.view", Module: "clinical", Context: "INSTANCE",
+				Expression: capabilitycatalog.Expression{
+					Permission: &capabilitycatalog.PermissionRequirement{Resource: "patient_record", Action: "read", TargetRef: "patient"},
+				},
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/authz/resources/patient_record/actions/delete/capabilities", nil)
+	req.SetPathValue("resource", "patient_record")
+	req.SetPathValue("action", "delete")
+	req = req.WithContext(tokenauth.WithIdentity(req.Context(), tokenauth.Identity{PrincipalID: "admin-1"}))
+	rec := httptest.NewRecorder()
+	handler.CapabilityImpact(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if !contains(rec.Body.String(), `"capabilities":[]`) {
+		t.Errorf("body = %s, want an empty capabilities array, not an error", rec.Body.String())
+	}
+}
+
 func contains(haystack, needle string) bool {
 	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
 }

--- a/apps/admin-service/internal/config/config.go
+++ b/apps/admin-service/internal/config/config.go
@@ -24,6 +24,10 @@ type Config struct {
 	// loaded from - the same per-pod-mounted release tree Cerbos and the
 	// ADS read policies and UI capabilities from (§13.1).
 	CatalogDir string
+	// CapabilityCatalogDir is the local path the capability impact
+	// endpoint (issue #18) reads UiCapabilityDefinitions from. Mirrors
+	// the ADS's own config field of the same name and default.
+	CapabilityCatalogDir string
 	// RootPolicyRevision is the immutable root-policy tag currently served
 	// (§9.4's "current root revision"), e.g. "root-v1.4.0". Mirrors the
 	// ADS's own config field of the same name and default.
@@ -56,12 +60,13 @@ type LookupFunc func(key string) (string, bool)
 // service names used by the walking skeleton.
 func FromEnv(lookup LookupFunc) Config {
 	return Config{
-		HTTPAddr:           valueOr(lookup, "ADMIN_SERVICE_HTTP_ADDR", ":8081"),
-		PostgresAddr:       valueOr(lookup, "POSTGRES_ADDR", "postgres:5432"),
-		PostgresDSN:        valueOr(lookup, "ASSIGNMENTSTORE_POSTGRES_DSN", ""),
-		IdPAddr:            valueOr(lookup, "IDP_ADDR", "keycloak:8080"),
-		CatalogDir:         valueOr(lookup, "AUTHORIZATION_CATALOG_DIR", "/etc/cerbos-catalog/resources"),
-		RootPolicyRevision: valueOr(lookup, "ROOT_POLICY_REVISION", "root-v1.4.0"),
+		HTTPAddr:             valueOr(lookup, "ADMIN_SERVICE_HTTP_ADDR", ":8081"),
+		PostgresAddr:         valueOr(lookup, "POSTGRES_ADDR", "postgres:5432"),
+		PostgresDSN:          valueOr(lookup, "ASSIGNMENTSTORE_POSTGRES_DSN", ""),
+		IdPAddr:              valueOr(lookup, "IDP_ADDR", "keycloak:8080"),
+		CatalogDir:           valueOr(lookup, "AUTHORIZATION_CATALOG_DIR", "/etc/cerbos-catalog/resources"),
+		CapabilityCatalogDir: valueOr(lookup, "CAPABILITY_CATALOG_DIR", "/etc/cerbos-catalog/ui-capabilities"),
+		RootPolicyRevision:   valueOr(lookup, "ROOT_POLICY_REVISION", "root-v1.4.0"),
 
 		KafkaBrokers:          splitOr(lookup, "KAFKA_BROKERS", []string{"redpanda:9092"}),
 		KafkaTopic:            valueOr(lookup, "KAFKA_PERMISSION_CHANGED_TOPIC", "permission-changed"),

--- a/apps/admin-service/internal/server/server.go
+++ b/apps/admin-service/internal/server/server.go
@@ -79,6 +79,8 @@ func New(cfg Config) http.Handler {
 		}
 		if cfg.Catalog != nil {
 			mux.Handle("GET /admin/authz/resources", authenticated(cfg.Catalog.Read))
+			mux.Handle("GET /admin/authz/resources/{resource}/actions/{action}/capabilities",
+				authenticated(cfg.Catalog.CapabilityImpact))
 		}
 	}
 

--- a/apps/admin-service/internal/server/server_test.go
+++ b/apps/admin-service/internal/server/server_test.go
@@ -95,6 +95,27 @@ func TestCatalogRouteRequiresABearerToken(t *testing.T) {
 	}
 }
 
+func TestCapabilityImpactRouteIsAbsentWithoutACatalogHandler(t *testing.T) {
+	handler := server.New(server.Config{})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/authz/resources/patient_record/actions/read/capabilities", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 when no catalog handler is configured", rec.Code)
+	}
+}
+
+func TestCapabilityImpactRouteRequiresABearerToken(t *testing.T) {
+	handler := server.New(server.Config{
+		Verifier: fakeVerifier{},
+		Catalog:  &catalogapi.Handler{},
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/authz/resources/patient_record/actions/read/capabilities", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 with no bearer token", rec.Code)
+	}
+}
+
 func TestReadyzReportsReadyWithNoDependencies(t *testing.T) {
 	handler := server.New(server.Config{})
 	rec := httptest.NewRecorder()

--- a/deploy/cerbos/catalog/resources/account.yaml
+++ b/deploy/cerbos/catalog/resources/account.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create account
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List account
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read account
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update account
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete account
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign account
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/activity_definition.yaml
+++ b/deploy/cerbos/catalog/resources/activity_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create activity definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List activity definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read activity definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update activity definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete activity definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign activity definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/actor_definition.yaml
+++ b/deploy/cerbos/catalog/resources/actor_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create actor definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List actor definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read actor definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update actor definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete actor definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign actor definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/administrable_product_definition.yaml
+++ b/deploy/cerbos/catalog/resources/administrable_product_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create administrable product definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List administrable product definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read administrable product definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update administrable product definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete administrable product definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign administrable product definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/adverse_event.yaml
+++ b/deploy/cerbos/catalog/resources/adverse_event.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create adverse event
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List adverse event
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read adverse event
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update adverse event
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete adverse event
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign adverse event
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/allergy_intolerance.yaml
+++ b/deploy/cerbos/catalog/resources/allergy_intolerance.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create allergy intolerance
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List allergy intolerance
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read allergy intolerance
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update allergy intolerance
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete allergy intolerance
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign allergy intolerance
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/appointment.yaml
+++ b/deploy/cerbos/catalog/resources/appointment.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create appointment
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List appointment
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read appointment
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update appointment
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete appointment
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign appointment
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/appointment_response.yaml
+++ b/deploy/cerbos/catalog/resources/appointment_response.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create appointment response
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List appointment response
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read appointment response
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update appointment response
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete appointment response
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign appointment response
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/artifact_assessment.yaml
+++ b/deploy/cerbos/catalog/resources/artifact_assessment.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create artifact assessment
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List artifact assessment
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read artifact assessment
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update artifact assessment
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete artifact assessment
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign artifact assessment
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/audit_event.yaml
+++ b/deploy/cerbos/catalog/resources/audit_event.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create audit event
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List audit event
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read audit event
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update audit event
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete audit event
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign audit event
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/basic.yaml
+++ b/deploy/cerbos/catalog/resources/basic.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create basic
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List basic
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read basic
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update basic
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete basic
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign basic
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/binary.yaml
+++ b/deploy/cerbos/catalog/resources/binary.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create binary
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List binary
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read binary
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update binary
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete binary
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign binary
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/biologically_derived_product.yaml
+++ b/deploy/cerbos/catalog/resources/biologically_derived_product.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create biologically derived product
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List biologically derived product
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read biologically derived product
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update biologically derived product
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete biologically derived product
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign biologically derived product
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/biologically_derived_product_dispense.yaml
+++ b/deploy/cerbos/catalog/resources/biologically_derived_product_dispense.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create biologically derived product dispense
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List biologically derived product dispense
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read biologically derived product dispense
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update biologically derived product dispense
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete biologically derived product dispense
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign biologically derived product dispense
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/body_structure.yaml
+++ b/deploy/cerbos/catalog/resources/body_structure.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create body structure
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List body structure
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read body structure
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update body structure
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete body structure
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign body structure
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/bundle.yaml
+++ b/deploy/cerbos/catalog/resources/bundle.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create bundle
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List bundle
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read bundle
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update bundle
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete bundle
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign bundle
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/capability_statement.yaml
+++ b/deploy/cerbos/catalog/resources/capability_statement.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create capability statement
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List capability statement
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read capability statement
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update capability statement
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete capability statement
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign capability statement
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/care_plan.yaml
+++ b/deploy/cerbos/catalog/resources/care_plan.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create care plan
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List care plan
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read care plan
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update care plan
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete care plan
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign care plan
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/care_team.yaml
+++ b/deploy/cerbos/catalog/resources/care_team.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create care team
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List care team
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read care team
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update care team
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete care team
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign care team
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/charge_item.yaml
+++ b/deploy/cerbos/catalog/resources/charge_item.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create charge item
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List charge item
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read charge item
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update charge item
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete charge item
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign charge item
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/charge_item_definition.yaml
+++ b/deploy/cerbos/catalog/resources/charge_item_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create charge item definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List charge item definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read charge item definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update charge item definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete charge item definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign charge item definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/citation.yaml
+++ b/deploy/cerbos/catalog/resources/citation.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create citation
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List citation
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read citation
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update citation
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete citation
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign citation
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/claim.yaml
+++ b/deploy/cerbos/catalog/resources/claim.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create claim
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List claim
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read claim
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update claim
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete claim
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign claim
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/claim_response.yaml
+++ b/deploy/cerbos/catalog/resources/claim_response.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create claim response
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List claim response
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read claim response
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update claim response
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete claim response
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign claim response
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/clinical_impression.yaml
+++ b/deploy/cerbos/catalog/resources/clinical_impression.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create clinical impression
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List clinical impression
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read clinical impression
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update clinical impression
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete clinical impression
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign clinical impression
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/clinical_use_definition.yaml
+++ b/deploy/cerbos/catalog/resources/clinical_use_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create clinical use definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List clinical use definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read clinical use definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update clinical use definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete clinical use definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign clinical use definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/code_system.yaml
+++ b/deploy/cerbos/catalog/resources/code_system.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create code system
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List code system
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read code system
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update code system
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete code system
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign code system
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/communication.yaml
+++ b/deploy/cerbos/catalog/resources/communication.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create communication
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List communication
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read communication
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update communication
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete communication
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign communication
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/communication_request.yaml
+++ b/deploy/cerbos/catalog/resources/communication_request.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create communication request
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List communication request
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read communication request
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update communication request
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete communication request
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign communication request
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/compartment_definition.yaml
+++ b/deploy/cerbos/catalog/resources/compartment_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create compartment definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List compartment definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read compartment definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update compartment definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete compartment definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign compartment definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/composition.yaml
+++ b/deploy/cerbos/catalog/resources/composition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create composition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List composition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read composition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update composition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete composition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign composition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/concept_map.yaml
+++ b/deploy/cerbos/catalog/resources/concept_map.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create concept map
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List concept map
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read concept map
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update concept map
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete concept map
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign concept map
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/condition.yaml
+++ b/deploy/cerbos/catalog/resources/condition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create condition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List condition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read condition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update condition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete condition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign condition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/consent.yaml
+++ b/deploy/cerbos/catalog/resources/consent.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create consent
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List consent
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read consent
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update consent
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete consent
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign consent
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/contract.yaml
+++ b/deploy/cerbos/catalog/resources/contract.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create contract
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List contract
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read contract
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update contract
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete contract
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign contract
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/coverage.yaml
+++ b/deploy/cerbos/catalog/resources/coverage.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create coverage
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List coverage
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read coverage
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update coverage
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete coverage
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign coverage
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/coverage_eligibility_request.yaml
+++ b/deploy/cerbos/catalog/resources/coverage_eligibility_request.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create coverage eligibility request
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List coverage eligibility request
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read coverage eligibility request
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update coverage eligibility request
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete coverage eligibility request
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign coverage eligibility request
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/coverage_eligibility_response.yaml
+++ b/deploy/cerbos/catalog/resources/coverage_eligibility_response.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create coverage eligibility response
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List coverage eligibility response
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read coverage eligibility response
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update coverage eligibility response
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete coverage eligibility response
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign coverage eligibility response
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/detected_issue.yaml
+++ b/deploy/cerbos/catalog/resources/detected_issue.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create detected issue
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List detected issue
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read detected issue
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update detected issue
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete detected issue
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign detected issue
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/device.yaml
+++ b/deploy/cerbos/catalog/resources/device.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create device
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List device
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read device
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update device
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete device
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign device
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/device_association.yaml
+++ b/deploy/cerbos/catalog/resources/device_association.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create device association
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List device association
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read device association
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update device association
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete device association
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign device association
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/device_definition.yaml
+++ b/deploy/cerbos/catalog/resources/device_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create device definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List device definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read device definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update device definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete device definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign device definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/device_dispense.yaml
+++ b/deploy/cerbos/catalog/resources/device_dispense.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create device dispense
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List device dispense
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read device dispense
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update device dispense
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete device dispense
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign device dispense
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/device_metric.yaml
+++ b/deploy/cerbos/catalog/resources/device_metric.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create device metric
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List device metric
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read device metric
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update device metric
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete device metric
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign device metric
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/device_request.yaml
+++ b/deploy/cerbos/catalog/resources/device_request.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create device request
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List device request
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read device request
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update device request
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete device request
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign device request
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/device_usage.yaml
+++ b/deploy/cerbos/catalog/resources/device_usage.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create device usage
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List device usage
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read device usage
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update device usage
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete device usage
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign device usage
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/diagnostic_report.yaml
+++ b/deploy/cerbos/catalog/resources/diagnostic_report.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create diagnostic report
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List diagnostic report
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read diagnostic report
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update diagnostic report
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete diagnostic report
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign diagnostic report
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/document_reference.yaml
+++ b/deploy/cerbos/catalog/resources/document_reference.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create document reference
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List document reference
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read document reference
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update document reference
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete document reference
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign document reference
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/encounter.yaml
+++ b/deploy/cerbos/catalog/resources/encounter.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create encounter
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List encounter
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read encounter
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update encounter
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete encounter
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign encounter
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/encounter_history.yaml
+++ b/deploy/cerbos/catalog/resources/encounter_history.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create encounter history
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List encounter history
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read encounter history
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update encounter history
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete encounter history
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign encounter history
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/endpoint.yaml
+++ b/deploy/cerbos/catalog/resources/endpoint.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create endpoint
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List endpoint
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read endpoint
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update endpoint
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete endpoint
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign endpoint
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/enrollment_request.yaml
+++ b/deploy/cerbos/catalog/resources/enrollment_request.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create enrollment request
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List enrollment request
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read enrollment request
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update enrollment request
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete enrollment request
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign enrollment request
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/enrollment_response.yaml
+++ b/deploy/cerbos/catalog/resources/enrollment_response.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create enrollment response
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List enrollment response
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read enrollment response
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update enrollment response
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete enrollment response
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign enrollment response
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/episode_of_care.yaml
+++ b/deploy/cerbos/catalog/resources/episode_of_care.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create episode of care
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List episode of care
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read episode of care
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update episode of care
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete episode of care
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign episode of care
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/evidence.yaml
+++ b/deploy/cerbos/catalog/resources/evidence.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create evidence
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List evidence
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read evidence
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update evidence
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete evidence
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign evidence
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/evidence_report.yaml
+++ b/deploy/cerbos/catalog/resources/evidence_report.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create evidence report
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List evidence report
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read evidence report
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update evidence report
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete evidence report
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign evidence report
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/evidence_variable.yaml
+++ b/deploy/cerbos/catalog/resources/evidence_variable.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create evidence variable
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List evidence variable
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read evidence variable
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update evidence variable
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete evidence variable
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign evidence variable
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/example_scenario.yaml
+++ b/deploy/cerbos/catalog/resources/example_scenario.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create example scenario
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List example scenario
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read example scenario
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update example scenario
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete example scenario
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign example scenario
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/explanation_of_benefit.yaml
+++ b/deploy/cerbos/catalog/resources/explanation_of_benefit.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create explanation of benefit
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List explanation of benefit
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read explanation of benefit
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update explanation of benefit
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete explanation of benefit
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign explanation of benefit
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/family_member_history.yaml
+++ b/deploy/cerbos/catalog/resources/family_member_history.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create family member history
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List family member history
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read family member history
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update family member history
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete family member history
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign family member history
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/flag.yaml
+++ b/deploy/cerbos/catalog/resources/flag.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create flag
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List flag
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read flag
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update flag
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete flag
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign flag
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/genomic_study.yaml
+++ b/deploy/cerbos/catalog/resources/genomic_study.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create genomic study
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List genomic study
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read genomic study
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update genomic study
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete genomic study
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign genomic study
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/goal.yaml
+++ b/deploy/cerbos/catalog/resources/goal.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create goal
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List goal
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read goal
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update goal
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete goal
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign goal
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/graph_definition.yaml
+++ b/deploy/cerbos/catalog/resources/graph_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create graph definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List graph definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read graph definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update graph definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete graph definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign graph definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/group.yaml
+++ b/deploy/cerbos/catalog/resources/group.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create group
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List group
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read group
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update group
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete group
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign group
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/guidance_response.yaml
+++ b/deploy/cerbos/catalog/resources/guidance_response.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create guidance response
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List guidance response
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read guidance response
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update guidance response
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete guidance response
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign guidance response
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/healthcare_service.yaml
+++ b/deploy/cerbos/catalog/resources/healthcare_service.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create healthcare service
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List healthcare service
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read healthcare service
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update healthcare service
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete healthcare service
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign healthcare service
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/imaging_selection.yaml
+++ b/deploy/cerbos/catalog/resources/imaging_selection.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create imaging selection
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List imaging selection
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read imaging selection
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update imaging selection
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete imaging selection
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign imaging selection
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/imaging_study.yaml
+++ b/deploy/cerbos/catalog/resources/imaging_study.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create imaging study
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List imaging study
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read imaging study
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update imaging study
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete imaging study
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign imaging study
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/immunization.yaml
+++ b/deploy/cerbos/catalog/resources/immunization.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create immunization
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List immunization
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read immunization
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update immunization
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete immunization
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign immunization
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/immunization_evaluation.yaml
+++ b/deploy/cerbos/catalog/resources/immunization_evaluation.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create immunization evaluation
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List immunization evaluation
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read immunization evaluation
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update immunization evaluation
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete immunization evaluation
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign immunization evaluation
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/immunization_recommendation.yaml
+++ b/deploy/cerbos/catalog/resources/immunization_recommendation.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create immunization recommendation
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List immunization recommendation
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read immunization recommendation
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update immunization recommendation
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete immunization recommendation
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign immunization recommendation
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/implementation_guide.yaml
+++ b/deploy/cerbos/catalog/resources/implementation_guide.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create implementation guide
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List implementation guide
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read implementation guide
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update implementation guide
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete implementation guide
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign implementation guide
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/ingredient.yaml
+++ b/deploy/cerbos/catalog/resources/ingredient.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create ingredient
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List ingredient
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read ingredient
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update ingredient
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete ingredient
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign ingredient
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/insurance_plan.yaml
+++ b/deploy/cerbos/catalog/resources/insurance_plan.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create insurance plan
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List insurance plan
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read insurance plan
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update insurance plan
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete insurance plan
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign insurance plan
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/inventory_item.yaml
+++ b/deploy/cerbos/catalog/resources/inventory_item.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create inventory item
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List inventory item
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read inventory item
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update inventory item
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete inventory item
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign inventory item
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/inventory_report.yaml
+++ b/deploy/cerbos/catalog/resources/inventory_report.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create inventory report
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List inventory report
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read inventory report
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update inventory report
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete inventory report
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign inventory report
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/invoice.yaml
+++ b/deploy/cerbos/catalog/resources/invoice.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create invoice
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List invoice
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read invoice
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update invoice
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete invoice
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign invoice
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/linkage.yaml
+++ b/deploy/cerbos/catalog/resources/linkage.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create linkage
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List linkage
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read linkage
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update linkage
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete linkage
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign linkage
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/list.yaml
+++ b/deploy/cerbos/catalog/resources/list.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create list
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List list
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read list
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update list
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete list
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign list
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/location.yaml
+++ b/deploy/cerbos/catalog/resources/location.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create location
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List location
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read location
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update location
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete location
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign location
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/manufactured_item_definition.yaml
+++ b/deploy/cerbos/catalog/resources/manufactured_item_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create manufactured item definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List manufactured item definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read manufactured item definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update manufactured item definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete manufactured item definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign manufactured item definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/measure.yaml
+++ b/deploy/cerbos/catalog/resources/measure.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create measure
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List measure
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read measure
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update measure
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete measure
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign measure
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/measure_report.yaml
+++ b/deploy/cerbos/catalog/resources/measure_report.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create measure report
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List measure report
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read measure report
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update measure report
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete measure report
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign measure report
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/media.yaml
+++ b/deploy/cerbos/catalog/resources/media.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create media
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List media
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read media
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update media
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete media
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign media
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/medication.yaml
+++ b/deploy/cerbos/catalog/resources/medication.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create medication
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List medication
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read medication
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update medication
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete medication
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign medication
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/medication_administration.yaml
+++ b/deploy/cerbos/catalog/resources/medication_administration.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create medication administration
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List medication administration
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read medication administration
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update medication administration
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete medication administration
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign medication administration
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/medication_dispense.yaml
+++ b/deploy/cerbos/catalog/resources/medication_dispense.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create medication dispense
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List medication dispense
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read medication dispense
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update medication dispense
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete medication dispense
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign medication dispense
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/medication_knowledge.yaml
+++ b/deploy/cerbos/catalog/resources/medication_knowledge.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create medication knowledge
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List medication knowledge
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read medication knowledge
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update medication knowledge
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete medication knowledge
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign medication knowledge
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/medication_request.yaml
+++ b/deploy/cerbos/catalog/resources/medication_request.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create medication request
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List medication request
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read medication request
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update medication request
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete medication request
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign medication request
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/medication_statement.yaml
+++ b/deploy/cerbos/catalog/resources/medication_statement.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create medication statement
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List medication statement
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read medication statement
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update medication statement
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete medication statement
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign medication statement
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/medicinal_product_definition.yaml
+++ b/deploy/cerbos/catalog/resources/medicinal_product_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create medicinal product definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List medicinal product definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read medicinal product definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update medicinal product definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete medicinal product definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign medicinal product definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/message_definition.yaml
+++ b/deploy/cerbos/catalog/resources/message_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create message definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List message definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read message definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update message definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete message definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign message definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/message_header.yaml
+++ b/deploy/cerbos/catalog/resources/message_header.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create message header
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List message header
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read message header
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update message header
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete message header
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign message header
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/molecular_sequence.yaml
+++ b/deploy/cerbos/catalog/resources/molecular_sequence.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create molecular sequence
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List molecular sequence
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read molecular sequence
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update molecular sequence
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete molecular sequence
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign molecular sequence
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/naming_system.yaml
+++ b/deploy/cerbos/catalog/resources/naming_system.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create naming system
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List naming system
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read naming system
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update naming system
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete naming system
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign naming system
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/nutrition_intake.yaml
+++ b/deploy/cerbos/catalog/resources/nutrition_intake.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create nutrition intake
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List nutrition intake
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read nutrition intake
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update nutrition intake
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete nutrition intake
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign nutrition intake
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/nutrition_order.yaml
+++ b/deploy/cerbos/catalog/resources/nutrition_order.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create nutrition order
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List nutrition order
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read nutrition order
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update nutrition order
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete nutrition order
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign nutrition order
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/nutrition_product.yaml
+++ b/deploy/cerbos/catalog/resources/nutrition_product.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create nutrition product
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List nutrition product
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read nutrition product
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update nutrition product
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete nutrition product
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign nutrition product
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/observation.yaml
+++ b/deploy/cerbos/catalog/resources/observation.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create observation
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List observation
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read observation
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update observation
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete observation
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign observation
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/observation_definition.yaml
+++ b/deploy/cerbos/catalog/resources/observation_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create observation definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List observation definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read observation definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update observation definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete observation definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign observation definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/operation_definition.yaml
+++ b/deploy/cerbos/catalog/resources/operation_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create operation definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List operation definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read operation definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update operation definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete operation definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign operation definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/operation_outcome.yaml
+++ b/deploy/cerbos/catalog/resources/operation_outcome.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create operation outcome
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List operation outcome
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read operation outcome
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update operation outcome
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete operation outcome
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign operation outcome
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/organization.yaml
+++ b/deploy/cerbos/catalog/resources/organization.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create organization
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List organization
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read organization
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update organization
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete organization
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign organization
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/organization_affiliation.yaml
+++ b/deploy/cerbos/catalog/resources/organization_affiliation.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create organization affiliation
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List organization affiliation
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read organization affiliation
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update organization affiliation
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete organization affiliation
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign organization affiliation
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/packaged_product_definition.yaml
+++ b/deploy/cerbos/catalog/resources/packaged_product_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create packaged product definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List packaged product definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read packaged product definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update packaged product definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete packaged product definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign packaged product definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/parameters.yaml
+++ b/deploy/cerbos/catalog/resources/parameters.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create parameters
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List parameters
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read parameters
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update parameters
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete parameters
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign parameters
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/patient_record.yaml
+++ b/deploy/cerbos/catalog/resources/patient_record.yaml
@@ -14,12 +14,16 @@ actions:
   - key: list
     displayName: List patients
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: View patient
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update patient
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete patient
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/payment_notice.yaml
+++ b/deploy/cerbos/catalog/resources/payment_notice.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create payment notice
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List payment notice
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read payment notice
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update payment notice
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete payment notice
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign payment notice
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/payment_reconciliation.yaml
+++ b/deploy/cerbos/catalog/resources/payment_reconciliation.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create payment reconciliation
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List payment reconciliation
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read payment reconciliation
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update payment reconciliation
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete payment reconciliation
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign payment reconciliation
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/permission.yaml
+++ b/deploy/cerbos/catalog/resources/permission.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create permission
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List permission
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read permission
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update permission
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete permission
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign permission
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/person.yaml
+++ b/deploy/cerbos/catalog/resources/person.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create person
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List person
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read person
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update person
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete person
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign person
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/plan_definition.yaml
+++ b/deploy/cerbos/catalog/resources/plan_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create plan definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List plan definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read plan definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update plan definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete plan definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign plan definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/practitioner.yaml
+++ b/deploy/cerbos/catalog/resources/practitioner.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create practitioner
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List practitioner
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read practitioner
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update practitioner
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete practitioner
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign practitioner
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/practitioner_role.yaml
+++ b/deploy/cerbos/catalog/resources/practitioner_role.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create practitioner role
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List practitioner role
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read practitioner role
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update practitioner role
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete practitioner role
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign practitioner role
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/procedure.yaml
+++ b/deploy/cerbos/catalog/resources/procedure.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create procedure
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List procedure
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read procedure
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update procedure
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete procedure
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign procedure
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/provenance.yaml
+++ b/deploy/cerbos/catalog/resources/provenance.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create provenance
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List provenance
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read provenance
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update provenance
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete provenance
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign provenance
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/questionnaire.yaml
+++ b/deploy/cerbos/catalog/resources/questionnaire.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create questionnaire
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List questionnaire
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read questionnaire
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update questionnaire
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete questionnaire
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign questionnaire
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/questionnaire_response.yaml
+++ b/deploy/cerbos/catalog/resources/questionnaire_response.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create questionnaire response
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List questionnaire response
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read questionnaire response
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update questionnaire response
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete questionnaire response
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign questionnaire response
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/regulated_authorization.yaml
+++ b/deploy/cerbos/catalog/resources/regulated_authorization.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create regulated authorization
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List regulated authorization
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read regulated authorization
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update regulated authorization
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete regulated authorization
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign regulated authorization
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/related_person.yaml
+++ b/deploy/cerbos/catalog/resources/related_person.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create related person
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List related person
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read related person
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update related person
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete related person
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign related person
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/request_orchestration.yaml
+++ b/deploy/cerbos/catalog/resources/request_orchestration.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create request orchestration
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List request orchestration
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read request orchestration
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update request orchestration
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete request orchestration
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign request orchestration
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/requirements.yaml
+++ b/deploy/cerbos/catalog/resources/requirements.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create requirements
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List requirements
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read requirements
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update requirements
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete requirements
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign requirements
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/research_study.yaml
+++ b/deploy/cerbos/catalog/resources/research_study.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create research study
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List research study
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read research study
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update research study
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete research study
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign research study
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/research_subject.yaml
+++ b/deploy/cerbos/catalog/resources/research_subject.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create research subject
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List research subject
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read research subject
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update research subject
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete research subject
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign research subject
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/risk_assessment.yaml
+++ b/deploy/cerbos/catalog/resources/risk_assessment.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create risk assessment
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List risk assessment
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read risk assessment
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update risk assessment
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete risk assessment
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign risk assessment
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/schedule.yaml
+++ b/deploy/cerbos/catalog/resources/schedule.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create schedule
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List schedule
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read schedule
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update schedule
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete schedule
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign schedule
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/search_parameter.yaml
+++ b/deploy/cerbos/catalog/resources/search_parameter.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create search parameter
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List search parameter
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read search parameter
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update search parameter
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete search parameter
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign search parameter
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/service_request.yaml
+++ b/deploy/cerbos/catalog/resources/service_request.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create service request
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List service request
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read service request
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update service request
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete service request
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign service request
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/slot.yaml
+++ b/deploy/cerbos/catalog/resources/slot.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create slot
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List slot
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read slot
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update slot
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete slot
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign slot
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/specimen.yaml
+++ b/deploy/cerbos/catalog/resources/specimen.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create specimen
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List specimen
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read specimen
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update specimen
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete specimen
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign specimen
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/specimen_definition.yaml
+++ b/deploy/cerbos/catalog/resources/specimen_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create specimen definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List specimen definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read specimen definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update specimen definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete specimen definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign specimen definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/structure_definition.yaml
+++ b/deploy/cerbos/catalog/resources/structure_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create structure definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List structure definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read structure definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update structure definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete structure definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign structure definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/structure_map.yaml
+++ b/deploy/cerbos/catalog/resources/structure_map.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create structure map
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List structure map
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read structure map
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update structure map
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete structure map
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign structure map
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/subscription.yaml
+++ b/deploy/cerbos/catalog/resources/subscription.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create subscription
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List subscription
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read subscription
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update subscription
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete subscription
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign subscription
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/subscription_status.yaml
+++ b/deploy/cerbos/catalog/resources/subscription_status.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create subscription status
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List subscription status
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read subscription status
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update subscription status
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete subscription status
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign subscription status
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/subscription_topic.yaml
+++ b/deploy/cerbos/catalog/resources/subscription_topic.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create subscription topic
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List subscription topic
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read subscription topic
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update subscription topic
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete subscription topic
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign subscription topic
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/substance.yaml
+++ b/deploy/cerbos/catalog/resources/substance.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create substance
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List substance
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read substance
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update substance
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete substance
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign substance
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/substance_definition.yaml
+++ b/deploy/cerbos/catalog/resources/substance_definition.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create substance definition
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List substance definition
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read substance definition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update substance definition
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete substance definition
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign substance definition
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/substance_nucleic_acid.yaml
+++ b/deploy/cerbos/catalog/resources/substance_nucleic_acid.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create substance nucleic acid
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List substance nucleic acid
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read substance nucleic acid
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update substance nucleic acid
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete substance nucleic acid
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign substance nucleic acid
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/substance_polymer.yaml
+++ b/deploy/cerbos/catalog/resources/substance_polymer.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create substance polymer
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List substance polymer
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read substance polymer
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update substance polymer
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete substance polymer
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign substance polymer
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/substance_protein.yaml
+++ b/deploy/cerbos/catalog/resources/substance_protein.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create substance protein
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List substance protein
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read substance protein
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update substance protein
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete substance protein
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign substance protein
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/substance_reference_information.yaml
+++ b/deploy/cerbos/catalog/resources/substance_reference_information.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create substance reference information
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List substance reference information
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read substance reference information
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update substance reference information
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete substance reference information
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign substance reference information
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/substance_source_material.yaml
+++ b/deploy/cerbos/catalog/resources/substance_source_material.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create substance source material
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List substance source material
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read substance source material
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update substance source material
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete substance source material
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign substance source material
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/supply_delivery.yaml
+++ b/deploy/cerbos/catalog/resources/supply_delivery.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create supply delivery
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List supply delivery
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read supply delivery
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update supply delivery
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete supply delivery
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign supply delivery
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/supply_request.yaml
+++ b/deploy/cerbos/catalog/resources/supply_request.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create supply request
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List supply request
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read supply request
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update supply request
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete supply request
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign supply request
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/task.yaml
+++ b/deploy/cerbos/catalog/resources/task.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create task
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List task
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read task
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update task
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete task
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign task
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/terminology_capabilities.yaml
+++ b/deploy/cerbos/catalog/resources/terminology_capabilities.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create terminology capabilities
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List terminology capabilities
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read terminology capabilities
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update terminology capabilities
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete terminology capabilities
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign terminology capabilities
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/test_plan.yaml
+++ b/deploy/cerbos/catalog/resources/test_plan.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create test plan
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List test plan
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read test plan
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update test plan
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete test plan
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign test plan
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/test_report.yaml
+++ b/deploy/cerbos/catalog/resources/test_report.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create test report
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List test report
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read test report
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update test report
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete test report
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign test report
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/test_script.yaml
+++ b/deploy/cerbos/catalog/resources/test_script.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create test script
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List test script
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read test script
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update test script
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete test script
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign test script
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/transport.yaml
+++ b/deploy/cerbos/catalog/resources/transport.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create transport
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List transport
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read transport
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update transport
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete transport
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign transport
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/value_set.yaml
+++ b/deploy/cerbos/catalog/resources/value_set.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create value set
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List value set
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read value set
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update value set
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete value set
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign value set
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/verification_result.yaml
+++ b/deploy/cerbos/catalog/resources/verification_result.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create verification result
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List verification result
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read verification result
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update verification result
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete verification result
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign verification result
     context: INSTANCE
+    risk: ELEVATED

--- a/deploy/cerbos/catalog/resources/vision_prescription.yaml
+++ b/deploy/cerbos/catalog/resources/vision_prescription.yaml
@@ -12,18 +12,24 @@ actions:
   - key: create
     displayName: Create vision prescription
     context: COLLECTION
+    risk: STANDARD
   - key: list
     displayName: List vision prescription
     context: COLLECTION
+    risk: STANDARD
   - key: read
     displayName: Read vision prescription
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update vision prescription
     context: INSTANCE
+    risk: ELEVATED
   - key: delete
     displayName: Delete vision prescription
     context: INSTANCE
+    risk: ELEVATED
   - key: assign
     displayName: Assign vision prescription
     context: INSTANCE
+    risk: ELEVATED

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,10 @@ services:
       IDP_ISSUER: "${KEYCLOAK_HOSTNAME:-http://localhost:8081}/realms/${IDP_REALM:-cerbos-poc}"
       IDP_CREDENTIALS_SECRET_REF: "/run/secrets/idp-admin-credentials"
       AUTHORIZATION_CATALOG_DIR: "/authorization-catalog"
+      # The capability impact endpoint (§9.1, issue #18) reads the same
+      # committed capability catalog Cerbos and the ADS's own capability
+      # snapshot endpoint read theirs from.
+      CAPABILITY_CATALOG_DIR: "/capability-catalog"
       KAFKA_BROKERS: "redpanda:9092"
       KAFKA_PERMISSION_CHANGED_TOPIC: "${KAFKA_PERMISSION_CHANGED_TOPIC:-permission-changed}"
       # §9.3: high-risk actions default to a bounded expiry when a GRANT or
@@ -209,6 +213,7 @@ services:
     volumes:
       - ./deploy/secrets/idp-admin-credentials:/run/secrets/idp-admin-credentials:ro
       - ./deploy/cerbos/catalog/resources:/authorization-catalog:ro
+      - ./deploy/cerbos/catalog/ui-capabilities:/capability-catalog:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/libs/capabilitycatalog/impact.go
+++ b/libs/capabilitycatalog/impact.go
@@ -1,0 +1,31 @@
+package capabilitycatalog
+
+import "sort"
+
+// CapabilitiesReferencing returns every capability in defs whose
+// expression references the resource:action leaf, at any depth of
+// allOf/anyOf nesting, sorted by key for a deterministic response (issue
+// #18, §9.1's capability impact module: "Selecting a resource-action
+// lists every capability that depends on it").
+//
+// The result is never nil: a resource-action no capability references
+// returns an empty, non-nil slice, so a caller serialising it to JSON
+// gets [] rather than null - the difference between "checked and found
+// none" and "not checked" (the same acceptance criterion's "clearly
+// shown as such rather than as an empty error").
+func CapabilitiesReferencing(defs []UiCapabilityDefinition, resource, action string) []UiCapabilityDefinition {
+	matches := make([]UiCapabilityDefinition, 0)
+	for _, d := range defs {
+		found := false
+		walkExpression(d.Expression, func(e Expression) {
+			if e.Permission != nil && e.Permission.Resource == resource && e.Permission.Action == action {
+				found = true
+			}
+		})
+		if found {
+			matches = append(matches, d)
+		}
+	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].Key < matches[j].Key })
+	return matches
+}

--- a/libs/capabilitycatalog/impact_test.go
+++ b/libs/capabilitycatalog/impact_test.go
@@ -1,0 +1,78 @@
+package capabilitycatalog_test
+
+import (
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+)
+
+func def(key, module string, expr capabilitycatalog.Expression) capabilitycatalog.UiCapabilityDefinition {
+	return capabilitycatalog.UiCapabilityDefinition{Key: key, Module: module, Context: "INSTANCE", Expression: expr}
+}
+
+func permissionExpr(resource, action string) capabilitycatalog.Expression {
+	return capabilitycatalog.Expression{Permission: &capabilitycatalog.PermissionRequirement{
+		Resource: resource, Action: action, TargetRef: resource,
+	}}
+}
+
+// The capability impact module (issue #18, §9.1) needs the reverse index
+// from a resource-action leaf to every capability whose expression
+// references it, at any depth of allOf/anyOf nesting - not just the top
+// level.
+func TestCapabilitiesReferencingFindsALeafNestedInsideAllOf(t *testing.T) {
+	defs := []capabilitycatalog.UiCapabilityDefinition{
+		def("patient.route.edit", "clinical", capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+			permissionExpr("patient_record", "read"),
+			permissionExpr("patient_record", "update"),
+		}}),
+		def("patient.route.view", "clinical", permissionExpr("patient_record", "read")),
+		def("prescription.route.view", "pharmacy", permissionExpr("prescription", "read")),
+	}
+
+	got := capabilitycatalog.CapabilitiesReferencing(defs, "patient_record", "update")
+
+	if len(got) != 1 || got[0].Key != "patient.route.edit" {
+		t.Fatalf("CapabilitiesReferencing(patient_record, update) = %+v, want exactly [patient.route.edit]", got)
+	}
+}
+
+// A leaf shared by multiple capabilities must return every one of them,
+// sorted, so the impact list is deterministic for the same reason every
+// other loader/generator output in this package is.
+func TestCapabilitiesReferencingReturnsEveryCapabilitySharingALeafSorted(t *testing.T) {
+	defs := []capabilitycatalog.UiCapabilityDefinition{
+		def("patient.route.view", "clinical", permissionExpr("patient_record", "read")),
+		def("patient.component.summary", "clinical", capabilitycatalog.Expression{AnyOf: []capabilitycatalog.Expression{
+			permissionExpr("patient_record", "read"),
+			permissionExpr("patient_record", "list"),
+		}}),
+	}
+
+	got := capabilitycatalog.CapabilitiesReferencing(defs, "patient_record", "read")
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 capabilities referencing patient_record:read, got %d: %+v", len(got), got)
+	}
+	if got[0].Key != "patient.component.summary" || got[1].Key != "patient.route.view" {
+		t.Errorf("expected capabilities sorted by key, got %q then %q", got[0].Key, got[1].Key)
+	}
+}
+
+// A resource-action no capability references must come back as an empty
+// slice, never an error - issue #18's "A resource-action used by no
+// capability is clearly shown as such rather than as an empty error".
+func TestCapabilitiesReferencingReturnsEmptyNotErrorWhenNothingMatches(t *testing.T) {
+	defs := []capabilitycatalog.UiCapabilityDefinition{
+		def("patient.route.view", "clinical", permissionExpr("patient_record", "read")),
+	}
+
+	got := capabilitycatalog.CapabilitiesReferencing(defs, "patient_record", "delete")
+
+	if got == nil {
+		t.Fatal("expected a non-nil empty slice, got nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no capabilities, got %+v", got)
+	}
+}

--- a/libs/capabilitycatalog/loader.go
+++ b/libs/capabilitycatalog/loader.go
@@ -65,6 +65,7 @@ type catalogResourceEntry struct {
 		Key         string `yaml:"key"`
 		DisplayName string `yaml:"displayName"`
 		Context     string `yaml:"context"`
+		Risk        string `yaml:"risk"`
 	} `yaml:"actions"`
 }
 
@@ -75,6 +76,11 @@ type ActionEntry struct {
 	Key         string `json:"key"`
 	DisplayName string `json:"displayName"`
 	Context     string `json:"context"`
+	// Risk is STANDARD or ELEVATED (§6.1, issue #18's resource catalog
+	// risk metadata), the same classification
+	// libs/cataloggen.RenderActionSeedCSV assigns the DB seed's
+	// risk_level column from the manifest's lockableActions list.
+	Risk string `json:"risk"`
 }
 
 // ResourceEntry is one resource's full administration-facing catalog entry:
@@ -156,7 +162,7 @@ func LoadResourceCatalogDir(dir string) ([]ResourceEntry, error) {
 		}
 		actions := make([]ActionEntry, 0, len(e.Actions))
 		for _, a := range e.Actions {
-			actions = append(actions, ActionEntry{Key: a.Key, DisplayName: a.DisplayName, Context: a.Context})
+			actions = append(actions, ActionEntry{Key: a.Key, DisplayName: a.DisplayName, Context: a.Context, Risk: a.Risk})
 		}
 		all = append(all, ResourceEntry{
 			ResourceKey: e.Resource, Version: e.Version,

--- a/libs/capabilitycatalog/loader_test.go
+++ b/libs/capabilitycatalog/loader_test.go
@@ -82,6 +82,31 @@ func TestLoadResourceCatalogDirReadsDisplayMetadata(t *testing.T) {
 	}
 }
 
+// The resource catalog module needs risk metadata to browse by (issue
+// #18, §6.1), so the loader must carry it through rather than dropping
+// it on the floor between the YAML file and ResourceEntry.
+func TestLoadResourceCatalogDirReadsRiskMetadata(t *testing.T) {
+	entries, err := capabilitycatalog.LoadResourceCatalogDir(filepath.Join("testdata", "catalog"))
+	if err != nil {
+		t.Fatalf("LoadResourceCatalogDir: %v", err)
+	}
+
+	byKey := make(map[string]capabilitycatalog.ResourceEntry, len(entries))
+	for _, entry := range entries {
+		byKey[entry.ResourceKey] = entry
+	}
+	patient, ok := byKey["patient_record"]
+	if !ok {
+		t.Fatal("patient_record entry is missing")
+	}
+	if patient.Actions[0].Risk != "STANDARD" {
+		t.Errorf("patient_record read risk = %q, want STANDARD", patient.Actions[0].Risk)
+	}
+	if patient.Actions[1].Risk != "ELEVATED" {
+		t.Errorf("patient_record update risk = %q, want ELEVATED", patient.Actions[1].Risk)
+	}
+}
+
 func TestLoadResourceCatalogDirIsSortedByResourceKey(t *testing.T) {
 	entries, err := capabilitycatalog.LoadResourceCatalogDir(filepath.Join("testdata", "catalog"))
 	if err != nil {

--- a/libs/capabilitycatalog/testdata/catalog/patient_record.yaml
+++ b/libs/capabilitycatalog/testdata/catalog/patient_record.yaml
@@ -6,6 +6,8 @@ actions:
   - key: read
     displayName: View patient
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update patient
     context: INSTANCE
+    risk: ELEVATED

--- a/libs/cataloggen/catalog.go
+++ b/libs/cataloggen/catalog.go
@@ -29,6 +29,15 @@ func RenderCatalogEntry(m *Manifest, entry ResourceEntry) string {
 		fmt.Fprintf(&b, "  - key: %s\n", action.Key)
 		fmt.Fprintf(&b, "    displayName: %s %s\n", action.DisplayName, strings.ToLower(entry.Display))
 		fmt.Fprintf(&b, "    context: %s\n", action.Context)
+		// Same classification the DB seed's risk_level column uses (see
+		// RenderActionSeedCSV): one lockableActions list drives both, so
+		// the catalog the browser reads and the row the database stores
+		// can never name a different risk for the same action.
+		risk := "STANDARD"
+		if isLockable(m, action.Key) {
+			risk = "ELEVATED"
+		}
+		fmt.Fprintf(&b, "    risk: %s\n", risk)
 	}
 	return b.String()
 }

--- a/libs/cataloggen/catalog_test.go
+++ b/libs/cataloggen/catalog_test.go
@@ -1,0 +1,44 @@
+package cataloggen_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/cataloggen"
+)
+
+// The catalog is the administration-facing metadata source the resource
+// catalog module renders (issue #18, §6.1's "labels, descriptions,
+// grouping, context type and risk metadata"). A lockable action carries
+// more consequence than a non-lockable one, so the catalog must say so
+// with the same classification the DB seed's risk_level column already
+// uses, rather than leaving risk out of the file the browser reads.
+func TestRenderCatalogEntryMarksLockableActionsAsElevatedRisk(t *testing.T) {
+	m, err := cataloggen.ParseManifest([]byte(`
+catalogRevision: 1
+actions:
+  - key: read
+    displayName: Read
+    context: INSTANCE
+  - key: update
+    displayName: Update
+    context: INSTANCE
+lockableActions: [update]
+resources:
+  - fhirType: Condition
+    domain: clinical
+`))
+	if err != nil {
+		t.Fatalf("parsing manifest: %v", err)
+	}
+
+	entry := m.IncludedResources()[0]
+	rendered := cataloggen.RenderCatalogEntry(m, entry)
+
+	if !strings.Contains(rendered, "key: read\n    displayName: Read condition\n    context: INSTANCE\n    risk: STANDARD\n") {
+		t.Errorf("read action was not rendered as STANDARD risk:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "key: update\n    displayName: Update condition\n    context: INSTANCE\n    risk: ELEVATED\n") {
+		t.Errorf("update action was not rendered as ELEVATED risk (it is lockable):\n%s", rendered)
+	}
+}

--- a/libs/cataloggen/testdata/golden/catalog/condition.yaml
+++ b/libs/cataloggen/testdata/golden/catalog/condition.yaml
@@ -12,6 +12,8 @@ actions:
   - key: read
     displayName: Read condition
     context: INSTANCE
+    risk: STANDARD
   - key: update
     displayName: Update condition
     context: INSTANCE
+    risk: ELEVATED


### PR DESCRIPTION
## What changed

Implements issue #18: the two screens that make permission changes
explainable, plus the role matrix's impact preview that consumes the
second one (§6.1, §9.1, §9.2).

**Risk metadata (§6.1):**
- `libs/cataloggen.RenderCatalogEntry` now emits `risk: STANDARD` or
  `risk: ELEVATED` per action, from the same `lockableActions`
  classification `RenderActionSeedCSV` already uses for the DB seed's
  `risk_level` column - one classification, not two that could drift.
- The hand-authored `patient_record.yaml` catalog entry carries the same
  field by hand, matching its own lockable actions (`update`, `delete`).
- `libs/capabilitycatalog`'s loader carries `Risk` through to
  `ActionEntry`, so `GET /admin/authz/resources` exposes it with no
  second, hand-maintained mapping.

**Capability impact index (§9.1):**
- `capabilitycatalog.CapabilitiesReferencing` is the reverse index from a
  resource-action leaf to every composite UI capability whose expression
  references it, at any depth of `allOf`/`anyOf` nesting - derived from
  the same committed capability definitions the write path already
  validates against. An unmatched resource-action returns an empty,
  non-nil slice, never an error.
- `catalogapi.Handler.CapabilityImpact` serves this at
  `GET /admin/authz/resources/{resource}/actions/{action}/capabilities`.

**Frontend:**
- `ResourceCatalogBrowser`: browses the catalog by domain, shows each
  action's risk badge and the current root policy revision, and lists
  the capabilities depending on a selected resource-action (with an
  explicit empty state).
- `RoleMatrix.previewSave()`/`confirmSave()`: saving now computes the
  capability impact of every changed row and shows it - split into
  "may become enabled" and "may become disabled" - before the write
  actually commits, with an explicit confirm/cancel step.

## Acceptance criteria

- [x] The catalog is browsable with domain grouping, risk metadata and
      the current catalog revision - `ResourceCatalogBrowser`'s domain
      `<details>` groups, per-action risk badges, and the
      `rootPolicyRevision` line.
- [x] Selecting a resource-action lists every capability that depends on
      it - `selectAction()` calls the new capability-impact endpoint and
      renders the list.
- [x] A resource-action used by no capability is clearly shown as such
      rather than as an empty error - the `impact-empty` state, backed
      by `CapabilitiesReferencing`'s non-nil empty slice and the
      handler's unconditional 200.
- [x] Saving a role matrix change shows an impact preview before commit
      - `previewSave()` blocks the write until confirmed.
- [x] The preview distinguishes capabilities that may become enabled
      from those that may become disabled - each preview row carries an
      explicit `direction`.
- [x] The impact index is derived from the active capability catalog
      revision, not hardcoded - `CapabilityImpact` reads the same
      `[]UiCapabilityDefinition` loaded from the committed
      `ui-capabilities` directory at startup.

## How this was verified locally

- `go test ./...` for `libs/cataloggen`, `libs/capabilitycatalog`,
  `apps/admin-service` - all green, including new tests for the risk
  field, `CapabilitiesReferencing`, and `CapabilityImpact`.
- `nx test admin-console` - 55/55 green, including new specs for
  `ResourceCatalogBrowser` and the role matrix's impact preview.
- `nx affected --target=lint/test/build --base=main` - clean (0 errors).
- `make catalog-check` / `make capability-check` - both pass: the
  regenerated catalog and golden files match the committed tree, and
  the 400-capability set still validates cleanly.
- `python3 scripts/tests/compose-contract.py` and
  `scripts/tests/nx-affected-isolation.sh` - both pass.

Closes #18


Closes #18
