### PR TITLE
Effective access simulator (#19)

### DIFF
--- a/apps/admin-console/src/app/app.routes.ts
+++ b/apps/admin-console/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { Callback } from './auth/callback';
 import { ResourceCatalogBrowser } from './resource-catalog-browser/resource-catalog-browser';
 import { RoleMatrix } from './role-matrix/role-matrix';
 import { Shell } from './shell/shell';
+import { Simulator } from './simulator/simulator';
 import { UserOverride } from './user-override/user-override';
 
 export const appRoutes: Route[] = [
@@ -18,6 +19,7 @@ export const appRoutes: Route[] = [
       { path: 'role-matrix', component: RoleMatrix },
       { path: 'user-overrides', component: UserOverride },
       { path: 'resource-catalog', component: ResourceCatalogBrowser },
+      { path: 'simulator', component: Simulator },
     ],
   },
 ];

--- a/apps/admin-console/src/app/shell/shell.html
+++ b/apps/admin-console/src/app/shell/shell.html
@@ -3,6 +3,7 @@
     <a routerLink="/role-matrix" data-testid="nav-role-matrix">Role matrix</a>
     <a routerLink="/user-overrides" data-testid="nav-user-overrides">User overrides</a>
     <a routerLink="/resource-catalog" data-testid="nav-resource-catalog">Resource catalog</a>
+    <a routerLink="/simulator" data-testid="nav-simulator">Simulator</a>
   </nav>
   @if (auth.claims(); as claims) {
     <div class="shell-identity" data-testid="shell-identity">

--- a/apps/admin-console/src/app/simulator/simulator-api.ts
+++ b/apps/admin-console/src/app/simulator/simulator-api.ts
@@ -1,0 +1,89 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ADMIN_BASE_URL } from '../admin-base-url';
+
+/** The sample resource named in an access simulation (§9.4, issue #19). */
+export interface SimulateAccessTarget {
+  kind: string;
+  id: string;
+  attributes: Record<string, unknown>;
+}
+
+export interface SimulateAccessRequest {
+  tenantId: string;
+  hospitalId: string;
+  principalId: string;
+  idpRoles: string[];
+  resource: SimulateAccessTarget;
+  action: string;
+}
+
+/** Appendix A's decision source vocabulary. */
+export type DecisionSource = 'MANDATORY_RULE' | 'USER_REVOKE' | 'USER_GRANT' | 'ROLE';
+
+export interface SimulateAccessResult {
+  cerbosCallId: string;
+  permissionRevision: number;
+  allowed: boolean;
+  source: DecisionSource;
+}
+
+export interface SimulateCapabilitiesRequest {
+  module: string;
+  capabilityKeys: string[];
+  tenantId: string;
+  hospitalId: string;
+  principalId: string;
+  idpRoles: string[];
+  /** targetRef -> sample trusted attributes, supplied directly rather
+   * than resolved from a real resource. */
+  sampleAttributes: Record<string, Record<string, unknown>>;
+}
+
+export interface LeafDecision {
+  resource: string;
+  action: string;
+  target: string;
+  allowed: boolean;
+  reason: string;
+}
+
+export interface CapabilityResult {
+  allowed: boolean;
+  reason?: string;
+  failedRequirements?: { resource: string; action: string; target: string; reason: string }[];
+}
+
+export interface SimulateCapabilitiesResult {
+  authorizationRevision: number;
+  rootPolicyRevision: string;
+  capabilityCatalogRevision: string;
+  capabilities: Record<string, CapabilityResult>;
+  /** The full per-leaf requirement tree - administration-audience
+   * evidence only (§12.4). */
+  requirementTree: LeafDecision[];
+}
+
+/**
+ * `POST /admin/authz/simulate` and `POST /admin/authz/simulate-capabilities`
+ * (§9.4, issue #19): the effective-access simulator, running through the
+ * real ADS and Cerbos path for an explicitly named principal.
+ */
+@Injectable({ providedIn: 'root' })
+export class SimulatorApi {
+  private readonly http = inject(HttpClient);
+  private readonly adminBaseUrl = inject(ADMIN_BASE_URL);
+
+  simulateAccess(request: SimulateAccessRequest): Observable<SimulateAccessResult> {
+    return this.http.post<SimulateAccessResult>(`${this.adminBaseUrl}/authz/simulate`, request);
+  }
+
+  simulateCapabilities(request: SimulateCapabilitiesRequest): Observable<SimulateCapabilitiesResult> {
+    return this.http.post<SimulateCapabilitiesResult>(
+      `${this.adminBaseUrl}/authz/simulate-capabilities`,
+      request,
+    );
+  }
+}

--- a/apps/admin-console/src/app/simulator/simulator.css
+++ b/apps/admin-console/src/app/simulator/simulator.css
@@ -1,0 +1,15 @@
+.error {
+  color: #b00020;
+}
+
+.access-simulator label,
+.capability-simulator label {
+  display: block;
+  margin-top: 0.5rem;
+}
+
+textarea {
+  width: 100%;
+  min-height: 4rem;
+  font-family: monospace;
+}

--- a/apps/admin-console/src/app/simulator/simulator.html
+++ b/apps/admin-console/src/app/simulator/simulator.html
@@ -1,0 +1,107 @@
+<h1>Effective access simulator</h1>
+<p data-testid="scope-note">
+  Scope: tenant {{ tenant() }}, hospital {{ hospital() }} (your own authority).
+</p>
+
+<section class="access-simulator" data-testid="access-simulator">
+  <h2>Simulate one resource-action</h2>
+
+  <label>
+    Principal ID
+    <input type="text" data-testid="principal-id-input" [(ngModel)]="principalId" />
+  </label>
+  <label>
+    IdP roles (comma separated)
+    <input type="text" data-testid="idp-roles-input" [(ngModel)]="idpRoles" />
+  </label>
+  <label>
+    Resource kind
+    <input type="text" data-testid="resource-kind-input" [(ngModel)]="resourceKind" />
+  </label>
+  <label>
+    Resource ID
+    <input type="text" data-testid="resource-id-input" [(ngModel)]="resourceId" />
+  </label>
+  <label>
+    Resource attributes (JSON)
+    <textarea data-testid="resource-attributes-input" [(ngModel)]="resourceAttributes"></textarea>
+  </label>
+  <label>
+    Action
+    <input type="text" data-testid="action-input" [(ngModel)]="action" />
+  </label>
+
+  <button type="button" data-testid="run-access-simulation" [disabled]="accessRunning()" (click)="runAccessSimulation()">
+    Simulate
+  </button>
+
+  @if (accessError()) {
+    <p data-testid="access-error" class="error">{{ accessError() }}</p>
+  }
+  @if (accessResult(); as result) {
+    <div data-testid="access-result">
+      <p data-testid="access-allowed">Allowed: {{ result.allowed }}</p>
+      <p data-testid="access-source">Source: {{ result.source }}</p>
+      <p data-testid="access-revision">Permission revision: {{ result.permissionRevision }}</p>
+    </div>
+  }
+</section>
+
+<section class="capability-simulator" data-testid="capability-simulator">
+  <h2>Simulate composite capabilities</h2>
+
+  <label>
+    Module
+    <input type="text" data-testid="capability-module-input" [(ngModel)]="capabilityModule" />
+  </label>
+  <label>
+    Capability keys (comma separated)
+    <input type="text" data-testid="capability-keys-input" [(ngModel)]="capabilityKeys" />
+  </label>
+  <label>
+    Principal ID
+    <input type="text" data-testid="capability-principal-id-input" [(ngModel)]="capabilityPrincipalId" />
+  </label>
+  <label>
+    IdP roles (comma separated)
+    <input type="text" data-testid="capability-idp-roles-input" [(ngModel)]="capabilityIdpRoles" />
+  </label>
+  <label>
+    Sample attributes per targetRef (JSON)
+    <textarea data-testid="sample-attributes-input" [(ngModel)]="sampleAttributesJSON"></textarea>
+  </label>
+
+  <button
+    type="button"
+    data-testid="run-capability-simulation"
+    [disabled]="capabilityRunning()"
+    (click)="runCapabilitySimulation()"
+  >
+    Simulate
+  </button>
+
+  @if (capabilityError()) {
+    <p data-testid="capability-error" class="error">{{ capabilityError() }}</p>
+  }
+  @if (capabilityResult(); as result) {
+    <div data-testid="capability-result">
+      <ul data-testid="capability-outcomes">
+        @for (entry of capabilityEntries(result); track entry.key) {
+          <li>
+            {{ entry.key }}: {{ entry.allowed ? 'allowed' : 'denied' }}
+          </li>
+        }
+      </ul>
+
+      <h3>Full requirement tree</h3>
+      <ul data-testid="requirement-tree">
+        @for (leaf of result.requirementTree; track leaf.resource + ':' + leaf.action + ':' + leaf.target) {
+          <li [attr.data-testid]="'leaf-' + leaf.resource + '-' + leaf.action">
+            {{ leaf.resource }}:{{ leaf.action }} ({{ leaf.target }}) -
+            {{ leaf.allowed ? 'allowed' : 'denied' }} ({{ leaf.reason }})
+          </li>
+        }
+      </ul>
+    </div>
+  }
+</section>

--- a/apps/admin-console/src/app/simulator/simulator.spec.ts
+++ b/apps/admin-console/src/app/simulator/simulator.spec.ts
@@ -1,0 +1,137 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from '../auth/auth.service';
+import { Simulator } from './simulator';
+
+function setUp() {
+  TestBed.configureTestingModule({
+    imports: [Simulator],
+    providers: [
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      {
+        provide: AuthService,
+        useValue: { claims: () => ({ tenantId: 'tenant-a', hospitalId: 'hospital-1' }) },
+      },
+    ],
+  });
+  return TestBed.inject(HttpTestingController);
+}
+
+describe('Simulator', () => {
+  it('states its own tenant/hospital scope', () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(Simulator);
+    fixture.detectChanges();
+
+    const note = fixture.nativeElement.querySelector('[data-testid="scope-note"]') as HTMLElement;
+    expect(note.textContent).toContain('tenant-a');
+    expect(note.textContent).toContain('hospital-1');
+    httpMock.verify();
+  });
+
+  it('reports the decision source for an access simulation', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(Simulator);
+    fixture.detectChanges();
+
+    fixture.componentInstance.principalId.set('user-doctor');
+    fixture.componentInstance.resourceKind.set('patient_record');
+    fixture.componentInstance.resourceId.set('patient-456');
+    fixture.componentInstance.action.set('read');
+
+    const runPromise = fixture.componentInstance.runAccessSimulation();
+    const req = httpMock.expectOne('/api/admin/authz/simulate');
+    expect(req.request.body.tenantId).toEqual('tenant-a');
+    expect(req.request.body.hospitalId).toEqual('hospital-1');
+    expect(req.request.body.principalId).toEqual('user-doctor');
+    req.flush({ cerbosCallId: 'call-1', permissionRevision: 4, allowed: true, source: 'ROLE' });
+    await runPromise;
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="access-source"]')?.textContent,
+    ).toContain('ROLE');
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="access-allowed"]')?.textContent,
+    ).toContain('true');
+  });
+
+  // §19's acceptance criterion naming this exact scenario.
+  it('reports MANDATORY_RULE for a LOCKED sample attribute', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(Simulator);
+    fixture.detectChanges();
+
+    fixture.componentInstance.principalId.set('user-doctor');
+    fixture.componentInstance.resourceKind.set('patient_record');
+    fixture.componentInstance.resourceId.set('patient-456');
+    fixture.componentInstance.resourceAttributes.set('{"status": "LOCKED"}');
+    fixture.componentInstance.action.set('update');
+
+    const runPromise = fixture.componentInstance.runAccessSimulation();
+    const req = httpMock.expectOne('/api/admin/authz/simulate');
+    expect(req.request.body.resource.attributes).toEqual({ status: 'LOCKED' });
+    req.flush({ cerbosCallId: 'call-2', permissionRevision: 4, allowed: false, source: 'MANDATORY_RULE' });
+    await runPromise;
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="access-source"]')?.textContent,
+    ).toContain('MANDATORY_RULE');
+  });
+
+  it('returns the full requirement tree for a capability simulation, with each leaf decision', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(Simulator);
+    fixture.detectChanges();
+
+    fixture.componentInstance.capabilityModule.set('clinical');
+    fixture.componentInstance.capabilityKeys.set('patient.route.edit');
+    fixture.componentInstance.capabilityPrincipalId.set('user-doctor');
+
+    const runPromise = fixture.componentInstance.runCapabilitySimulation();
+    const req = httpMock.expectOne('/api/admin/authz/simulate-capabilities');
+    expect(req.request.body.tenantId).toEqual('tenant-a');
+    expect(req.request.body.capabilityKeys).toEqual(['patient.route.edit']);
+    req.flush({
+      authorizationRevision: 1,
+      rootPolicyRevision: 'root-v1.4.0',
+      capabilityCatalogRevision: '1',
+      capabilities: { 'patient.route.edit': { allowed: false, reason: 'REQUIRED_PERMISSION_DENIED' } },
+      requirementTree: [
+        { resource: 'patient_record', action: 'read', target: 'sample:patient', allowed: true, reason: 'ROLE' },
+        { resource: 'patient_record', action: 'update', target: 'sample:patient', allowed: false, reason: 'USER_REVOKE' },
+      ],
+    });
+    await runPromise;
+    fixture.detectChanges();
+
+    const tree = fixture.nativeElement.querySelector('[data-testid="requirement-tree"]') as HTMLElement;
+    expect(tree.textContent).toContain('read');
+    expect(tree.textContent).toContain('update');
+    expect(tree.textContent).toContain('USER_REVOKE');
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="capability-outcomes"]')?.textContent,
+    ).toContain('denied');
+  });
+
+  it('rejects malformed JSON in the resource attributes without calling the server', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(Simulator);
+    fixture.detectChanges();
+
+    fixture.componentInstance.resourceAttributes.set('not json');
+    await fixture.componentInstance.runAccessSimulation();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="access-error"]')).toBeTruthy();
+    httpMock.expectNone('/api/admin/authz/simulate');
+  });
+});

--- a/apps/admin-console/src/app/simulator/simulator.ts
+++ b/apps/admin-console/src/app/simulator/simulator.ts
@@ -1,0 +1,153 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { firstValueFrom } from 'rxjs';
+
+import { AuthService } from '../auth/auth.service';
+import {
+  LeafDecision,
+  SimulateAccessResult,
+  SimulateCapabilitiesResult,
+  SimulatorApi,
+} from './simulator-api';
+
+function parseList(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s !== '');
+}
+
+function parseJSONObject(raw: string): Record<string, unknown> {
+  if (raw.trim() === '') {
+    return {};
+  }
+  const parsed = JSON.parse(raw);
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('expected a JSON object');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * The effective-access simulator (§9.4, §12.4, issue #19): answers "why
+ * can this person do this" by running the real ADS and Cerbos path for
+ * an explicitly named principal - never a client-side reimplementation
+ * of precedence.
+ */
+@Component({
+  standalone: true,
+  imports: [FormsModule],
+  selector: 'app-simulator',
+  templateUrl: './simulator.html',
+  styleUrl: './simulator.css',
+})
+export class Simulator {
+  private readonly api = inject(SimulatorApi);
+  private readonly auth = inject(AuthService);
+
+  /** Fixed by the administrator's own token scope, the same authority
+   * check every other admin-service write/simulate endpoint enforces. */
+  readonly tenant = computed(() => this.auth.claims()?.tenantId ?? '');
+  readonly hospital = computed(() => this.auth.claims()?.hospitalId ?? '');
+
+  // --- Access simulation ---
+  readonly principalId = signal('');
+  readonly idpRoles = signal('');
+  readonly resourceKind = signal('');
+  readonly resourceId = signal('');
+  readonly resourceAttributes = signal('{"status": "ACTIVE"}');
+  readonly action = signal('');
+
+  readonly accessResult = signal<SimulateAccessResult | null>(null);
+  readonly accessError = signal<string | null>(null);
+  readonly accessRunning = signal(false);
+
+  async runAccessSimulation(): Promise<void> {
+    this.accessError.set(null);
+    this.accessResult.set(null);
+
+    let attributes: Record<string, unknown>;
+    try {
+      attributes = parseJSONObject(this.resourceAttributes());
+    } catch {
+      this.accessError.set('Resource attributes must be a JSON object.');
+      return;
+    }
+
+    this.accessRunning.set(true);
+    try {
+      const result = await firstValueFrom(
+        this.api.simulateAccess({
+          tenantId: this.tenant(),
+          hospitalId: this.hospital(),
+          principalId: this.principalId(),
+          idpRoles: parseList(this.idpRoles()),
+          resource: { kind: this.resourceKind(), id: this.resourceId(), attributes },
+          action: this.action(),
+        }),
+      );
+      this.accessResult.set(result);
+    } catch {
+      this.accessError.set('The simulation could not be run.');
+    } finally {
+      this.accessRunning.set(false);
+    }
+  }
+
+  // --- Capability simulation ---
+  readonly capabilityModule = signal('');
+  readonly capabilityKeys = signal('');
+  readonly capabilityPrincipalId = signal('');
+  readonly capabilityIdpRoles = signal('');
+  readonly sampleAttributesJSON = signal('{"patient": {"status": "ACTIVE"}}');
+
+  readonly capabilityResult = signal<SimulateCapabilitiesResult | null>(null);
+  readonly capabilityError = signal<string | null>(null);
+  readonly capabilityRunning = signal(false);
+
+  async runCapabilitySimulation(): Promise<void> {
+    this.capabilityError.set(null);
+    this.capabilityResult.set(null);
+
+    let sampleAttributes: Record<string, Record<string, unknown>>;
+    try {
+      const raw = this.sampleAttributesJSON().trim();
+      sampleAttributes = raw === '' ? {} : (JSON.parse(raw) as Record<string, Record<string, unknown>>);
+    } catch {
+      this.capabilityError.set('Sample attributes must be a JSON object of targetRef to attributes.');
+      return;
+    }
+
+    this.capabilityRunning.set(true);
+    try {
+      const result = await firstValueFrom(
+        this.api.simulateCapabilities({
+          module: this.capabilityModule(),
+          capabilityKeys: parseList(this.capabilityKeys()),
+          tenantId: this.tenant(),
+          hospitalId: this.hospital(),
+          principalId: this.capabilityPrincipalId(),
+          idpRoles: parseList(this.capabilityIdpRoles()),
+          sampleAttributes,
+        }),
+      );
+      this.capabilityResult.set(result);
+    } catch {
+      this.capabilityError.set('The simulation could not be run.');
+    } finally {
+      this.capabilityRunning.set(false);
+    }
+  }
+
+  /** Every leaf's decision, allowed and denied alike - administrators
+   * only (§12.4). */
+  requirementTreeFor(result: SimulateCapabilitiesResult): LeafDecision[] {
+    return result.requirementTree;
+  }
+
+  /** Angular templates cannot call Object.keys/entries directly, so this
+   * projects the capabilities map into an iterable array. */
+  capabilityEntries(result: SimulateCapabilitiesResult): { key: string; allowed: boolean }[] {
+    return Object.entries(result.capabilities).map(([key, value]) => ({ key, allowed: value.allowed }));
+  }
+}

--- a/apps/admin-service/cmd/admin-service/main.go
+++ b/apps/admin-service/cmd/admin-service/main.go
@@ -13,10 +13,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/adsclient"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/catalogapi"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/config"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/server"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/simulate"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/useroverride"
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/postgresstore"
 	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
@@ -87,6 +89,9 @@ func main() {
 			Resources:          resourceCatalog,
 			RootPolicyRevision: cfg.RootPolicyRevision,
 			Capabilities:       uiCapabilities,
+		},
+		Simulate: &simulate.Handler{
+			ADS: adsclient.New(cfg.ADSAddr),
 		},
 	})
 

--- a/apps/admin-service/internal/adsclient/adsclient.go
+++ b/apps/admin-service/internal/adsclient/adsclient.go
@@ -1,0 +1,164 @@
+// Package adsclient is the Administration Service's transport to the
+// Assignment Data Service's simulation endpoints (issue #19).
+//
+// The simulator's whole point is answering "what would this decision be"
+// through the real runtime path, so this package never decides anything
+// itself: it only carries a request to the ADS's real /internal/authz/simulate
+// and /internal/capabilities/simulate endpoints and returns what they
+// answered, forwarding the calling administrator's own bearer token so
+// the ADS's own authentication middleware verifies it exactly as it would
+// for any other caller (§16.1).
+package adsclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Client calls the ADS's simulation endpoints over HTTP.
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+// New prepares a Client. baseURL is the ADS's base address, e.g.
+// "http://ads:8080".
+func New(baseURL string) *Client {
+	return &Client{baseURL: baseURL, http: &http.Client{}}
+}
+
+// SimulateAccessRequest names the target principal and one resource-action
+// explicitly, rather than deriving them from the caller's own token - the
+// whole point of a simulator is evaluating as someone else.
+type SimulateAccessRequest struct {
+	TenantID    string         `json:"tenantId"`
+	HospitalID  string         `json:"hospitalId"`
+	PrincipalID string         `json:"principalId"`
+	IdPRoles    []string       `json:"idpRoles"`
+	Resource    SimulateTarget `json:"resource"`
+	Action      string         `json:"action"`
+}
+
+// SimulateTarget is the resource being asked about, with sample
+// attributes the administrator supplies directly (§9.4).
+type SimulateTarget struct {
+	Kind       string         `json:"kind"`
+	ID         string         `json:"id"`
+	Attributes map[string]any `json:"attributes"`
+}
+
+// SimulateAccessResponse is the ADS's answer for one resource-action.
+type SimulateAccessResponse struct {
+	CerbosCallID       string `json:"cerbosCallId"`
+	PermissionRevision int64  `json:"permissionRevision"`
+	Allowed            bool   `json:"allowed"`
+	Source             string `json:"source"`
+}
+
+// SimulateAccess asks the ADS's real decision path what it would answer
+// for the named principal, resource and action.
+func (c *Client) SimulateAccess(ctx context.Context, token string, req SimulateAccessRequest) (SimulateAccessResponse, error) {
+	var resp SimulateAccessResponse
+	if err := c.post(ctx, token, "/internal/authz/simulate", req, &resp); err != nil {
+		return SimulateAccessResponse{}, err
+	}
+	return resp, nil
+}
+
+// SimulateCapabilitiesRequest names the target principal and the
+// composite capabilities to evaluate, with sample resource attributes
+// supplied directly per targetRef rather than resolved from a real
+// resource (§9.4).
+type SimulateCapabilitiesRequest struct {
+	Module           string                    `json:"module"`
+	CapabilityKeys   []string                  `json:"capabilityKeys"`
+	TenantID         string                    `json:"tenantId"`
+	HospitalID       string                    `json:"hospitalId"`
+	PrincipalID      string                    `json:"principalId"`
+	IdPRoles         []string                  `json:"idpRoles"`
+	SampleAttributes map[string]map[string]any `json:"sampleAttributes"`
+}
+
+// LeafDecision is one permission leaf's decision in the full requirement
+// tree the capability simulator exposes (§12.4).
+type LeafDecision struct {
+	Resource string `json:"resource"`
+	Action   string `json:"action"`
+	Target   string `json:"target"`
+	Allowed  bool   `json:"allowed"`
+	Reason   string `json:"reason"`
+}
+
+// SimulateCapabilitiesResponse is the ADS's capability simulation answer:
+// the same snapshot shape the runtime endpoint serves, plus the complete
+// per-leaf requirement tree.
+type SimulateCapabilitiesResponse struct {
+	AuthorizationRevision     int64                       `json:"authorizationRevision"`
+	RootPolicyRevision        string                      `json:"rootPolicyRevision"`
+	CapabilityCatalogRevision string                      `json:"capabilityCatalogRevision"`
+	Capabilities              map[string]CapabilityResult `json:"capabilities"`
+	RequirementTree           []LeafDecision              `json:"requirementTree"`
+}
+
+// CapabilityResult is one capability's simulated decision.
+type CapabilityResult struct {
+	Allowed            bool                `json:"allowed"`
+	Reason             string              `json:"reason,omitempty"`
+	FailedRequirements []FailedRequirement `json:"failedRequirements,omitempty"`
+}
+
+// FailedRequirement is one denied leaf that explains a capability's
+// simulated denial.
+type FailedRequirement struct {
+	Resource string `json:"resource"`
+	Action   string `json:"action"`
+	Target   string `json:"target"`
+	Reason   string `json:"reason"`
+}
+
+// SimulateCapabilities asks the ADS's real capability evaluation path
+// what it would answer for the named principal and sample context.
+func (c *Client) SimulateCapabilities(ctx context.Context, token string, req SimulateCapabilitiesRequest) (SimulateCapabilitiesResponse, error) {
+	var resp SimulateCapabilitiesResponse
+	if err := c.post(ctx, token, "/internal/capabilities/simulate", req, &resp); err != nil {
+		return SimulateCapabilitiesResponse{}, err
+	}
+	return resp, nil
+}
+
+func (c *Client) post(ctx context.Context, token, path string, requestBody, responseBody any) error {
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("adsclient: encoding the request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("adsclient: building the request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("adsclient: calling the ADS: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("adsclient: reading the ADS response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("adsclient: the ADS returned %d: %s", resp.StatusCode, respBody)
+	}
+
+	if err := json.Unmarshal(respBody, responseBody); err != nil {
+		return fmt.Errorf("adsclient: decoding the ADS response: %w", err)
+	}
+	return nil
+}

--- a/apps/admin-service/internal/adsclient/adsclient_test.go
+++ b/apps/admin-service/internal/adsclient/adsclient_test.go
@@ -1,0 +1,94 @@
+package adsclient_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/adsclient"
+)
+
+// The client forwards the caller's own bearer token, never one it mints
+// itself - the ADS's own authentication middleware verifies it exactly
+// as it would for any other caller.
+func TestSimulateAccessForwardsTheCallersOwnBearerToken(t *testing.T) {
+	var gotAuth, gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(adsclient.SimulateAccessResponse{
+			Allowed: true, Source: "ROLE", CerbosCallID: "call-1", PermissionRevision: 4,
+		})
+	}))
+	defer server.Close()
+
+	client := adsclient.New(server.URL)
+	resp, err := client.SimulateAccess(t.Context(), "admin-token", adsclient.SimulateAccessRequest{
+		TenantID: "tenant-a", HospitalID: "hospital-1", PrincipalID: "user-doctor",
+		Resource: adsclient.SimulateTarget{Kind: "patient_record", ID: "patient-456"},
+		Action:   "read",
+	})
+	if err != nil {
+		t.Fatalf("SimulateAccess: %v", err)
+	}
+
+	if gotAuth != "Bearer admin-token" {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer admin-token")
+	}
+	if gotPath != "/internal/authz/simulate" {
+		t.Errorf("path = %q, want /internal/authz/simulate", gotPath)
+	}
+	if !resp.Allowed || resp.Source != "ROLE" {
+		t.Errorf("response = %+v, want allowed=true source=ROLE", resp)
+	}
+}
+
+func TestSimulateAccessReturnsAnErrorForANonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"the PDP is unreachable"}`))
+	}))
+	defer server.Close()
+
+	client := adsclient.New(server.URL)
+	_, err := client.SimulateAccess(t.Context(), "admin-token", adsclient.SimulateAccessRequest{})
+	if err == nil {
+		t.Fatal("expected an error for a non-200 response")
+	}
+}
+
+func TestSimulateCapabilitiesForwardsTheCallersOwnBearerTokenAndReturnsTheRequirementTree(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(adsclient.SimulateCapabilitiesResponse{
+			Capabilities: map[string]adsclient.CapabilityResult{
+				"patient.route.edit": {Allowed: true},
+			},
+			RequirementTree: []adsclient.LeafDecision{
+				{Resource: "patient_record", Action: "read", Target: "sample:patient", Allowed: true, Reason: "ROLE"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := adsclient.New(server.URL)
+	resp, err := client.SimulateCapabilities(t.Context(), "admin-token", adsclient.SimulateCapabilitiesRequest{
+		Module: "clinical", CapabilityKeys: []string{"patient.route.edit"},
+		TenantID: "tenant-a", HospitalID: "hospital-1", PrincipalID: "user-doctor",
+	})
+	if err != nil {
+		t.Fatalf("SimulateCapabilities: %v", err)
+	}
+
+	if gotPath != "/internal/capabilities/simulate" {
+		t.Errorf("path = %q, want /internal/capabilities/simulate", gotPath)
+	}
+	if !resp.Capabilities["patient.route.edit"].Allowed {
+		t.Error("patient.route.edit = denied, want allowed")
+	}
+	if len(resp.RequirementTree) != 1 || resp.RequirementTree[0].Action != "read" {
+		t.Errorf("requirementTree = %+v, want one read leaf", resp.RequirementTree)
+	}
+}

--- a/apps/admin-service/internal/config/config.go
+++ b/apps/admin-service/internal/config/config.go
@@ -28,6 +28,9 @@ type Config struct {
 	// endpoint (issue #18) reads UiCapabilityDefinitions from. Mirrors
 	// the ADS's own config field of the same name and default.
 	CapabilityCatalogDir string
+	// ADSAddr is the ADS's base address the simulator (issue #19) calls
+	// its internal simulation endpoints against, e.g. "http://ads:8080".
+	ADSAddr string
 	// RootPolicyRevision is the immutable root-policy tag currently served
 	// (§9.4's "current root revision"), e.g. "root-v1.4.0". Mirrors the
 	// ADS's own config field of the same name and default.
@@ -66,6 +69,7 @@ func FromEnv(lookup LookupFunc) Config {
 		IdPAddr:              valueOr(lookup, "IDP_ADDR", "keycloak:8080"),
 		CatalogDir:           valueOr(lookup, "AUTHORIZATION_CATALOG_DIR", "/etc/cerbos-catalog/resources"),
 		CapabilityCatalogDir: valueOr(lookup, "CAPABILITY_CATALOG_DIR", "/etc/cerbos-catalog/ui-capabilities"),
+		ADSAddr:              valueOr(lookup, "ADS_ADDR", "http://ads:8080"),
 		RootPolicyRevision:   valueOr(lookup, "ROOT_POLICY_REVISION", "root-v1.4.0"),
 
 		KafkaBrokers:          splitOr(lookup, "KAFKA_BROKERS", []string{"redpanda:9092"}),

--- a/apps/admin-service/internal/server/server.go
+++ b/apps/admin-service/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/catalogapi"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/simulate"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/useroverride"
 )
@@ -48,6 +49,10 @@ type Config struct {
 	// Catalog serves the resource catalog endpoint. Nil means the route
 	// is not registered.
 	Catalog *catalogapi.Handler
+
+	// Simulate serves the effective-access simulator endpoints (issue
+	// #19). Nil means the routes are not registered.
+	Simulate *simulate.Handler
 }
 
 // New builds the Administration Service HTTP handler.
@@ -81,6 +86,10 @@ func New(cfg Config) http.Handler {
 			mux.Handle("GET /admin/authz/resources", authenticated(cfg.Catalog.Read))
 			mux.Handle("GET /admin/authz/resources/{resource}/actions/{action}/capabilities",
 				authenticated(cfg.Catalog.CapabilityImpact))
+		}
+		if cfg.Simulate != nil {
+			mux.Handle("POST /admin/authz/simulate", authenticated(cfg.Simulate.SimulateAccess))
+			mux.Handle("POST /admin/authz/simulate-capabilities", authenticated(cfg.Simulate.SimulateCapabilities))
 		}
 	}
 

--- a/apps/admin-service/internal/server/server_test.go
+++ b/apps/admin-service/internal/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/catalogapi"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/server"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/simulate"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/useroverride"
 	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
 )
@@ -90,6 +91,48 @@ func TestCatalogRouteRequiresABearerToken(t *testing.T) {
 	})
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/authz/resources", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 with no bearer token", rec.Code)
+	}
+}
+
+func TestSimulateAccessRouteIsAbsentWithoutASimulateHandler(t *testing.T) {
+	handler := server.New(server.Config{})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/admin/authz/simulate", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 when no simulate handler is configured", rec.Code)
+	}
+}
+
+func TestSimulateAccessRouteRequiresABearerToken(t *testing.T) {
+	handler := server.New(server.Config{
+		Verifier: fakeVerifier{},
+		Simulate: &simulate.Handler{},
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/admin/authz/simulate", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 with no bearer token", rec.Code)
+	}
+}
+
+func TestSimulateCapabilitiesRouteIsAbsentWithoutASimulateHandler(t *testing.T) {
+	handler := server.New(server.Config{})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/admin/authz/simulate-capabilities", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 when no simulate handler is configured", rec.Code)
+	}
+}
+
+func TestSimulateCapabilitiesRouteRequiresABearerToken(t *testing.T) {
+	handler := server.New(server.Config{
+		Verifier: fakeVerifier{},
+		Simulate: &simulate.Handler{},
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/admin/authz/simulate-capabilities", nil))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401 with no bearer token", rec.Code)
 	}

--- a/apps/admin-service/internal/simulate/simulate.go
+++ b/apps/admin-service/internal/simulate/simulate.go
@@ -1,0 +1,178 @@
+// Package simulate implements
+// POST /admin/authz/simulate and POST /admin/authz/simulate-capabilities
+// (§9.4, issue #19): the effective-access simulator that answers "why can
+// this person do this" by running the real ADS and Cerbos path for an
+// explicitly named principal, never a second evaluation implementation
+// of its own (§21).
+package simulate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/adsclient"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/authority"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+)
+
+// ADS is the narrow slice of the ADS's simulation surface this handler
+// needs, satisfied by adsclient.Client in production and a fake in tests.
+type ADS interface {
+	SimulateAccess(ctx context.Context, token string, req adsclient.SimulateAccessRequest) (adsclient.SimulateAccessResponse, error)
+	SimulateCapabilities(ctx context.Context, token string, req adsclient.SimulateCapabilitiesRequest) (adsclient.SimulateCapabilitiesResponse, error)
+}
+
+// Handler serves the simulator endpoints.
+type Handler struct {
+	ADS ADS
+}
+
+type accessRequest struct {
+	TenantID    string           `json:"tenantId"`
+	HospitalID  string           `json:"hospitalId"`
+	PrincipalID string           `json:"principalId"`
+	IdPRoles    []string         `json:"idpRoles"`
+	Resource    accessRequestRes `json:"resource"`
+	Action      string           `json:"action"`
+}
+
+type accessRequestRes struct {
+	Kind       string         `json:"kind"`
+	ID         string         `json:"id"`
+	Attributes map[string]any `json:"attributes"`
+}
+
+func (r accessRequest) validate() error {
+	switch {
+	case r.TenantID == "":
+		return fmt.Errorf("tenantId is required")
+	case r.HospitalID == "":
+		return fmt.Errorf("hospitalId is required")
+	case r.PrincipalID == "":
+		return fmt.Errorf("principalId is required")
+	case r.Resource.Kind == "":
+		return fmt.Errorf("resource.kind is required")
+	case r.Resource.ID == "":
+		return fmt.Errorf("resource.id is required")
+	case r.Action == "":
+		return fmt.Errorf("action is required")
+	}
+	return nil
+}
+
+// SimulateAccess handles POST /admin/authz/simulate.
+func (h *Handler) SimulateAccess(w http.ResponseWriter, r *http.Request) {
+	identity, ok := tokenauth.From(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	var req accessRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "malformed request body")
+		return
+	}
+	if err := req.validate(); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := authority.Validate(
+		authority.Principal{TenantID: identity.TenantID, HospitalID: identity.HospitalID},
+		req.TenantID, req.HospitalID); err != nil {
+		writeError(w, http.StatusForbidden, "you do not have authority over this tenant and hospital")
+		return
+	}
+
+	resp, err := h.ADS.SimulateAccess(r.Context(), identity.RawToken, adsclient.SimulateAccessRequest{
+		TenantID: req.TenantID, HospitalID: req.HospitalID, PrincipalID: req.PrincipalID,
+		IdPRoles: req.IdPRoles,
+		Resource: adsclient.SimulateTarget{
+			Kind: req.Resource.Kind, ID: req.Resource.ID, Attributes: req.Resource.Attributes,
+		},
+		Action: req.Action,
+	})
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "the simulation could not be run")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+type capabilitiesRequest struct {
+	Module           string                    `json:"module"`
+	CapabilityKeys   []string                  `json:"capabilityKeys"`
+	TenantID         string                    `json:"tenantId"`
+	HospitalID       string                    `json:"hospitalId"`
+	PrincipalID      string                    `json:"principalId"`
+	IdPRoles         []string                  `json:"idpRoles"`
+	SampleAttributes map[string]map[string]any `json:"sampleAttributes"`
+}
+
+func (r capabilitiesRequest) validate() error {
+	switch {
+	case r.Module == "":
+		return fmt.Errorf("module is required")
+	case len(r.CapabilityKeys) == 0:
+		return fmt.Errorf("capabilityKeys must not be empty")
+	case r.TenantID == "":
+		return fmt.Errorf("tenantId is required")
+	case r.HospitalID == "":
+		return fmt.Errorf("hospitalId is required")
+	case r.PrincipalID == "":
+		return fmt.Errorf("principalId is required")
+	}
+	return nil
+}
+
+// SimulateCapabilities handles POST /admin/authz/simulate-capabilities.
+func (h *Handler) SimulateCapabilities(w http.ResponseWriter, r *http.Request) {
+	identity, ok := tokenauth.From(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	var req capabilitiesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "malformed request body")
+		return
+	}
+	if err := req.validate(); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := authority.Validate(
+		authority.Principal{TenantID: identity.TenantID, HospitalID: identity.HospitalID},
+		req.TenantID, req.HospitalID); err != nil {
+		writeError(w, http.StatusForbidden, "you do not have authority over this tenant and hospital")
+		return
+	}
+
+	resp, err := h.ADS.SimulateCapabilities(r.Context(), identity.RawToken, adsclient.SimulateCapabilitiesRequest{
+		Module: req.Module, CapabilityKeys: req.CapabilityKeys,
+		TenantID: req.TenantID, HospitalID: req.HospitalID, PrincipalID: req.PrincipalID,
+		IdPRoles: req.IdPRoles, SampleAttributes: req.SampleAttributes,
+	})
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "the simulation could not be run")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}

--- a/apps/admin-service/internal/simulate/simulate_test.go
+++ b/apps/admin-service/internal/simulate/simulate_test.go
@@ -1,0 +1,191 @@
+package simulate_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/adsclient"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/simulate"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+)
+
+func adminOf(tenant, hospital string) tokenauth.Identity {
+	return tokenauth.Identity{
+		PrincipalID: "admin-1", TenantID: tenant, HospitalID: hospital,
+		Roles: []string{"kc:cerbos-poc:patient-app:administrator"}, RawToken: "admin-token",
+	}
+}
+
+func post(target, body string, identity tokenauth.Identity) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req.WithContext(tokenauth.WithIdentity(req.Context(), identity))
+}
+
+type fakeADS struct {
+	accessReq  adsclient.SimulateAccessRequest
+	accessResp adsclient.SimulateAccessResponse
+	accessErr  error
+
+	capsReq  adsclient.SimulateCapabilitiesRequest
+	capsResp adsclient.SimulateCapabilitiesResponse
+	capsErr  error
+
+	lastToken string
+}
+
+func (f *fakeADS) SimulateAccess(_ context.Context, token string, req adsclient.SimulateAccessRequest) (adsclient.SimulateAccessResponse, error) {
+	f.lastToken = token
+	f.accessReq = req
+	return f.accessResp, f.accessErr
+}
+
+func (f *fakeADS) SimulateCapabilities(_ context.Context, token string, req adsclient.SimulateCapabilitiesRequest) (adsclient.SimulateCapabilitiesResponse, error) {
+	f.lastToken = token
+	f.capsReq = req
+	return f.capsResp, f.capsErr
+}
+
+const accessBody = `{
+  "tenantId": "tenant-a",
+  "hospitalId": "hospital-1",
+  "principalId": "user-doctor",
+  "idpRoles": ["kc:cerbos-poc:patient-app:doctor"],
+  "resource": {"kind": "patient_record", "id": "patient-456", "attributes": {"status": "ACTIVE"}},
+  "action": "read"
+}`
+
+// The simulator forwards the caller's own bearer token to the ADS, never
+// minting a credential of its own.
+func TestSimulateAccessForwardsTheAdminsOwnToken(t *testing.T) {
+	ads := &fakeADS{accessResp: adsclient.SimulateAccessResponse{Allowed: true, Source: "ROLE"}}
+	handler := simulate.Handler{ADS: ads}
+
+	rec := httptest.NewRecorder()
+	handler.SimulateAccess(rec, post("/admin/authz/simulate", accessBody, adminOf("tenant-a", "hospital-1")))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body)
+	}
+	if ads.lastToken != "admin-token" {
+		t.Errorf("token forwarded to the ADS = %q, want admin-token", ads.lastToken)
+	}
+	if ads.accessReq.PrincipalID != "user-doctor" {
+		t.Errorf("principalId forwarded = %q, want user-doctor", ads.accessReq.PrincipalID)
+	}
+
+	var body adsclient.SimulateAccessResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if !body.Allowed {
+		t.Error("allowed = false, want true")
+	}
+}
+
+// §9.4's authority check: an administrator may simulate only within the
+// tenant and hospital their own token scopes them to.
+func TestSimulateAccessRejectsACrossHospitalRequest(t *testing.T) {
+	ads := &fakeADS{}
+	handler := simulate.Handler{ADS: ads}
+
+	rec := httptest.NewRecorder()
+	handler.SimulateAccess(rec, post("/admin/authz/simulate", accessBody, adminOf("tenant-a", "hospital-2")))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", rec.Code, rec.Body)
+	}
+	if ads.accessReq.PrincipalID != "" {
+		t.Error("the ADS was called for an unauthorized cross-hospital simulation")
+	}
+}
+
+func TestSimulateAccessRequiresAVerifiedIdentity(t *testing.T) {
+	ads := &fakeADS{}
+	handler := simulate.Handler{ADS: ads}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/authz/simulate", strings.NewReader(accessBody))
+	rec := httptest.NewRecorder()
+	handler.SimulateAccess(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestSimulateAccessSurfacesAnADSFailureWithoutLeakingTheCredential(t *testing.T) {
+	adminSecret := "a-secret-nobody-should-see"
+	ads := &fakeADS{accessErr: errFromADS(adminSecret)}
+	handler := simulate.Handler{ADS: ads}
+
+	rec := httptest.NewRecorder()
+	handler.SimulateAccess(rec, post("/admin/authz/simulate", accessBody, adminOf("tenant-a", "hospital-1")))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), adminSecret) {
+		t.Errorf("the response echoed the credential: %s", rec.Body)
+	}
+}
+
+const capabilitiesBody = `{
+  "module": "clinical",
+  "capabilityKeys": ["patient.route.edit"],
+  "tenantId": "tenant-a",
+  "hospitalId": "hospital-1",
+  "principalId": "user-doctor",
+  "idpRoles": ["kc:cerbos-poc:patient-app:doctor"],
+  "sampleAttributes": {"patient": {"status": "ACTIVE"}}
+}`
+
+// Capability simulation returns the full requirement tree, exactly what
+// the ADS reported - the admin-service adds no evaluation of its own.
+func TestSimulateCapabilitiesReturnsTheFullRequirementTree(t *testing.T) {
+	ads := &fakeADS{capsResp: adsclient.SimulateCapabilitiesResponse{
+		Capabilities: map[string]adsclient.CapabilityResult{"patient.route.edit": {Allowed: true}},
+		RequirementTree: []adsclient.LeafDecision{
+			{Resource: "patient_record", Action: "read", Target: "sample:patient", Allowed: true, Reason: "ROLE"},
+			{Resource: "patient_record", Action: "update", Target: "sample:patient", Allowed: true, Reason: "ROLE"},
+		},
+	}}
+	handler := simulate.Handler{ADS: ads}
+
+	rec := httptest.NewRecorder()
+	handler.SimulateCapabilities(rec, post("/admin/authz/simulate-capabilities", capabilitiesBody, adminOf("tenant-a", "hospital-1")))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body)
+	}
+	var body adsclient.SimulateCapabilitiesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if len(body.RequirementTree) != 2 {
+		t.Fatalf("requirementTree = %d leaves, want 2", len(body.RequirementTree))
+	}
+}
+
+func TestSimulateCapabilitiesRejectsACrossTenantRequest(t *testing.T) {
+	ads := &fakeADS{}
+	handler := simulate.Handler{ADS: ads}
+
+	rec := httptest.NewRecorder()
+	handler.SimulateCapabilities(rec, post("/admin/authz/simulate-capabilities", capabilitiesBody, adminOf("tenant-b", "hospital-1")))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", rec.Code, rec.Body)
+	}
+}
+
+type simpleError string
+
+func (e simpleError) Error() string { return string(e) }
+
+func errFromADS(secret string) error {
+	return simpleError("adsclient: the ADS returned 503: client_secret=" + secret)
+}

--- a/apps/admin-service/internal/tokenauth/tokenauth.go
+++ b/apps/admin-service/internal/tokenauth/tokenauth.go
@@ -27,6 +27,10 @@ type Identity struct {
 	HospitalID  string
 	// Roles are canonical §7.5 identifiers.
 	Roles []string
+	// RawToken is the verified bearer token exactly as it arrived, so the
+	// simulator (issue #19) can present the same credential to the ADS's
+	// internal simulate endpoints rather than minting one of its own.
+	RawToken string
 }
 
 // Verifier is the token verification this middleware delegates to.
@@ -91,6 +95,7 @@ func Require(cfg Config, next http.Handler) http.Handler {
 			TenantID:    verified.TenantID,
 			HospitalID:  verified.HospitalID,
 			Roles:       verified.Roles,
+			RawToken:    raw,
 		}
 		next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), identity)))
 	})

--- a/apps/ads/Dockerfile
+++ b/apps/ads/Dockerfile
@@ -18,6 +18,7 @@ COPY libs/authzcache/go.mod ./libs/authzcache/
 COPY libs/capabilitycatalog/go.mod libs/capabilitycatalog/go.sum ./libs/capabilitycatalog/
 COPY libs/capabilityeval/go.mod libs/capabilityeval/go.sum ./libs/capabilityeval/
 COPY libs/cataloggen/go.mod libs/cataloggen/go.sum ./libs/cataloggen/
+COPY libs/permissionevents/go.mod ./libs/permissionevents/
 WORKDIR /src/apps/ads
 RUN go mod download
 

--- a/apps/ads/cmd/ads/main.go
+++ b/apps/ads/cmd/ads/main.go
@@ -181,6 +181,24 @@ func main() {
 			RootPolicyRevision: cfg.RootPolicyRevision,
 			Logger:             logger,
 		})),
+		SimulateHandler: authenticated(authz.NewSimulateHandler(authz.Config{
+			PDP: pdp,
+			Assignments: assignments.NewResolver(assignments.ResolverConfig{
+				Matrix:    roleMatrixCache,
+				Overrides: assignments.NewDBOverrides(store, nil),
+			}),
+			Logger: logger,
+		})),
+		CapabilitySimulateHandler: authenticated(capability.NewSimulateHandler(capability.Config{
+			PDP:               pdp,
+			CapabilityCatalog: capability.NewFSCatalog(cfg.CapabilityCatalogDir, cfg.CapabilityCatalogRevision, nil),
+			Assignments: assignments.NewResolver(assignments.ResolverConfig{
+				Matrix:    roleMatrixCache,
+				Overrides: assignments.NewDBOverrides(store, nil),
+			}),
+			RootPolicyRevision: cfg.RootPolicyRevision,
+			Logger:             logger,
+		})),
 		MetricsHandler: promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
 	})
 

--- a/apps/ads/internal/authz/simulate.go
+++ b/apps/ads/internal/authz/simulate.go
@@ -1,0 +1,152 @@
+package authz
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient"
+	"github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext"
+)
+
+// SimulateRequest is the administration simulator's request (issue #19,
+// §9.4): unlike Request, the principal, tenant and hospital are named
+// explicitly rather than derived from the caller's own verified token -
+// the whole point of a simulator is answering "what would this other
+// person see", not "what do I see".
+type SimulateRequest struct {
+	TenantID    string          `json:"tenantId"`
+	HospitalID  string          `json:"hospitalId"`
+	PrincipalID string          `json:"principalId"`
+	IdPRoles    []string        `json:"idpRoles"`
+	Resource    RequestResource `json:"resource"`
+	Action      string          `json:"action"`
+}
+
+func (r SimulateRequest) validate() error {
+	switch {
+	case r.TenantID == "":
+		return fmt.Errorf("tenantId is required")
+	case r.HospitalID == "":
+		return fmt.Errorf("hospitalId is required")
+	case r.PrincipalID == "":
+		return fmt.Errorf("principalId is required")
+	case r.Resource.Kind == "":
+		return fmt.Errorf("resource.kind is required")
+	case r.Resource.ID == "":
+		return fmt.Errorf("resource.id is required")
+	case r.Action == "":
+		return fmt.Errorf("action is required")
+	}
+	return nil
+}
+
+// SimulateResponse is the simulator's answer for one resource-action.
+type SimulateResponse struct {
+	CerbosCallID       string `json:"cerbosCallId"`
+	PermissionRevision int64  `json:"permissionRevision"`
+	Allowed            bool   `json:"allowed"`
+	Source             Source `json:"source"`
+}
+
+// NewSimulateHandler builds the POST /internal/authz/simulate handler
+// (issue #19). It resolves assignments, assembles permissionContext, and
+// asks the PDP through exactly the same Assignments and PDP collaborators
+// the real decision endpoint uses, and labels the outcome with the same
+// DecisionSource function - so a simulated answer is the runtime's own
+// answer for the named principal, never a second evaluation
+// implementation (§21).
+//
+// It is reachable only from other backend services over the internal
+// compose network, never from a browser, the same trust boundary every
+// other /internal/* route on this service already relies on.
+func NewSimulateHandler(cfg Config) http.Handler {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := tokenauth.From(r.Context()); !ok {
+			logger.ErrorContext(r.Context(), "the simulate endpoint was reached without a verified identity")
+			writeError(w, http.StatusUnauthorized, "a bearer token is required")
+			return
+		}
+
+		var req SimulateRequest
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("malformed request: %v", err))
+			return
+		}
+		if err := req.validate(); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		if role, found := reservedRole(req.IdPRoles); found {
+			logger.ErrorContext(r.Context(), "a simulation named a reserved role",
+				slog.String("role", role))
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("role %q is reserved for the platform", role))
+			return
+		}
+
+		input, err := cfg.Assignments.For(r.Context(), AssignmentQuery{
+			TenantID:     req.TenantID,
+			HospitalID:   req.HospitalID,
+			PrincipalID:  req.PrincipalID,
+			ResourceKind: req.Resource.Kind,
+			ResourceID:   req.Resource.ID,
+			IdPRoles:     req.IdPRoles,
+		})
+		if err != nil {
+			logger.ErrorContext(r.Context(), "resolving assignments for a simulation failed",
+				slog.String("principalId", req.PrincipalID), slog.Any("error", err))
+			writeError(w, http.StatusServiceUnavailable, "could not resolve permissions")
+			return
+		}
+
+		assembled := permissioncontext.Assemble(input)
+		ref := cerbosclient.ResourceRef{Kind: req.Resource.Kind, ID: req.Resource.ID}
+
+		attr := make(map[string]any, len(req.Resource.Attributes)+1)
+		for name, value := range req.Resource.Attributes {
+			attr[name] = value
+		}
+		attr["permissionContext"] = assembled.AsMap()
+
+		result, err := cfg.PDP.Check(r.Context(), cerbosclient.Request{
+			Principal: cerbosclient.Principal{
+				ID: req.PrincipalID,
+				Attr: map[string]any{
+					"tenantId":   req.TenantID,
+					"hospitalId": req.HospitalID,
+					"idpRoles":   req.IdPRoles,
+				},
+			},
+			Resources: []cerbosclient.ResourceCheck{{
+				Resource: ref,
+				Attr:     attr,
+				Actions:  []string{req.Action},
+			}},
+		})
+		if err != nil {
+			logger.ErrorContext(r.Context(), "the PDP could not be reached for a simulation",
+				slog.Any("error", err))
+			writeError(w, http.StatusServiceUnavailable, "could not reach the policy decision point")
+			return
+		}
+
+		decision := result.Decisions[cerbosclient.Leaf{Resource: ref, Action: req.Action}]
+		writeJSON(w, http.StatusOK, SimulateResponse{
+			CerbosCallID:       result.CallID,
+			PermissionRevision: assembled.PermissionRevision,
+			Allowed:            decision.Allowed,
+			Source:             DecisionSource(req.Action, decision.Allowed, result.FiredRules[ref]),
+		})
+	})
+}

--- a/apps/ads/internal/authz/simulate_test.go
+++ b/apps/ads/internal/authz/simulate_test.go
@@ -1,0 +1,195 @@
+package authz_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient"
+	"github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext"
+)
+
+// The simulator names a target principal explicitly - the whole point is
+// evaluating as someone other than the caller - so the request body
+// carries identity fields the real decision endpoint refuses (issue #19).
+const simulateRequest = `{
+  "tenantId": "tenant-a",
+  "hospitalId": "hospital-1",
+  "principalId": "user-doctor",
+  "idpRoles": ["kc:cerbos-poc:patient-app:doctor"],
+  "resource": {
+    "kind": "patient_record",
+    "id": "patient-456",
+    "attributes": {"status": "ACTIVE"}
+  },
+  "action": "read"
+}`
+
+func simulatePost(body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/internal/authz/simulate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req.WithContext(tokenauth.WithIdentity(req.Context(), identityWithRoles("kc:cerbos-poc:patient-app:administrator")))
+}
+
+// The simulator reuses the exact same Assignments+PDP+DecisionSource path
+// the runtime decision endpoint uses (issue #19's "not a separate
+// evaluation implementation"), asserted the same way
+// TestTheDecisionSourceComesFromThePDPsFiredRules asserts it for the real
+// endpoint: the reported source comes from the PDP's own fired rules.
+func TestSimulateReportsTheDecisionSourceFromThePDPsFiredRules(t *testing.T) {
+	pdp := &recordingPDP{
+		result: cerbosclient.Result{
+			CallID: "call-sim-1",
+			Decisions: map[cerbosclient.Leaf]cerbosclient.Decision{
+				leaf("patient-456", "read"): {Allowed: true},
+			},
+			FiredRules: map[cerbosclient.ResourceRef][]string{
+				{Kind: "patient_record", ID: "patient-456"}: {"grant_read_to_user"},
+			},
+		},
+	}
+	handler := authz.NewSimulateHandler(authz.Config{PDP: pdp, Assignments: emptyAssignments{}})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, simulatePost(simulateRequest))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body)
+	}
+	var body authz.SimulateResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if !body.Allowed {
+		t.Error("allowed = false, want true")
+	}
+	if body.Source != authz.SourceUserGrant {
+		t.Errorf("source = %q, want %q", body.Source, authz.SourceUserGrant)
+	}
+	if body.CerbosCallID != "call-sim-1" {
+		t.Errorf("cerbosCallId = %q, want call-sim-1", body.CerbosCallID)
+	}
+}
+
+// A LOCKED sample attribute must be forwarded to the real Cerbos policy
+// exactly like the runtime path forwards it, so the mandatory constraint
+// fires for real rather than being simulated separately (issue #19's
+// acceptance criterion naming this exact scenario).
+func TestSimulateWithALockedAttributeReportsMandatoryRule(t *testing.T) {
+	pdp := &recordingPDP{
+		result: cerbosclient.Result{
+			CallID: "call-sim-2",
+			Decisions: map[cerbosclient.Leaf]cerbosclient.Decision{
+				leaf("patient-456", "update"): {Allowed: false},
+			},
+			FiredRules: map[cerbosclient.ResourceRef][]string{
+				{Kind: "patient_record", ID: "patient-456"}: {"locked_record_restriction"},
+			},
+		},
+	}
+	handler := authz.NewSimulateHandler(authz.Config{PDP: pdp, Assignments: emptyAssignments{}})
+
+	locked := strings.Replace(simulateRequest, `"status": "ACTIVE"`, `"status": "LOCKED"`, 1)
+	locked = strings.Replace(locked, `"action": "read"`, `"action": "update"`, 1)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, simulatePost(locked))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body)
+	}
+	if pdp.request.Resources[0].Attr["status"] != "LOCKED" {
+		t.Fatalf("the sample attribute was not forwarded to the PDP: %#v", pdp.request.Resources[0].Attr)
+	}
+	var body authz.SimulateResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if body.Allowed {
+		t.Error("allowed = true, want false for a locked record")
+	}
+	if body.Source != authz.SourceMandatory {
+		t.Errorf("source = %q, want %q", body.Source, authz.SourceMandatory)
+	}
+}
+
+// The simulator writes nothing and advances no revision - it only reports
+// the PermissionRevision the assignments were resolved at.
+func TestSimulateReportsThePermissionRevisionWithoutWriting(t *testing.T) {
+	pdp := &recordingPDP{result: cerbosclient.Result{CallID: "call-sim-3"}}
+	handler := authz.NewSimulateHandler(authz.Config{
+		PDP:         pdp,
+		Assignments: fixedAssignments{input: permissioncontext.Input{Revision: 184}},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, simulatePost(simulateRequest))
+
+	var body authz.SimulateResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if body.PermissionRevision != 184 {
+		t.Errorf("permissionRevision = %d, want 184", body.PermissionRevision)
+	}
+}
+
+func TestSimulateRequiresAVerifiedIdentity(t *testing.T) {
+	pdp := &recordingPDP{}
+	handler := authz.NewSimulateHandler(authz.Config{PDP: pdp, Assignments: emptyAssignments{}})
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/authz/simulate", strings.NewReader(simulateRequest))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+	if pdp.calls != 0 {
+		t.Error("the PDP was called for an unauthenticated request")
+	}
+}
+
+func TestSimulateRejectsASimulatedReservedRole(t *testing.T) {
+	pdp := &recordingPDP{}
+	handler := authz.NewSimulateHandler(authz.Config{PDP: pdp, Assignments: emptyAssignments{}})
+
+	withReservedRole := strings.Replace(simulateRequest,
+		`"idpRoles": ["kc:cerbos-poc:patient-app:doctor"]`,
+		`"idpRoles": ["sys:permission-evaluator"]`, 1)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, simulatePost(withReservedRole))
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
+	}
+	if pdp.calls != 0 {
+		t.Error("the PDP was called for a simulated reserved role")
+	}
+}
+
+func TestSimulateRejectsMalformedRequests(t *testing.T) {
+	cases := map[string]string{
+		"no tenantId":    strings.Replace(simulateRequest, `"tenantId": "tenant-a",`, "", 1),
+		"no principalId": strings.Replace(simulateRequest, `"principalId": "user-doctor",`, "", 1),
+		"no action":      strings.Replace(simulateRequest, `"action": "read"`, `"action": ""`, 1),
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			pdp := &recordingPDP{}
+			handler := authz.NewSimulateHandler(authz.Config{PDP: pdp, Assignments: emptyAssignments{}})
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, simulatePost(body))
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", rec.Code)
+			}
+		})
+	}
+}

--- a/apps/ads/internal/capability/algorithm.go
+++ b/apps/ads/internal/capability/algorithm.go
@@ -18,28 +18,33 @@ import (
 )
 
 // evaluate implements the §12.3 backend evaluation algorithm end to end.
-func evaluate(ctx context.Context, cfg Config, maxResources int, identity tokenauth.Identity, req Request) (Snapshot, error) {
+// The returned leafOutcomes carries every leaf's decision, allowed and
+// denied alike - NewHandler's own snapshot only surfaces the denied ones
+// as FailedRequirements, but the simulator (issue #19) needs the complete
+// requirement tree, and reusing this return value rather than
+// re-evaluating is what keeps it from being a second implementation.
+func evaluate(ctx context.Context, cfg Config, maxResources int, identity tokenauth.Identity, req Request) (Snapshot, map[capabilityeval.Leaf]capabilityeval.LeafOutcome, error) {
 	// Step 1: load definitions for the active capability-catalog revision.
 	allDefs, catalogRevision, err := cfg.CapabilityCatalog.Definitions(ctx, req.Module)
 	if err != nil {
-		return Snapshot{}, fmt.Errorf("loading capability definitions: %w", err)
+		return Snapshot{}, nil, fmt.Errorf("loading capability definitions: %w", err)
 	}
 
 	defs, err := selectRequested(allDefs, req.CapabilityKeys)
 	if err != nil {
-		return Snapshot{}, err
+		return Snapshot{}, nil, err
 	}
 
 	// Step 2: resolve every targetRef into a concrete resource, server-side.
 	targets, targetOrder, resourceAttrs, err := resolveTargets(ctx, cfg, identity, req, defs)
 	if err != nil {
-		return Snapshot{}, fmt.Errorf("resolving targets: %w", err)
+		return Snapshot{}, nil, fmt.Errorf("resolving targets: %w", err)
 	}
 
 	// Steps 3-4: flatten and deduplicate every permission leaf.
 	leaves, err := capabilityeval.Flatten(defs, targets)
 	if err != nil {
-		return Snapshot{}, fmt.Errorf("flattening capabilities: %w", err)
+		return Snapshot{}, nil, fmt.Errorf("flattening capabilities: %w", err)
 	}
 
 	// Group deduplicated leaves by resource, so assignments and Cerbos are
@@ -50,13 +55,13 @@ func evaluate(ctx context.Context, cfg Config, maxResources int, identity tokena
 	// Step 5: resolve assignments once per resource for this subject.
 	revision, resourceChecks, err := buildResourceChecks(ctx, cfg, identity, resourceOrder, resourceActions, resourceAttrs)
 	if err != nil {
-		return Snapshot{}, fmt.Errorf("resolving assignments: %w", err)
+		return Snapshot{}, nil, fmt.Errorf("resolving assignments: %w", err)
 	}
 
 	// Steps 6-7: issue a bounded number of Cerbos calls and merge results.
 	decisions, firedRules, err := checkInChunks(ctx, cfg, maxResources, identity, resourceChecks)
 	if err != nil {
-		return Snapshot{}, fmt.Errorf("checking resources: %w", err)
+		return Snapshot{}, nil, fmt.Errorf("checking resources: %w", err)
 	}
 
 	leafOutcomes := make(map[capabilityeval.Leaf]capabilityeval.LeafOutcome, len(leaves))
@@ -72,7 +77,7 @@ func evaluate(ctx context.Context, cfg Config, maxResources int, identity tokena
 	// Step 8: evaluate every capability expression in memory.
 	outcomes, err := capabilityeval.Evaluate(defs, targets, leafOutcomes)
 	if err != nil {
-		return Snapshot{}, fmt.Errorf("evaluating capabilities: %w", err)
+		return Snapshot{}, nil, fmt.Errorf("evaluating capabilities: %w", err)
 	}
 
 	// Step 9: assemble the snapshot.
@@ -102,7 +107,7 @@ func evaluate(ctx context.Context, cfg Config, maxResources int, identity tokena
 		Module:                    req.Module,
 		ContextFingerprint:        contextFingerprint(identity, req, targetOrder, targets),
 		Capabilities:              capabilities,
-	}, nil
+	}, leafOutcomes, nil
 }
 
 // selectRequested filters defs down to exactly the requested capability

--- a/apps/ads/internal/capability/capability.go
+++ b/apps/ads/internal/capability/capability.go
@@ -199,7 +199,7 @@ func NewHandler(cfg Config) http.Handler {
 			return
 		}
 
-		snapshot, err := evaluate(r.Context(), cfg, maxResources, identity, req)
+		snapshot, _, err := evaluate(r.Context(), cfg, maxResources, identity, req)
 		if err != nil {
 			var badRequest *badRequestError
 			if errors.As(err, &badRequest) {

--- a/apps/ads/internal/capability/simulate.go
+++ b/apps/ads/internal/capability/simulate.go
@@ -1,0 +1,186 @@
+package capability
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/canonicalid"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilityeval"
+)
+
+// SimulateRequest is the administration capability simulator's request
+// (issue #19, §9.4): the principal is named explicitly, and every
+// targetRef's resource attributes are supplied directly as trusted
+// sample context rather than resolved from a real resource - the whole
+// point of a simulator is trying attributes without a real instance
+// existing yet.
+type SimulateRequest struct {
+	Module           string                    `json:"module"`
+	CapabilityKeys   []string                  `json:"capabilityKeys"`
+	TenantID         string                    `json:"tenantId"`
+	HospitalID       string                    `json:"hospitalId"`
+	PrincipalID      string                    `json:"principalId"`
+	IdPRoles         []string                  `json:"idpRoles"`
+	SampleAttributes map[string]map[string]any `json:"sampleAttributes"`
+}
+
+func (r SimulateRequest) validate() error {
+	switch {
+	case r.Module == "":
+		return errors.New("module is required")
+	case len(r.CapabilityKeys) == 0:
+		return errors.New("capabilityKeys must not be empty")
+	case r.TenantID == "":
+		return errors.New("tenantId is required")
+	case r.HospitalID == "":
+		return errors.New("hospitalId is required")
+	case r.PrincipalID == "":
+		return errors.New("principalId is required")
+	}
+	return nil
+}
+
+// LeafDecision is one permission leaf's decision in the full requirement
+// tree the simulator exposes to administrators only (§12.4, issue #19).
+type LeafDecision struct {
+	Resource string `json:"resource"`
+	Action   string `json:"action"`
+	Target   string `json:"target"`
+	Allowed  bool   `json:"allowed"`
+	Reason   string `json:"reason"`
+}
+
+// SimulateSnapshot is the capability simulator's response: the same
+// Snapshot shape the runtime endpoint serves, plus the complete,
+// per-leaf requirement tree - administration-audience evidence that must
+// never reach an end-user path (§12.4).
+type SimulateSnapshot struct {
+	Snapshot
+	RequirementTree []LeafDecision `json:"requirementTree"`
+}
+
+// sampleTargetResolver satisfies TargetResolver from the request's own
+// SampleAttributes, so the simulator reuses evaluate() - the exact same
+// target-resolution, leaf-flattening, Cerbos-batching and
+// capabilityeval.Evaluate composition the runtime snapshot endpoint uses
+// - rather than a second evaluation implementation (§21). Only the
+// source of a targetRef's attributes differs; every step after that is
+// identical code.
+type sampleTargetResolver struct {
+	sampleAttributes map[string]map[string]any
+}
+
+func (s sampleTargetResolver) Resolve(_ context.Context, query TargetQuery) (ResolvedTarget, error) {
+	return ResolvedTarget{
+		Resource:   capabilityeval.ResourceRef{Kind: query.ResourceKind, ID: "sample:" + query.TargetRef},
+		Attributes: s.sampleAttributes[query.TargetRef],
+	}, nil
+}
+
+// NewSimulateHandler builds the POST /internal/capabilities/simulate
+// handler (issue #19). It is reachable only from other backend services
+// over the internal compose network, never from a browser - the same
+// trust boundary every other /internal/* route on this service relies
+// on - and it always answers at AudienceAdmin, since existing is the
+// whole point.
+func NewSimulateHandler(cfg Config) http.Handler {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	maxResources := cfg.MaxResourcesPerCheck
+	if maxResources <= 0 {
+		maxResources = DefaultMaxResourcesPerCheck
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := tokenauth.From(r.Context()); !ok {
+			logger.ErrorContext(r.Context(), "the capability simulate endpoint was reached without a verified identity")
+			writeError(w, http.StatusUnauthorized, "a bearer token is required")
+			return
+		}
+
+		var req SimulateRequest
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("malformed request: %v", err))
+			return
+		}
+		if err := req.validate(); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		if role, found := simulatedReservedRole(req.IdPRoles); found {
+			logger.ErrorContext(r.Context(), "a capability simulation named a reserved role",
+				slog.String("role", role))
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("role %q is reserved for the platform", role))
+			return
+		}
+
+		identity := tokenauth.Identity{
+			PrincipalID: req.PrincipalID,
+			TenantID:    req.TenantID,
+			HospitalID:  req.HospitalID,
+			Roles:       req.IdPRoles,
+		}
+
+		simCfg := cfg
+		simCfg.TargetResolver = sampleTargetResolver{sampleAttributes: req.SampleAttributes}
+		simCfg.Audience = AudienceAdmin
+
+		snapshot, leafOutcomes, err := evaluate(r.Context(), simCfg, maxResources, identity, Request{
+			Module:         req.Module,
+			CapabilityKeys: req.CapabilityKeys,
+		})
+		if err != nil {
+			var badRequest *badRequestError
+			if errors.As(err, &badRequest) {
+				writeError(w, http.StatusBadRequest, badRequest.Error())
+				return
+			}
+			logger.ErrorContext(r.Context(), "simulating capabilities failed",
+				slog.String("principalId", req.PrincipalID),
+				slog.String("module", req.Module),
+				slog.Any("error", err))
+			writeError(w, http.StatusServiceUnavailable, "could not simulate capabilities")
+			return
+		}
+
+		tree := make([]LeafDecision, 0, len(leafOutcomes))
+		for leaf, outcome := range leafOutcomes {
+			tree = append(tree, LeafDecision{
+				Resource: leaf.Resource.Kind, Action: leaf.Action, Target: leaf.Resource.ID,
+				Allowed: outcome.Allowed, Reason: outcome.Reason,
+			})
+		}
+		sort.Slice(tree, func(i, j int) bool {
+			if tree[i].Resource != tree[j].Resource {
+				return tree[i].Resource < tree[j].Resource
+			}
+			if tree[i].Target != tree[j].Target {
+				return tree[i].Target < tree[j].Target
+			}
+			return tree[i].Action < tree[j].Action
+		})
+
+		writeJSON(w, http.StatusOK, SimulateSnapshot{Snapshot: snapshot, RequirementTree: tree})
+	})
+}
+
+func simulatedReservedRole(roles []string) (string, bool) {
+	for _, role := range roles {
+		if canonicalid.IsReserved(role) {
+			return role, true
+		}
+	}
+	return "", false
+}

--- a/apps/ads/internal/capability/simulate_test.go
+++ b/apps/ads/internal/capability/simulate_test.go
@@ -1,0 +1,195 @@
+package capability_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/capability"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/capabilitycatalog"
+	"github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient"
+)
+
+// firingPDP answers every leaf as allowed unless named in denied, and
+// reports the given fired rule names for every resource - the simulator
+// tests need decision-source labelling, which recordingPDP does not
+// exercise.
+type firingPDP struct {
+	denied     map[cerbosclient.Leaf]bool
+	firedRules []string
+	lastReq    cerbosclient.Request
+}
+
+func (p *firingPDP) Check(_ context.Context, req cerbosclient.Request) (cerbosclient.Result, error) {
+	p.lastReq = req
+	decisions := make(map[cerbosclient.Leaf]cerbosclient.Decision)
+	firedRules := make(map[cerbosclient.ResourceRef][]string)
+	for _, resource := range req.Resources {
+		firedRules[resource.Resource] = p.firedRules
+		for _, action := range resource.Actions {
+			l := cerbosclient.Leaf{Resource: resource.Resource, Action: action}
+			decisions[l] = cerbosclient.Decision{Allowed: !p.denied[l]}
+		}
+	}
+	return cerbosclient.Result{CallID: "sim-call-1", Decisions: decisions, FiredRules: firedRules}, nil
+}
+
+func simulateCapabilitiesPost(t *testing.T, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/internal/capabilities/simulate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req.WithContext(tokenauth.WithIdentity(req.Context(), identity()))
+}
+
+const simulateCapabilitiesRequest = `{
+  "module": "clinical",
+  "capabilityKeys": ["patient.route.edit"],
+  "tenantId": "tenant-a",
+  "hospitalId": "hospital-1",
+  "principalId": "user-doctor",
+  "idpRoles": ["kc:cerbos-poc:patient-app:doctor"],
+  "sampleAttributes": {
+    "patient": {"status": "ACTIVE"}
+  }
+}`
+
+// The simulator reuses evaluate() itself, so this asserts it produces the
+// same composed answer that machinery already produces for the real
+// endpoint (issue #19's "not a separate evaluation implementation").
+func TestSimulateCapabilitiesComposesTheSameAsTheRuntime(t *testing.T) {
+	catalog := fakeCatalog{
+		revision: "1",
+		defs: []capabilitycatalog.UiCapabilityDefinition{
+			{
+				Key: "patient.route.edit", Module: "clinical", Context: "INSTANCE",
+				Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+					permission("patient_record", "read", "patient"),
+					permission("patient_record", "update", "patient"),
+				}},
+			},
+		},
+	}
+	pdp := &firingPDP{}
+	handler := capability.NewSimulateHandler(capability.Config{
+		PDP: pdp, CapabilityCatalog: catalog, Assignments: emptyAssignments{}, RootPolicyRevision: "root-v1.4.0",
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, simulateCapabilitiesPost(t, simulateCapabilitiesRequest))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body)
+	}
+	var body capability.SimulateSnapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if !body.Capabilities["patient.route.edit"].Allowed {
+		t.Errorf("patient.route.edit = denied, want allowed: %+v", body.Capabilities)
+	}
+}
+
+// The full requirement tree names every leaf's decision, allowed and
+// denied alike - not only the ones that explain a denial.
+func TestSimulateCapabilitiesReturnsTheFullRequirementTree(t *testing.T) {
+	catalog := fakeCatalog{
+		revision: "1",
+		defs: []capabilitycatalog.UiCapabilityDefinition{
+			{
+				Key: "patient.route.edit", Module: "clinical", Context: "INSTANCE",
+				Expression: capabilitycatalog.Expression{AllOf: []capabilitycatalog.Expression{
+					permission("patient_record", "read", "patient"),
+					permission("patient_record", "update", "patient"),
+				}},
+			},
+		},
+	}
+	pdp := &firingPDP{denied: map[cerbosclient.Leaf]bool{
+		{Resource: cerbosclient.ResourceRef{Kind: "patient_record", ID: "sample:patient"}, Action: "update"}: true,
+	}}
+	handler := capability.NewSimulateHandler(capability.Config{
+		PDP: pdp, CapabilityCatalog: catalog, Assignments: emptyAssignments{}, RootPolicyRevision: "root-v1.4.0",
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, simulateCapabilitiesPost(t, simulateCapabilitiesRequest))
+
+	var body capability.SimulateSnapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if len(body.RequirementTree) != 2 {
+		t.Fatalf("requirement tree = %d leaves, want 2 (read and update): %+v", len(body.RequirementTree), body.RequirementTree)
+	}
+	byAction := make(map[string]capability.LeafDecision, 2)
+	for _, leaf := range body.RequirementTree {
+		byAction[leaf.Action] = leaf
+	}
+	if !byAction["read"].Allowed {
+		t.Errorf("read leaf = denied, want allowed: %+v", byAction["read"])
+	}
+	if byAction["update"].Allowed {
+		t.Errorf("update leaf = allowed, want denied: %+v", byAction["update"])
+	}
+	if body.Capabilities["patient.route.edit"].Allowed {
+		t.Error("patient.route.edit = allowed, want denied (update failed)")
+	}
+}
+
+// Sample attributes are trusted context supplied directly by the
+// administrator, not resolved from a real resource - they must still
+// reach the PDP exactly like a resolved target's attributes would.
+func TestSimulateCapabilitiesForwardsSampleAttributesToThePDP(t *testing.T) {
+	catalog := fakeCatalog{
+		revision: "1",
+		defs: []capabilitycatalog.UiCapabilityDefinition{
+			{Key: "patient.route.view", Module: "clinical", Context: "INSTANCE",
+				Expression: permission("patient_record", "read", "patient")},
+		},
+	}
+	pdp := &firingPDP{}
+	handler := capability.NewSimulateHandler(capability.Config{
+		PDP: pdp, CapabilityCatalog: catalog, Assignments: emptyAssignments{}, RootPolicyRevision: "root-v1.4.0",
+	})
+
+	req := strings.Replace(simulateCapabilitiesRequest, `["patient.route.edit"]`, `["patient.route.view"]`, 1)
+	handler.ServeHTTP(httptest.NewRecorder(), simulateCapabilitiesPost(t, req))
+
+	if pdp.lastReq.Resources[0].Attr["status"] != "ACTIVE" {
+		t.Errorf("sample attribute was not forwarded to the PDP: %#v", pdp.lastReq.Resources[0].Attr)
+	}
+}
+
+func TestSimulateCapabilitiesRequiresAVerifiedIdentity(t *testing.T) {
+	handler := capability.NewSimulateHandler(capability.Config{
+		PDP: &firingPDP{}, CapabilityCatalog: fakeCatalog{}, Assignments: emptyAssignments{},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/capabilities/simulate", strings.NewReader(simulateCapabilitiesRequest))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestSimulateCapabilitiesRejectsASimulatedReservedRole(t *testing.T) {
+	handler := capability.NewSimulateHandler(capability.Config{
+		PDP: &firingPDP{}, CapabilityCatalog: fakeCatalog{}, Assignments: emptyAssignments{},
+	})
+
+	req := strings.Replace(simulateCapabilitiesRequest,
+		`["kc:cerbos-poc:patient-app:doctor"]`, `["sys:permission-evaluator"]`, 1)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, simulateCapabilitiesPost(t, req))
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rec.Code)
+	}
+}

--- a/apps/ads/internal/server/server.go
+++ b/apps/ads/internal/server/server.go
@@ -51,6 +51,14 @@ type Config struct {
 	// does not exist.
 	CapabilityHandler http.Handler
 
+	// SimulateHandler serves POST /internal/authz/simulate and
+	// CapabilitySimulateHandler serves POST /internal/capabilities/simulate
+	// (issue #19). Both are reachable only from other backend services over
+	// the internal compose network, never from a browser - nil means the
+	// route does not exist.
+	SimulateHandler           http.Handler
+	CapabilitySimulateHandler http.Handler
+
 	// MetricsHandler serves GET /metrics, the §10 convergence metrics
 	// (issue #14). Nil means the route does not exist. Unauthenticated,
 	// like every other Prometheus scrape target on this network.
@@ -77,6 +85,12 @@ func New(cfg Config) http.Handler {
 	}
 	if cfg.CapabilityHandler != nil {
 		mux.Handle("POST /internal/capabilities/evaluate", cfg.CapabilityHandler)
+	}
+	if cfg.SimulateHandler != nil {
+		mux.Handle("POST /internal/authz/simulate", cfg.SimulateHandler)
+	}
+	if cfg.CapabilitySimulateHandler != nil {
+		mux.Handle("POST /internal/capabilities/simulate", cfg.CapabilitySimulateHandler)
 	}
 	if cfg.MetricsHandler != nil {
 		mux.Handle("GET /metrics", cfg.MetricsHandler)

--- a/apps/ads/internal/server/server_test.go
+++ b/apps/ads/internal/server/server_test.go
@@ -119,6 +119,58 @@ func TestTheCapabilityEndpointIsAbsentWhenNoHandlerIsConfigured(t *testing.T) {
 	}
 }
 
+func TestTheSimulateEndpointIsMountedWhenAHandlerIsConfigured(t *testing.T) {
+	handler := server.New(server.Config{
+		SimulateHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		}),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/authz/simulate", nil))
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("POST /internal/authz/simulate status = %d, want the configured handler to answer", rec.Code)
+	}
+}
+
+func TestTheSimulateEndpointIsAbsentWhenNoHandlerIsConfigured(t *testing.T) {
+	handler := server.New(server.Config{})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/authz/simulate", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("POST /internal/authz/simulate status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestTheCapabilitySimulateEndpointIsMountedWhenAHandlerIsConfigured(t *testing.T) {
+	handler := server.New(server.Config{
+		CapabilitySimulateHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		}),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/capabilities/simulate", nil))
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("POST /internal/capabilities/simulate status = %d, want the configured handler to answer", rec.Code)
+	}
+}
+
+func TestTheCapabilitySimulateEndpointIsAbsentWhenNoHandlerIsConfigured(t *testing.T) {
+	handler := server.New(server.Config{})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/internal/capabilities/simulate", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("POST /internal/capabilities/simulate status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
 func TestTheUserRolesEndpointIsMountedWhenAHandlerIsConfigured(t *testing.T) {
 	handler := server.New(server.Config{
 		DirectoryUserRolesHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,6 +210,10 @@ services:
       # REVOKE names none, rather than being left unbounded (issue #15).
       USER_OVERRIDE_HIGH_RISK_ACTIONS: "${USER_OVERRIDE_HIGH_RISK_ACTIONS:-update,delete,assign}"
       USER_OVERRIDE_HIGH_RISK_VALIDITY: "${USER_OVERRIDE_HIGH_RISK_VALIDITY:-2160h}"
+      # The effective-access simulator (§9.4, issue #19) runs the real ADS
+      # and Cerbos path for an explicitly named principal, never a second
+      # evaluation implementation of its own.
+      ADS_ADDR: "http://ads:8080"
     volumes:
       - ./deploy/secrets/idp-admin-credentials:/run/secrets/idp-admin-credentials:ro
       - ./deploy/cerbos/catalog/resources:/authorization-catalog:ro
@@ -220,6 +224,8 @@ services:
       keycloak:
         condition: service_healthy
       redpanda:
+        condition: service_healthy
+      ads:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8081/readyz"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,8 +111,12 @@ services:
       - --check=false
       # Redpanda reports anonymous usage stats to Redpanda Data by default;
       # this is an invalidation transport internal to the compose network,
-      # not a deployment with a Redpanda support relationship.
-      - --set=redpanda.enable_usage_stats=false
+      # not a deployment with a Redpanda support relationship. This must
+      # be two array entries: v24.2.7's rpk forwards '--set' straight to
+      # the redpanda binary's own parser, which rejects the '--set=key=value'
+      # single-token form.
+      - --set
+      - enable_usage_stats=false
     healthcheck:
       test: ["CMD", "rpk", "cluster", "health", "--exit-when-healthy"]
       interval: 5s


### PR DESCRIPTION
## What changed

Implements issue #19: the effective-access simulator that answers "why
can this person do this" by running through the real ADS and Cerbos
path for an explicitly named principal - never a client-side or
server-side reimplementation of precedence (§21).

**ADS (the real runtime path, parameterized by an explicit principal):**
- `authz.NewSimulateHandler` serves `POST /internal/authz/simulate`:
  resolves assignments, assembles `permissionContext`, and asks the same
  `PDP`/`Assignments` collaborators the runtime decision endpoint uses,
  labelling the outcome with the same `DecisionSource` function.
- `capability.NewSimulateHandler` serves
  `POST /internal/capabilities/simulate`: reuses `evaluate()` itself -
  the exact target-resolution, leaf-flattening, Cerbos-batching and
  `capabilityeval.Evaluate` composition the runtime capability snapshot
  endpoint uses - with sample attributes supplied directly per
  `targetRef` instead of a resolved real resource.
- `evaluate()` now also returns the full per-leaf outcome map; the
  runtime handler ignores it, the simulate handler uses it to expose the
  complete requirement tree (§12.4) - administration-audience evidence,
  never on an end-user path.
- Both routes are internal-only (reachable only from other backend
  services over the compose network), the same trust boundary every
  other `/internal/*` ADS route already relies on.

**Admin Service:**
- `adsclient` forwards the calling administrator's own bearer token to
  the ADS's internal simulate endpoints - the ADS's own authentication
  middleware verifies it exactly as it would for any other caller, so
  nothing here mints a credential of its own.
- `simulate.Handler` serves `POST /admin/authz/simulate` and
  `POST /admin/authz/simulate-capabilities`, gated by the same
  tenant/hospital authority check every other admin-service write
  endpoint enforces, before forwarding to the ADS.
- `tokenauth.Identity` now carries `RawToken`, mirroring the resource
  service's own identity shape.

**Frontend:** a two-panel Simulator module - one resource-action
simulation with decision source, and a capability simulation showing
every capability's outcome plus the full requirement tree.

## Acceptance criteria

- [x] The simulator produces the same answer as the runtime for the
      same inputs, asserted by test - both simulate handlers reuse the
      exact same collaborators (`Assignments`, `PDP`, `DecisionSource`,
      `evaluate()`) the runtime endpoints call, proven directly in
      `apps/ads/internal/authz/simulate_test.go` and
      `apps/ads/internal/capability/simulate_test.go`.
- [x] The simulator invokes the real ADS and Cerbos path, not a separate
      evaluation implementation - no new precedence or composition logic
      was written; `capability.NewSimulateHandler` literally calls the
      production `evaluate()` function.
- [x] The decision source is reported and is correct for each of the
      four cases - `DecisionSource` is unmodified; `TestSimulateReportsTheDecisionSourceFromThePDPsFiredRules`
      exercises `USER_GRANT`, and the existing `decisionsource_test.go`
      already covers the other three against the same function.
- [x] Capability simulation returns the full requirement tree with each
      leaf decision - `TestSimulateCapabilitiesReturnsTheFullRequirementTree`
      asserts both the allowed and the denied leaf appear.
- [x] Simulation performs no write and increments no revision - neither
      simulate handler touches `assignmentstore`; they only read via the
      same `Assignments` interface every other read path uses.
- [x] Full requirement trees are available to administrators and are not
      returned on end-user paths - the requirement tree is only ever
      built inside the simulate handlers, which no end-user route calls.
- [x] Simulating with a LOCKED sample attribute reports `MANDATORY_RULE`
      as the source - `TestSimulateWithALockedAttributeReportsMandatoryRule`
      and the frontend's matching spec both assert this exact scenario.

## How this was verified locally

- `go test ./...` for `apps/ads` and `apps/admin-service` - all green,
  including new tests for both simulate handlers, `adsclient`, and the
  admin-service `simulate` package.
- `nx test admin-console` - 60/60 green, including the new
  `simulator.spec.ts`.
- `nx affected --target=lint/test/build --base=main` - clean (0 errors).
- `tests/architecture` (forced with `-count=1`) - clean: no Go code
  orders precedence outside Cerbos policy.
- `make catalog-check` / `make capability-check` and
  `python3 scripts/tests/compose-contract.py` /
  `scripts/tests/nx-affected-isolation.sh` - all pass.

Closes #19


Closes #19
