### PR TITLE
Audit query API and Admin Console audit module (#20)

### DIFF
--- a/apps/admin-console/src/app/app.routes.ts
+++ b/apps/admin-console/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Route } from '@angular/router';
 
+import { AuditSearch } from './audit-search/audit-search';
 import { authGuard } from './auth/auth.guard';
 import { Callback } from './auth/callback';
 import { ResourceCatalogBrowser } from './resource-catalog-browser/resource-catalog-browser';
@@ -20,6 +21,7 @@ export const appRoutes: Route[] = [
       { path: 'user-overrides', component: UserOverride },
       { path: 'resource-catalog', component: ResourceCatalogBrowser },
       { path: 'simulator', component: Simulator },
+      { path: 'audit', component: AuditSearch },
     ],
   },
 ];

--- a/apps/admin-console/src/app/audit-search/audit-search-api.ts
+++ b/apps/admin-console/src/app/audit-search/audit-search-api.ts
@@ -1,0 +1,65 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ADMIN_BASE_URL } from '../admin-base-url';
+
+/** One administration audit event (§9.1, §9.4, §17.3). */
+export interface AuditEventRow {
+  eventId: string;
+  actorId: string;
+  operation: string;
+  targetType: string;
+  before: string;
+  after: string;
+  tenantId: string;
+  hospitalId?: string;
+  roleExternalId?: string;
+  targetUserId?: string;
+  resourceActionKeys?: string;
+  correlationId?: string;
+  createdAt: string;
+}
+
+export interface AuditSearchResult {
+  events: AuditEventRow[];
+  totalCount: number;
+}
+
+/** Every filter GET /admin/authz/audit accepts (§9.4). tenant is supplied
+ * separately by the caller, the same mandatory predicate the server itself
+ * enforces (§8.2). */
+export interface AuditSearchFilters {
+  hospital?: string;
+  actor?: string;
+  role?: string;
+  user?: string;
+  resource?: string;
+  action?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AuditSearchApi {
+  private readonly http = inject(HttpClient);
+  private readonly adminBaseUrl = inject(ADMIN_BASE_URL);
+
+  search(tenant: string, filters: AuditSearchFilters): Observable<AuditSearchResult> {
+    const params: Record<string, string> = { tenant };
+    if (filters.hospital) params['hospital'] = filters.hospital;
+    if (filters.actor) params['actor'] = filters.actor;
+    if (filters.role) params['role'] = filters.role;
+    if (filters.user) params['user'] = filters.user;
+    if (filters.resource) params['resource'] = filters.resource;
+    if (filters.action) params['action'] = filters.action;
+    if (filters.from) params['from'] = filters.from;
+    if (filters.to) params['to'] = filters.to;
+    if (filters.limit !== undefined) params['limit'] = String(filters.limit);
+    if (filters.offset !== undefined) params['offset'] = String(filters.offset);
+
+    return this.http.get<AuditSearchResult>(`${this.adminBaseUrl}/authz/audit`, { params });
+  }
+}

--- a/apps/admin-console/src/app/audit-search/audit-search.css
+++ b/apps/admin-console/src/app/audit-search/audit-search.css
@@ -1,0 +1,29 @@
+.error {
+  color: #b00020;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: end;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+th, td {
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.pagination {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 0.75rem;
+}

--- a/apps/admin-console/src/app/audit-search/audit-search.html
+++ b/apps/admin-console/src/app/audit-search/audit-search.html
@@ -1,0 +1,84 @@
+<h1>Audit</h1>
+<p data-testid="scope-note">
+  Scope: tenant {{ tenant() }} (your own authority - audit history outside this tenant cannot
+  be searched here).
+</p>
+
+<section class="filters">
+  <label>
+    Actor
+    <input type="text" data-testid="actor-input" [(ngModel)]="actor" />
+  </label>
+  <label>
+    Role
+    <input type="text" data-testid="role-input" [(ngModel)]="role" />
+  </label>
+  <label>
+    User
+    <input type="text" data-testid="user-input" [(ngModel)]="user" />
+  </label>
+  <label>
+    Resource
+    <input type="text" data-testid="resource-input" [(ngModel)]="resource" />
+  </label>
+  <label>
+    Action
+    <input type="text" data-testid="action-input" [(ngModel)]="action" />
+  </label>
+  <label>
+    Hospital
+    <input type="text" data-testid="hospital-input" [(ngModel)]="hospital" />
+  </label>
+  <label>
+    From
+    <input type="datetime-local" data-testid="from-input" [(ngModel)]="from" />
+  </label>
+  <label>
+    To
+    <input type="datetime-local" data-testid="to-input" [(ngModel)]="to" />
+  </label>
+  <button type="button" data-testid="search-button" [disabled]="searching()" (click)="search()">
+    Search
+  </button>
+</section>
+
+@if (searchError()) {
+  <p data-testid="search-error" class="error">{{ searchError() }}</p>
+}
+
+<table data-testid="audit-results">
+  <thead>
+    <tr>
+      <th>When</th>
+      <th>Actor</th>
+      <th>Operation</th>
+      <th>Role</th>
+      <th>User</th>
+      <th>Resource:action</th>
+      <th>Correlation ID</th>
+    </tr>
+  </thead>
+  <tbody>
+    @for (event of events(); track event.eventId) {
+      <tr data-testid="audit-row">
+        <td>{{ event.createdAt }}</td>
+        <td>{{ event.actorId }}</td>
+        <td>{{ event.operation }}</td>
+        <td>{{ event.roleExternalId }}</td>
+        <td>{{ event.targetUserId }}</td>
+        <td>{{ event.resourceActionKeys }}</td>
+        <td>{{ event.correlationId }}</td>
+      </tr>
+    }
+  </tbody>
+</table>
+
+<div class="pagination">
+  <span data-testid="total-count">{{ totalCount() }} total</span>
+  <button type="button" data-testid="prev-page" [disabled]="offset() === 0" (click)="previousPage()">
+    Previous
+  </button>
+  <button type="button" data-testid="next-page" [disabled]="!hasMore()" (click)="nextPage()">
+    Next
+  </button>
+</div>

--- a/apps/admin-console/src/app/audit-search/audit-search.spec.ts
+++ b/apps/admin-console/src/app/audit-search/audit-search.spec.ts
@@ -69,6 +69,28 @@ describe('AuditSearch', () => {
     expect(total.textContent).toContain('1 total');
   });
 
+  it('sends a full RFC3339 timestamp for a date typed as datetime-local, not the bare local string', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(AuditSearch);
+    fixture.detectChanges();
+
+    // What a <input type="datetime-local"> actually produces: no
+    // timezone offset at all.
+    fixture.componentInstance.from.set('2026-06-01T12:00');
+    const searchPromise = fixture.componentInstance.search();
+
+    const req = httpMock.expectOne(
+      (r) => r.url === '/api/admin/authz/audit' && r.params.has('from'),
+    );
+    const from = req.request.params.get('from')!;
+    expect(() => new Date(from)).not.toThrow();
+    expect(Number.isNaN(Date.parse(from))).toBe(false);
+    expect(from).toMatch(/Z$|[+-]\d\d:\d\d$/);
+
+    req.flush({ events: [], totalCount: 0 });
+    await searchPromise;
+  });
+
   it('reports a search failure without leaving stale results on screen', async () => {
     const httpMock = setUp();
     const fixture = TestBed.createComponent(AuditSearch);

--- a/apps/admin-console/src/app/audit-search/audit-search.spec.ts
+++ b/apps/admin-console/src/app/audit-search/audit-search.spec.ts
@@ -1,0 +1,99 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from '../auth/auth.service';
+import { AuditSearch } from './audit-search';
+
+function setUp() {
+  TestBed.configureTestingModule({
+    imports: [AuditSearch],
+    providers: [
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      {
+        provide: AuthService,
+        useValue: { claims: () => ({ tenantId: 'tenant-a', hospitalId: 'hospital-1' }) },
+      },
+    ],
+  });
+  return TestBed.inject(HttpTestingController);
+}
+
+describe('AuditSearch', () => {
+  it('states its tenant-scoped authority up front', () => {
+    setUp();
+    const fixture = TestBed.createComponent(AuditSearch);
+    fixture.detectChanges();
+
+    const note = fixture.nativeElement.querySelector('[data-testid="scope-note"]') as HTMLElement;
+    expect(note.textContent).toContain('tenant-a');
+  });
+
+  it('searches with the tenant and every filter the administrator entered', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(AuditSearch);
+    fixture.detectChanges();
+
+    fixture.componentInstance.actor.set('admin-2');
+    fixture.componentInstance.role.set('role-doctor');
+    const searchPromise = fixture.componentInstance.search();
+
+    const req = httpMock.expectOne(
+      (r) =>
+        r.url === '/api/admin/authz/audit' &&
+        r.params.get('tenant') === 'tenant-a' &&
+        r.params.get('actor') === 'admin-2' &&
+        r.params.get('role') === 'role-doctor',
+    );
+    req.flush({
+      events: [
+        {
+          eventId: 'audit-1', actorId: 'admin-2', operation: 'ROLE_MATRIX_SAVE',
+          targetType: 'role_permission', before: '{}', after: '{}',
+          tenantId: 'tenant-a', roleExternalId: 'role-doctor',
+          resourceActionKeys: 'patient_record:read', createdAt: '2026-06-01T12:00:00Z',
+        },
+      ],
+      totalCount: 1,
+    });
+    await searchPromise;
+
+    fixture.detectChanges();
+    const rows = fixture.nativeElement.querySelectorAll('[data-testid="audit-row"]');
+    expect(rows.length).toBe(1);
+    const total = fixture.nativeElement.querySelector('[data-testid="total-count"]') as HTMLElement;
+    expect(total.textContent).toContain('1 total');
+  });
+
+  it('reports a search failure without leaving stale results on screen', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(AuditSearch);
+    fixture.detectChanges();
+
+    const searchPromise = fixture.componentInstance.search();
+    httpMock.expectOne((r) => r.url === '/api/admin/authz/audit').flush(
+      { error: 'boom' },
+      { status: 500, statusText: 'Internal Server Error' },
+    );
+    await searchPromise;
+
+    fixture.detectChanges();
+    const error = fixture.nativeElement.querySelector('[data-testid="search-error"]') as HTMLElement;
+    expect(error.textContent).toContain('failed');
+    expect(fixture.nativeElement.querySelectorAll('[data-testid="audit-row"]').length).toBe(0);
+  });
+
+  it('has no control anywhere in the template that edits or deletes an audit event', () => {
+    setUp();
+    const fixture = TestBed.createComponent(AuditSearch);
+    fixture.detectChanges();
+
+    const html = (fixture.nativeElement as HTMLElement).innerHTML.toLowerCase();
+    expect(html).not.toContain('delete');
+    expect(html).not.toContain('data-testid="edit-');
+  });
+});

--- a/apps/admin-console/src/app/audit-search/audit-search.ts
+++ b/apps/admin-console/src/app/audit-search/audit-search.ts
@@ -8,6 +8,21 @@ import { AuditEventRow, AuditSearchApi } from './audit-search-api';
 const PAGE_LIMIT = 20;
 
 /**
+ * A `<input type="datetime-local">` value carries no timezone offset at
+ * all (e.g. "2026-06-01T12:00"), but the server's `from`/`to` filters
+ * require a full RFC3339 timestamp. Converting here, once, is what keeps
+ * every date an administrator actually picks from failing the server's
+ * "from must be an RFC3339 timestamp" check on every search.
+ */
+function toRFC3339(localValue: string): string | undefined {
+  if (!localValue) {
+    return undefined;
+  }
+  const parsed = new Date(localValue);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+}
+
+/**
  * The Admin Console's audit module (§9.1, §9.4, issue #20): search the
  * append-only administration audit by actor, role, target user, resource,
  * action, hospital and date range, and page through the results. There is
@@ -62,8 +77,8 @@ export class AuditSearch {
           user: this.user() || undefined,
           resource: this.resource() || undefined,
           action: this.action() || undefined,
-          from: this.from() || undefined,
-          to: this.to() || undefined,
+          from: toRFC3339(this.from()),
+          to: toRFC3339(this.to()),
           limit: PAGE_LIMIT,
           offset: this.offset(),
         }),

--- a/apps/admin-console/src/app/audit-search/audit-search.ts
+++ b/apps/admin-console/src/app/audit-search/audit-search.ts
@@ -1,0 +1,91 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { firstValueFrom } from 'rxjs';
+
+import { AuthService } from '../auth/auth.service';
+import { AuditEventRow, AuditSearchApi } from './audit-search-api';
+
+const PAGE_LIMIT = 20;
+
+/**
+ * The Admin Console's audit module (§9.1, §9.4, issue #20): search the
+ * append-only administration audit by actor, role, target user, resource,
+ * action, hospital and date range, and page through the results. There is
+ * no edit or delete affordance anywhere in this screen - the audit is
+ * append-only, and the console offers nothing that would suggest
+ * otherwise.
+ */
+@Component({
+  standalone: true,
+  imports: [FormsModule],
+  selector: 'app-audit-search',
+  templateUrl: './audit-search.html',
+  styleUrl: './audit-search.css',
+})
+export class AuditSearch {
+  private readonly api = inject(AuditSearchApi);
+  private readonly auth = inject(AuthService);
+
+  /** Fixed by the administrator's own token scope, the same as every
+   * other administration screen (§9.4's authority check). */
+  readonly tenant = computed(() => this.auth.claims()?.tenantId ?? '');
+
+  readonly hospital = signal('');
+  readonly actor = signal('');
+  readonly role = signal('');
+  readonly user = signal('');
+  readonly resource = signal('');
+  readonly action = signal('');
+  readonly from = signal('');
+  readonly to = signal('');
+
+  readonly offset = signal(0);
+  readonly events = signal<AuditEventRow[]>([]);
+  readonly totalCount = signal(0);
+  readonly searchError = signal<string | null>(null);
+  readonly searching = signal(false);
+
+  readonly hasMore = computed(() => this.offset() + PAGE_LIMIT < this.totalCount());
+
+  async search(resetOffset = true): Promise<void> {
+    if (resetOffset) {
+      this.offset.set(0);
+    }
+    this.searching.set(true);
+    this.searchError.set(null);
+    try {
+      const result = await firstValueFrom(
+        this.api.search(this.tenant(), {
+          hospital: this.hospital() || undefined,
+          actor: this.actor() || undefined,
+          role: this.role() || undefined,
+          user: this.user() || undefined,
+          resource: this.resource() || undefined,
+          action: this.action() || undefined,
+          from: this.from() || undefined,
+          to: this.to() || undefined,
+          limit: PAGE_LIMIT,
+          offset: this.offset(),
+        }),
+      );
+      this.events.set(result.events);
+      this.totalCount.set(result.totalCount);
+    } catch {
+      this.events.set([]);
+      this.totalCount.set(0);
+      this.searchError.set('The audit search failed.');
+    } finally {
+      this.searching.set(false);
+    }
+  }
+
+  async nextPage(): Promise<void> {
+    this.offset.set(this.offset() + PAGE_LIMIT);
+    await this.search(false);
+  }
+
+  async previousPage(): Promise<void> {
+    this.offset.set(Math.max(0, this.offset() - PAGE_LIMIT));
+    await this.search(false);
+  }
+}

--- a/apps/admin-console/src/app/shell/shell.html
+++ b/apps/admin-console/src/app/shell/shell.html
@@ -4,6 +4,7 @@
     <a routerLink="/user-overrides" data-testid="nav-user-overrides">User overrides</a>
     <a routerLink="/resource-catalog" data-testid="nav-resource-catalog">Resource catalog</a>
     <a routerLink="/simulator" data-testid="nav-simulator">Simulator</a>
+    <a routerLink="/audit" data-testid="nav-audit">Audit</a>
   </nav>
   @if (auth.claims(); as claims) {
     <div class="shell-identity" data-testid="shell-identity">

--- a/apps/admin-service/cmd/admin-service/main.go
+++ b/apps/admin-service/cmd/admin-service/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/adsclient"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/auditsearch"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/catalogapi"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/config"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
@@ -92,6 +93,9 @@ func main() {
 		},
 		Simulate: &simulate.Handler{
 			ADS: adsclient.New(cfg.ADSAddr),
+		},
+		AuditSearch: &auditsearch.Handler{
+			Store: store,
 		},
 	})
 

--- a/apps/admin-service/internal/auditsearch/handler.go
+++ b/apps/admin-service/internal/auditsearch/handler.go
@@ -1,0 +1,157 @@
+// Package auditsearch implements GET /admin/authz/audit (§9.1, §9.4): the
+// searchable administration audit, kept separate from the authorization
+// decision audit but joinable to it by correlation ID (§17.2, §17.3).
+//
+// There is deliberately no write path here. The audit is append-only
+// (§8.2): assignmentstore.Store.AppendAuditEvent is the only way a row is
+// ever written, and it is called from the role-matrix and user-override
+// save paths, never from this package.
+package auditsearch
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/authority"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+)
+
+// Store is the narrow slice of assignmentstore.Store this handler needs.
+type Store interface {
+	SearchAuditEvents(ctx context.Context, query assignmentstore.AuditEventSearchQuery) (page []assignmentstore.AuditEvent, totalCount int, err error)
+}
+
+// Handler serves the audit search endpoint.
+type Handler struct {
+	Store Store
+}
+
+// eventView is one row of a GET /admin/authz/audit response. Only the
+// fields §9.1's audit search dimensions and §17.3's administration audit
+// category need are exposed: before/after JSON never carries clinical
+// attributes (§9.4's before/after states are booleans and effect labels,
+// never resource payloads), so nothing here needs redacting.
+type eventView struct {
+	EventID        string    `json:"eventId"`
+	ActorID        string    `json:"actorId"`
+	Operation      string    `json:"operation"`
+	TargetType     string    `json:"targetType"`
+	BeforeJSON     string    `json:"before"`
+	AfterJSON      string    `json:"after"`
+	TenantID       string    `json:"tenantId"`
+	HospitalID     string    `json:"hospitalId,omitempty"`
+	RoleExternalID string    `json:"roleExternalId,omitempty"`
+	TargetUserID   string    `json:"targetUserId,omitempty"`
+	ResourceKeys   string    `json:"resourceActionKeys,omitempty"`
+	CorrelationID  string    `json:"correlationId,omitempty"`
+	CreatedAt      time.Time `json:"createdAt"`
+}
+
+// Search handles GET /admin/authz/audit?tenant=&hospital=&actor=&role=&
+// user=&resource=&action=&from=&to=&limit=&offset= (§9.4's audit search
+// endpoint).
+//
+// tenant is a required query parameter rather than a path segment, per
+// §9.4's endpoint shape, but it is still mandatory: an administration
+// query without a tenant predicate is exactly the mistake §8.2 warns
+// against, so an absent or unauthorized tenant is refused before the
+// store is ever asked.
+func (h *Handler) Search(w http.ResponseWriter, r *http.Request) {
+	identity, ok := tokenauth.From(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	query := r.URL.Query()
+	tenant := query.Get("tenant")
+	if tenant == "" {
+		writeError(w, http.StatusBadRequest, "a tenant query parameter is required")
+		return
+	}
+	if err := authority.Validate(
+		authority.Principal{TenantID: identity.TenantID, HospitalID: identity.HospitalID},
+		tenant, ""); err != nil {
+		writeError(w, http.StatusForbidden, "you do not have authority over this tenant")
+		return
+	}
+
+	search := assignmentstore.AuditEventSearchQuery{
+		TenantID:       tenant,
+		HospitalID:     query.Get("hospital"),
+		ActorID:        query.Get("actor"),
+		RoleExternalID: query.Get("role"),
+		TargetUserID:   query.Get("user"),
+		ResourceKey:    query.Get("resource"),
+		ActionKey:      query.Get("action"),
+	}
+
+	if from := query.Get("from"); from != "" {
+		parsed, err := time.Parse(time.RFC3339, from)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "from must be an RFC3339 timestamp")
+			return
+		}
+		search.CreatedFrom = parsed
+	}
+	if to := query.Get("to"); to != "" {
+		parsed, err := time.Parse(time.RFC3339, to)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "to must be an RFC3339 timestamp")
+			return
+		}
+		search.CreatedTo = parsed
+	}
+	if limit := query.Get("limit"); limit != "" {
+		parsed, err := strconv.Atoi(limit)
+		if err != nil || parsed < 0 {
+			writeError(w, http.StatusBadRequest, "limit must be a non-negative integer")
+			return
+		}
+		search.Limit = parsed
+	}
+	if offset := query.Get("offset"); offset != "" {
+		parsed, err := strconv.Atoi(offset)
+		if err != nil || parsed < 0 {
+			writeError(w, http.StatusBadRequest, "offset must be a non-negative integer")
+			return
+		}
+		search.Offset = parsed
+	}
+
+	events, total, err := h.Store.SearchAuditEvents(r.Context(), search)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "searching the audit history failed")
+		return
+	}
+
+	views := make([]eventView, 0, len(events))
+	for _, event := range events {
+		views = append(views, eventView{
+			EventID: event.EventID, ActorID: event.ActorID, Operation: event.Operation,
+			TargetType: event.TargetType, BeforeJSON: event.BeforeJSON, AfterJSON: event.AfterJSON,
+			TenantID: event.TenantID, HospitalID: event.HospitalID,
+			RoleExternalID: event.RoleExternalID, TargetUserID: event.TargetUserID,
+			ResourceKeys: event.ResourceActionKeys, CorrelationID: event.CorrelationID,
+			CreatedAt: event.CreatedAt,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"events":     views,
+		"totalCount": total,
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}

--- a/apps/admin-service/internal/auditsearch/handler_test.go
+++ b/apps/admin-service/internal/auditsearch/handler_test.go
@@ -1,0 +1,176 @@
+package auditsearch_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/auditsearch"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+)
+
+type fakeStore struct {
+	lastQuery assignmentstore.AuditEventSearchQuery
+	events    []assignmentstore.AuditEvent
+	total     int
+	err       error
+}
+
+func (f *fakeStore) SearchAuditEvents(_ context.Context, query assignmentstore.AuditEventSearchQuery) ([]assignmentstore.AuditEvent, int, error) {
+	f.lastQuery = query
+	if f.err != nil {
+		return nil, 0, f.err
+	}
+	return f.events, f.total, nil
+}
+
+func newHandler(store *fakeStore) *auditsearch.Handler {
+	return &auditsearch.Handler{Store: store}
+}
+
+func request(t *testing.T, identity tokenauth.Identity, rawQuery string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/admin/authz/audit?"+rawQuery, nil)
+	return req.WithContext(tokenauth.WithIdentity(req.Context(), identity))
+}
+
+func decodeResponse(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding the response body %q: %v", rec.Body.String(), err)
+	}
+	return body
+}
+
+func adminOf(tenant string) tokenauth.Identity {
+	return tokenauth.Identity{PrincipalID: "admin-1", TenantID: tenant}
+}
+
+// A search with a tenant the administrator's own token scopes them to
+// forwards every documented filter to the store and reports the total
+// alongside the page.
+func TestSearchForwardsEveryDimensionAndReportsTheTotal(t *testing.T) {
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		events: []assignmentstore.AuditEvent{
+			{EventID: "audit-1", ActorID: "admin-2", Operation: "ROLE_MATRIX_SAVE", TenantID: "tenant-a", CreatedAt: created},
+		},
+		total: 5,
+	}
+	handler := newHandler(store)
+
+	req := request(t, adminOf("tenant-a"),
+		"tenant=tenant-a&hospital=hospital-1&actor=admin-2&role=role-doctor&user=user-1"+
+			"&resource=patient_record&action=read&limit=2&offset=4")
+	rec := httptest.NewRecorder()
+	handler.Search(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	want := assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", HospitalID: "hospital-1", ActorID: "admin-2",
+		RoleExternalID: "role-doctor", TargetUserID: "user-1",
+		ResourceKey: "patient_record", ActionKey: "read",
+		Limit: 2, Offset: 4,
+	}
+	if store.lastQuery != want {
+		t.Errorf("query = %+v, want %+v", store.lastQuery, want)
+	}
+
+	body := decodeResponse(t, rec)
+	if body["totalCount"] != float64(5) {
+		t.Errorf("totalCount = %v, want 5", body["totalCount"])
+	}
+	events, ok := body["events"].([]any)
+	if !ok || len(events) != 1 {
+		t.Fatalf("events = %v, want exactly one", body["events"])
+	}
+}
+
+// A request with no tenant at all must be refused before the store is ever
+// asked: an administration query without a tenant predicate is exactly the
+// mistake §8.2 warns against.
+func TestSearchRejectsAMissingTenant(t *testing.T) {
+	store := &fakeStore{}
+	handler := newHandler(store)
+
+	req := request(t, adminOf("tenant-a"), "actor=admin-2")
+	rec := httptest.NewRecorder()
+	handler.Search(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if store.lastQuery != (assignmentstore.AuditEventSearchQuery{}) {
+		t.Error("the store was asked despite the missing tenant")
+	}
+}
+
+// An administrator whose token scopes them to a different tenant must be
+// rejected before the store is ever asked, the same guarantee every other
+// administration endpoint in this service gives.
+func TestSearchRejectsAnAdministratorWithNoAuthorityOverTheTargetTenant(t *testing.T) {
+	store := &fakeStore{}
+	handler := newHandler(store)
+
+	req := request(t, adminOf("tenant-b"), "tenant=tenant-a")
+	rec := httptest.NewRecorder()
+	handler.Search(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
+	if store.lastQuery != (assignmentstore.AuditEventSearchQuery{}) {
+		t.Error("the store was asked despite the authority check rejecting the search")
+	}
+}
+
+// A request with no verified identity at all is a wiring defect, not a
+// caller error, but the handler must still refuse it cleanly.
+func TestSearchRejectsARequestWithNoVerifiedIdentity(t *testing.T) {
+	store := &fakeStore{}
+	handler := newHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/authz/audit?tenant=tenant-a", nil)
+	rec := httptest.NewRecorder()
+	handler.Search(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// A malformed from/to timestamp is rejected with 400 rather than silently
+// ignored, so an administrator's mistyped date range fails loudly.
+func TestSearchRejectsAMalformedDateRange(t *testing.T) {
+	store := &fakeStore{}
+	handler := newHandler(store)
+
+	req := request(t, adminOf("tenant-a"), "tenant=tenant-a&from=not-a-date")
+	rec := httptest.NewRecorder()
+	handler.Search(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// A store failure is reported as 500, not silently swallowed.
+func TestSearchReportsAStoreFailure(t *testing.T) {
+	store := &fakeStore{err: context.DeadlineExceeded}
+	handler := newHandler(store)
+
+	req := request(t, adminOf("tenant-a"), "tenant=tenant-a")
+	rec := httptest.NewRecorder()
+	handler.Search(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/apps/admin-service/internal/server/server.go
+++ b/apps/admin-service/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/auditsearch"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/catalogapi"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/simulate"
@@ -53,6 +54,10 @@ type Config struct {
 	// Simulate serves the effective-access simulator endpoints (issue
 	// #19). Nil means the routes are not registered.
 	Simulate *simulate.Handler
+
+	// AuditSearch serves the audit search endpoint (issue #20). Nil means
+	// the route is not registered.
+	AuditSearch *auditsearch.Handler
 }
 
 // New builds the Administration Service HTTP handler.
@@ -90,6 +95,9 @@ func New(cfg Config) http.Handler {
 		if cfg.Simulate != nil {
 			mux.Handle("POST /admin/authz/simulate", authenticated(cfg.Simulate.SimulateAccess))
 			mux.Handle("POST /admin/authz/simulate-capabilities", authenticated(cfg.Simulate.SimulateCapabilities))
+		}
+		if cfg.AuditSearch != nil {
+			mux.Handle("GET /admin/authz/audit", authenticated(cfg.AuditSearch.Search))
 		}
 	}
 

--- a/deploy/liquibase/changelog/tables/010-audit-search-dimensions.yaml
+++ b/deploy/liquibase/changelog/tables/010-audit-search-dimensions.yaml
@@ -1,0 +1,42 @@
+databaseChangeLog:
+  - changeSet:
+      id: 010-audit-search-dimensions
+      author: cerbos-poc
+      comment: >-
+        Searchable dimensions for the administration audit (§9.1, §9.4):
+        role, target user and the resource:action keys an event touched.
+        All nullable because a single audit event may name a role
+        (ROLE_MATRIX_SAVE) or a target user (USER_OVERRIDE_SAVE) but never
+        both, and resource_action_keys is a comma-separated list because one
+        ROLE_MATRIX_SAVE audit event can span many resource:action pairs
+        while still being exactly one audit event (§9.4's "one database
+        transaction" guarantee already established by issue #13).
+      changes:
+        - addColumn:
+            tableName: permission_audit_event
+            columns:
+              - column:
+                  name: role_external_id
+                  type: VARCHAR(128)
+              - column:
+                  name: target_user_id
+                  type: VARCHAR(128)
+              - column:
+                  name: resource_action_keys
+                  type: CLOB
+        - createIndex:
+            tableName: permission_audit_event
+            indexName: ix_audit_role
+            columns:
+              - column:
+                  name: tenant_id
+              - column:
+                  name: role_external_id
+        - createIndex:
+            tableName: permission_audit_event
+            indexName: ix_audit_target_user
+            columns:
+              - column:
+                  name: tenant_id
+              - column:
+                  name: target_user_id

--- a/libs/assignmentstore/keys.go
+++ b/libs/assignmentstore/keys.go
@@ -3,6 +3,7 @@ package assignmentstore
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 // NormalizeOverrideKey puts an override key into the one form the database
@@ -17,6 +18,22 @@ func NormalizeOverrideKey(key UserOverrideKey) UserOverrideKey {
 		key.ResourceInstanceID = NoResourceInstance
 	}
 	return key
+}
+
+// ResourceActionKey formats one resource:action pair the way the audit
+// search dimensions "resource" and "action" (§9.1) are stored and matched.
+func ResourceActionKey(resourceKey, actionKey string) string {
+	return resourceKey + ":" + actionKey
+}
+
+// JoinResourceActionKeys formats the resource:action pairs a single audit
+// event touched, comma-separated, for AuditEvent.ResourceActionKeys.
+func JoinResourceActionKeys(inputs []RolePermissionInput) string {
+	keys := make([]string, 0, len(inputs))
+	for _, input := range inputs {
+		keys = append(keys, ResourceActionKey(input.ResourceKey, input.ActionKey))
+	}
+	return strings.Join(keys, ",")
 }
 
 // tableName is deliberately strict: table names reach SQL by concatenation in

--- a/libs/assignmentstore/oraclestore/oraclestore.go
+++ b/libs/assignmentstore/oraclestore/oraclestore.go
@@ -488,10 +488,22 @@ func (s *Store) SearchAuditEvents(ctx context.Context, query assignmentstore.Aud
 		conditions = append(conditions, "target_user_id = "+arg(query.TargetUserID))
 	}
 	if query.ResourceKey != "" {
-		conditions = append(conditions, "resource_action_keys LIKE "+arg("%"+query.ResourceKey+":%"))
+		// A key must match a whole "resourceKey:actionKey" pair, not a
+		// substring of one: without the comma-or-start anchor, a
+		// ResourceKey of "record" would falsely match "patient_record:read".
+		start := arg(query.ResourceKey + ":%")
+		middle := arg("%," + query.ResourceKey + ":%")
+		conditions = append(conditions,
+			fmt.Sprintf("(resource_action_keys LIKE %s OR resource_action_keys LIKE %s)", start, middle))
 	}
 	if query.ActionKey != "" {
-		conditions = append(conditions, "resource_action_keys LIKE "+arg("%:"+query.ActionKey+"%"))
+		// Symmetric anchor on the trailing side: without it, an ActionKey
+		// of "rea" would falsely match "patient_record:read" as a prefix
+		// of "read".
+		end := arg("%:" + query.ActionKey)
+		middle := arg("%:" + query.ActionKey + ",%")
+		conditions = append(conditions,
+			fmt.Sprintf("(resource_action_keys LIKE %s OR resource_action_keys LIKE %s)", end, middle))
 	}
 	if !query.CreatedFrom.IsZero() {
 		conditions = append(conditions, "created_at >= "+arg(query.CreatedFrom))

--- a/libs/assignmentstore/oraclestore/oraclestore.go
+++ b/libs/assignmentstore/oraclestore/oraclestore.go
@@ -416,12 +416,14 @@ func (s *Store) AppendAuditEvent(ctx context.Context, event assignmentstore.Audi
 	const statement = `
 		INSERT INTO permission_audit_event (
 			event_id, actor_id, operation, target_type, before_json, after_json,
-			tenant_id, hospital_id, correlation_id, created_at)
-		VALUES (:1, :2, :3, :4, :5, :6, :7, :8, :9, :10)`
+			tenant_id, hospital_id, role_external_id, target_user_id,
+			resource_action_keys, correlation_id, created_at)
+		VALUES (:1, :2, :3, :4, :5, :6, :7, :8, :9, :10, :11, :12, :13)`
 
 	_, err := s.db.ExecContext(ctx, statement,
 		event.EventID, event.ActorID, event.Operation, event.TargetType,
 		event.BeforeJSON, event.AfterJSON, event.TenantID, event.HospitalID,
+		event.RoleExternalID, event.TargetUserID, event.ResourceActionKeys,
 		event.CorrelationID, event.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("oraclestore: appending an audit event: %w", err)
@@ -430,26 +432,122 @@ func (s *Store) AppendAuditEvent(ctx context.Context, event assignmentstore.Audi
 }
 
 // AuditEvent reads one audit record.
+//
+// role_external_id, target_user_id and resource_action_keys are nullable,
+// and Oracle cannot tell an empty string from NULL, so all three come back
+// as the empty string rather than as a distinction callers would have to
+// handle differently per engine.
 func (s *Store) AuditEvent(ctx context.Context, eventID string) (assignmentstore.AuditEvent, bool, error) {
 	const query = `
 		SELECT actor_id, operation, target_type, before_json, after_json,
-		       tenant_id, hospital_id, correlation_id, created_at
+		       tenant_id, hospital_id, role_external_id, target_user_id,
+		       resource_action_keys, correlation_id, created_at
 		FROM permission_audit_event WHERE event_id = :1`
 
 	event := assignmentstore.AuditEvent{EventID: eventID}
+	var roleExternalID, targetUserID, resourceActionKeys sql.NullString
 	// The JSON columns are CLOBs. go-ora returns them as string when scanned
 	// into one, so no LOB handling leaks out of this package.
 	err := s.db.QueryRowContext(ctx, query, eventID).Scan(
 		&event.ActorID, &event.Operation, &event.TargetType,
 		&event.BeforeJSON, &event.AfterJSON, &event.TenantID,
-		&event.HospitalID, &event.CorrelationID, &event.CreatedAt)
+		&event.HospitalID, &roleExternalID, &targetUserID,
+		&resourceActionKeys, &event.CorrelationID, &event.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return assignmentstore.AuditEvent{}, false, nil
 	}
 	if err != nil {
 		return assignmentstore.AuditEvent{}, false, fmt.Errorf("oraclestore: reading an audit event: %w", err)
 	}
+	event.RoleExternalID = roleExternalID.String
+	event.TargetUserID = targetUserID.String
+	event.ResourceActionKeys = resourceActionKeys.String
 	return event, true, nil
+}
+
+// SearchAuditEvents searches the append-only administration audit (§9.1,
+// §9.4) across every documented dimension, newest first.
+func (s *Store) SearchAuditEvents(ctx context.Context, query assignmentstore.AuditEventSearchQuery) ([]assignmentstore.AuditEvent, int, error) {
+	conditions := []string{"tenant_id = :1"}
+	args := []any{query.TenantID}
+	arg := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf(":%d", len(args))
+	}
+
+	if query.HospitalID != "" {
+		conditions = append(conditions, "hospital_id = "+arg(query.HospitalID))
+	}
+	if query.ActorID != "" {
+		conditions = append(conditions, "actor_id = "+arg(query.ActorID))
+	}
+	if query.RoleExternalID != "" {
+		conditions = append(conditions, "role_external_id = "+arg(query.RoleExternalID))
+	}
+	if query.TargetUserID != "" {
+		conditions = append(conditions, "target_user_id = "+arg(query.TargetUserID))
+	}
+	if query.ResourceKey != "" {
+		conditions = append(conditions, "resource_action_keys LIKE "+arg("%"+query.ResourceKey+":%"))
+	}
+	if query.ActionKey != "" {
+		conditions = append(conditions, "resource_action_keys LIKE "+arg("%:"+query.ActionKey+"%"))
+	}
+	if !query.CreatedFrom.IsZero() {
+		conditions = append(conditions, "created_at >= "+arg(query.CreatedFrom))
+	}
+	if !query.CreatedTo.IsZero() {
+		conditions = append(conditions, "created_at <= "+arg(query.CreatedTo))
+	}
+
+	limit := query.Limit
+	if limit <= 0 {
+		limit = assignmentstore.DefaultAuditSearchLimit
+	}
+
+	where := strings.Join(conditions, " AND ")
+
+	var totalCount int
+	countQuery := "SELECT count(*) FROM permission_audit_event WHERE " + where
+	if err := s.db.QueryRowContext(ctx, countQuery, args...).Scan(&totalCount); err != nil {
+		return nil, 0, fmt.Errorf("oraclestore: counting audit events: %w", err)
+	}
+
+	offsetArg := arg(query.Offset)
+	limitArg := arg(limit)
+	pageQuery := fmt.Sprintf(`
+		SELECT event_id, actor_id, operation, target_type, before_json, after_json,
+		       tenant_id, hospital_id, role_external_id, target_user_id,
+		       resource_action_keys, correlation_id, created_at
+		FROM permission_audit_event WHERE %s
+		ORDER BY created_at DESC, event_id DESC
+		OFFSET %s ROWS FETCH NEXT %s ROWS ONLY`, where, offsetArg, limitArg)
+
+	rows, err := s.db.QueryContext(ctx, pageQuery, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("oraclestore: searching audit events: %w", err)
+	}
+	defer rows.Close()
+
+	var page []assignmentstore.AuditEvent
+	for rows.Next() {
+		var event assignmentstore.AuditEvent
+		var roleExternalID, targetUserID, resourceActionKeys sql.NullString
+		if err := rows.Scan(&event.EventID, &event.ActorID, &event.Operation, &event.TargetType,
+			&event.BeforeJSON, &event.AfterJSON, &event.TenantID, &event.HospitalID,
+			&roleExternalID, &targetUserID, &resourceActionKeys,
+			&event.CorrelationID, &event.CreatedAt); err != nil {
+			return nil, 0, fmt.Errorf("oraclestore: scanning an audit event: %w", err)
+		}
+		event.RoleExternalID = roleExternalID.String
+		event.TargetUserID = targetUserID.String
+		event.ResourceActionKeys = resourceActionKeys.String
+		page = append(page, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("oraclestore: reading audit event rows: %w", err)
+	}
+	return page, totalCount, nil
 }
 
 // AppendOutboxEvent appends one outbox row.
@@ -594,10 +692,12 @@ func (s *Store) SaveRoleMatrix(ctx context.Context, write assignmentstore.RoleMa
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO permission_audit_event (
 			event_id, actor_id, operation, target_type, before_json, after_json,
-			tenant_id, hospital_id, correlation_id, created_at)
-		VALUES (:1, :2, :3, :4, :5, :6, :7, :8, :9, :10)`,
+			tenant_id, hospital_id, role_external_id, resource_action_keys,
+			correlation_id, created_at)
+		VALUES (:1, :2, :3, :4, :5, :6, :7, :8, :9, :10, :11, :12)`,
 		write.Audit.EventID, write.Audit.ActorID, write.Audit.Operation, write.Audit.TargetType,
 		write.Audit.BeforeJSON, write.Audit.AfterJSON, write.TenantID, write.Audit.HospitalID,
+		write.RoleExternalID, assignmentstore.JoinResourceActionKeys(write.Permissions),
 		write.Audit.CorrelationID, write.Audit.CreatedAt); err != nil {
 		return 0, fmt.Errorf("oraclestore: appending the audit event: %w", err)
 	}
@@ -700,10 +800,12 @@ func (s *Store) SaveUserOverrideWrite(ctx context.Context, write assignmentstore
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO permission_audit_event (
 			event_id, actor_id, operation, target_type, before_json, after_json,
-			tenant_id, hospital_id, correlation_id, created_at)
-		VALUES (:1, :2, :3, :4, :5, :6, :7, :8, :9, :10)`,
+			tenant_id, hospital_id, target_user_id, resource_action_keys,
+			correlation_id, created_at)
+		VALUES (:1, :2, :3, :4, :5, :6, :7, :8, :9, :10, :11, :12)`,
 		write.Audit.EventID, write.Audit.ActorID, write.Audit.Operation, write.Audit.TargetType,
 		write.Audit.BeforeJSON, write.Audit.AfterJSON, key.TenantID, key.HospitalID,
+		key.UserExternalID, assignmentstore.ResourceActionKey(key.ResourceKey, key.ActionKey),
 		write.Audit.CorrelationID, write.Audit.CreatedAt); err != nil {
 		return 0, fmt.Errorf("oraclestore: appending the audit event: %w", err)
 	}

--- a/libs/assignmentstore/postgresstore/postgresstore.go
+++ b/libs/assignmentstore/postgresstore/postgresstore.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -371,12 +372,14 @@ func (s *Store) AppendAuditEvent(ctx context.Context, event assignmentstore.Audi
 	const statement = `
 		INSERT INTO permission_audit_event (
 			event_id, actor_id, operation, target_type, before_json, after_json,
-			tenant_id, hospital_id, correlation_id, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
+			tenant_id, hospital_id, role_external_id, target_user_id,
+			resource_action_keys, correlation_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`
 
 	_, err := s.pool.Exec(ctx, statement,
 		event.EventID, event.ActorID, event.Operation, event.TargetType,
 		event.BeforeJSON, event.AfterJSON, event.TenantID, event.HospitalID,
+		event.RoleExternalID, event.TargetUserID, event.ResourceActionKeys,
 		event.CorrelationID, event.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("postgresstore: appending an audit event: %w", err)
@@ -385,17 +388,24 @@ func (s *Store) AppendAuditEvent(ctx context.Context, event assignmentstore.Audi
 }
 
 // AuditEvent reads one audit record.
+//
+// role_external_id, target_user_id and resource_action_keys are nullable -
+// absent for whichever audit search dimensions a given event does not
+// carry - and COALESCE reads an absent one back as the empty string rather
+// than as a distinction the caller would have to handle.
 func (s *Store) AuditEvent(ctx context.Context, eventID string) (assignmentstore.AuditEvent, bool, error) {
 	const query = `
 		SELECT actor_id, operation, target_type, before_json, after_json,
-		       tenant_id, hospital_id, correlation_id, created_at
+		       tenant_id, hospital_id, COALESCE(role_external_id, ''), COALESCE(target_user_id, ''),
+		       COALESCE(resource_action_keys, ''), correlation_id, created_at
 		FROM permission_audit_event WHERE event_id = $1`
 
 	event := assignmentstore.AuditEvent{EventID: eventID}
 	err := s.pool.QueryRow(ctx, query, eventID).Scan(
 		&event.ActorID, &event.Operation, &event.TargetType,
 		&event.BeforeJSON, &event.AfterJSON, &event.TenantID,
-		&event.HospitalID, &event.CorrelationID, &event.CreatedAt)
+		&event.HospitalID, &event.RoleExternalID, &event.TargetUserID,
+		&event.ResourceActionKeys, &event.CorrelationID, &event.CreatedAt)
 	if isNoRows(err) {
 		return assignmentstore.AuditEvent{}, false, nil
 	}
@@ -403,6 +413,86 @@ func (s *Store) AuditEvent(ctx context.Context, eventID string) (assignmentstore
 		return assignmentstore.AuditEvent{}, false, fmt.Errorf("postgresstore: reading an audit event: %w", err)
 	}
 	return event, true, nil
+}
+
+// SearchAuditEvents searches the append-only administration audit (§9.1,
+// §9.4) across every documented dimension, newest first.
+func (s *Store) SearchAuditEvents(ctx context.Context, query assignmentstore.AuditEventSearchQuery) ([]assignmentstore.AuditEvent, int, error) {
+	conditions := []string{"tenant_id = $1"}
+	args := []any{query.TenantID}
+	arg := func(value any) string {
+		args = append(args, value)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	if query.HospitalID != "" {
+		conditions = append(conditions, "hospital_id = "+arg(query.HospitalID))
+	}
+	if query.ActorID != "" {
+		conditions = append(conditions, "actor_id = "+arg(query.ActorID))
+	}
+	if query.RoleExternalID != "" {
+		conditions = append(conditions, "role_external_id = "+arg(query.RoleExternalID))
+	}
+	if query.TargetUserID != "" {
+		conditions = append(conditions, "target_user_id = "+arg(query.TargetUserID))
+	}
+	if query.ResourceKey != "" {
+		conditions = append(conditions, "resource_action_keys LIKE "+arg("%"+query.ResourceKey+":%"))
+	}
+	if query.ActionKey != "" {
+		conditions = append(conditions, "resource_action_keys LIKE "+arg("%:"+query.ActionKey+"%"))
+	}
+	if !query.CreatedFrom.IsZero() {
+		conditions = append(conditions, "created_at >= "+arg(query.CreatedFrom))
+	}
+	if !query.CreatedTo.IsZero() {
+		conditions = append(conditions, "created_at <= "+arg(query.CreatedTo))
+	}
+
+	limit := query.Limit
+	if limit <= 0 {
+		limit = assignmentstore.DefaultAuditSearchLimit
+	}
+
+	where := strings.Join(conditions, " AND ")
+
+	var totalCount int
+	countQuery := "SELECT count(*) FROM permission_audit_event WHERE " + where
+	if err := s.pool.QueryRow(ctx, countQuery, args...).Scan(&totalCount); err != nil {
+		return nil, 0, fmt.Errorf("postgresstore: counting audit events: %w", err)
+	}
+
+	pageArgs := append(append([]any{}, args...), limit, query.Offset)
+	pageQuery := fmt.Sprintf(`
+		SELECT event_id, actor_id, operation, target_type, before_json, after_json,
+		       tenant_id, hospital_id, COALESCE(role_external_id, ''), COALESCE(target_user_id, ''),
+		       COALESCE(resource_action_keys, ''), correlation_id, created_at
+		FROM permission_audit_event WHERE %s
+		ORDER BY created_at DESC, event_id DESC
+		LIMIT $%d OFFSET $%d`, where, len(pageArgs)-1, len(pageArgs))
+
+	rows, err := s.pool.Query(ctx, pageQuery, pageArgs...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("postgresstore: searching audit events: %w", err)
+	}
+	defer rows.Close()
+
+	var page []assignmentstore.AuditEvent
+	for rows.Next() {
+		var event assignmentstore.AuditEvent
+		if err := rows.Scan(&event.EventID, &event.ActorID, &event.Operation, &event.TargetType,
+			&event.BeforeJSON, &event.AfterJSON, &event.TenantID, &event.HospitalID,
+			&event.RoleExternalID, &event.TargetUserID, &event.ResourceActionKeys,
+			&event.CorrelationID, &event.CreatedAt); err != nil {
+			return nil, 0, fmt.Errorf("postgresstore: scanning an audit event: %w", err)
+		}
+		page = append(page, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("postgresstore: reading audit event rows: %w", err)
+	}
+	return page, totalCount, nil
 }
 
 // AppendOutboxEvent appends one outbox row.
@@ -539,10 +629,12 @@ func (s *Store) SaveRoleMatrix(ctx context.Context, write assignmentstore.RoleMa
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO permission_audit_event (
 			event_id, actor_id, operation, target_type, before_json, after_json,
-			tenant_id, hospital_id, correlation_id, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+			tenant_id, hospital_id, role_external_id, resource_action_keys,
+			correlation_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
 		write.Audit.EventID, write.Audit.ActorID, write.Audit.Operation, write.Audit.TargetType,
 		write.Audit.BeforeJSON, write.Audit.AfterJSON, write.TenantID, write.Audit.HospitalID,
+		write.RoleExternalID, assignmentstore.JoinResourceActionKeys(write.Permissions),
 		write.Audit.CorrelationID, write.Audit.CreatedAt); err != nil {
 		return 0, fmt.Errorf("postgresstore: appending the audit event: %w", err)
 	}
@@ -633,10 +725,12 @@ func (s *Store) SaveUserOverrideWrite(ctx context.Context, write assignmentstore
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO permission_audit_event (
 			event_id, actor_id, operation, target_type, before_json, after_json,
-			tenant_id, hospital_id, correlation_id, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+			tenant_id, hospital_id, target_user_id, resource_action_keys,
+			correlation_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
 		write.Audit.EventID, write.Audit.ActorID, write.Audit.Operation, write.Audit.TargetType,
 		write.Audit.BeforeJSON, write.Audit.AfterJSON, key.TenantID, key.HospitalID,
+		key.UserExternalID, assignmentstore.ResourceActionKey(key.ResourceKey, key.ActionKey),
 		write.Audit.CorrelationID, write.Audit.CreatedAt); err != nil {
 		return 0, fmt.Errorf("postgresstore: appending the audit event: %w", err)
 	}

--- a/libs/assignmentstore/postgresstore/postgresstore.go
+++ b/libs/assignmentstore/postgresstore/postgresstore.go
@@ -438,10 +438,22 @@ func (s *Store) SearchAuditEvents(ctx context.Context, query assignmentstore.Aud
 		conditions = append(conditions, "target_user_id = "+arg(query.TargetUserID))
 	}
 	if query.ResourceKey != "" {
-		conditions = append(conditions, "resource_action_keys LIKE "+arg("%"+query.ResourceKey+":%"))
+		// A key must match a whole "resourceKey:actionKey" pair, not a
+		// substring of one: without the comma-or-start anchor, a
+		// ResourceKey of "record" would falsely match "patient_record:read".
+		start := arg(query.ResourceKey + ":%")
+		middle := arg("%," + query.ResourceKey + ":%")
+		conditions = append(conditions,
+			fmt.Sprintf("(resource_action_keys LIKE %s OR resource_action_keys LIKE %s)", start, middle))
 	}
 	if query.ActionKey != "" {
-		conditions = append(conditions, "resource_action_keys LIKE "+arg("%:"+query.ActionKey+"%"))
+		// Symmetric anchor on the trailing side: without it, an ActionKey
+		// of "rea" would falsely match "patient_record:read" as a prefix
+		// of "read".
+		end := arg("%:" + query.ActionKey)
+		middle := arg("%:" + query.ActionKey + ",%")
+		conditions = append(conditions,
+			fmt.Sprintf("(resource_action_keys LIKE %s OR resource_action_keys LIKE %s)", end, middle))
 	}
 	if !query.CreatedFrom.IsZero() {
 		conditions = append(conditions, "created_at >= "+arg(query.CreatedFrom))

--- a/libs/assignmentstore/store.go
+++ b/libs/assignmentstore/store.go
@@ -134,17 +134,61 @@ type PermissionRevision struct {
 
 // AuditEvent is one append-only record of an authorization change (§8.1).
 type AuditEvent struct {
-	EventID       string
-	ActorID       string
-	Operation     string
-	TargetType    string
-	BeforeJSON    string
-	AfterJSON     string
-	TenantID      string
-	HospitalID    string
-	CorrelationID string
-	CreatedAt     time.Time
+	EventID    string
+	ActorID    string
+	Operation  string
+	TargetType string
+	BeforeJSON string
+	AfterJSON  string
+	TenantID   string
+	HospitalID string
+	// RoleExternalID names the canonical role a ROLE_MATRIX_SAVE event
+	// changed permissions for. Empty for a USER_OVERRIDE_SAVE event
+	// (§9.1's audit search dimension "role").
+	RoleExternalID string
+	// TargetUserID names the user a USER_OVERRIDE_SAVE event changed an
+	// override for. Empty for a ROLE_MATRIX_SAVE event (§9.1's audit
+	// search dimension "user").
+	TargetUserID string
+	// ResourceActionKeys are the "resourceKey:actionKey" pairs this event
+	// touched, comma-separated. A ROLE_MATRIX_SAVE event can name several;
+	// a USER_OVERRIDE_SAVE event names exactly one (§9.1's audit search
+	// dimensions "resource" and "action").
+	ResourceActionKeys string
+	CorrelationID      string
+	CreatedAt          time.Time
 }
+
+// AuditEventSearchQuery searches the administration audit (§9.1, §9.4)
+// across every documented dimension. Every field is optional except
+// TenantID: an administration query without a tenant predicate is exactly
+// the mistake §8.2 warns every administration query to guard against, so
+// SearchAuditEvents treats an empty TenantID as "match no tenant" rather
+// than "match every tenant".
+type AuditEventSearchQuery struct {
+	TenantID       string
+	HospitalID     string
+	ActorID        string
+	RoleExternalID string
+	TargetUserID   string
+	// ResourceKey and ActionKey each match against ResourceActionKeys.
+	// Either may be given without the other.
+	ResourceKey string
+	ActionKey   string
+	// CreatedFrom and CreatedTo bound CreatedAt, inclusive. Zero means
+	// unbounded on that side.
+	CreatedFrom time.Time
+	CreatedTo   time.Time
+	// Limit bounds the page size. Zero means DefaultAuditSearchLimit.
+	Limit int
+	// Offset is the number of matching rows to skip, for the next page.
+	Offset int
+}
+
+// DefaultAuditSearchLimit is the page size SearchAuditEvents uses when a
+// query's Limit is zero, so a caller that forgets to set one gets a
+// bounded page rather than an installation's entire audit history.
+const DefaultAuditSearchLimit = 50
 
 // OutboxEvent is one row of the transactional outbox (§8.1).
 type OutboxEvent struct {
@@ -181,8 +225,10 @@ type RoleMatrixWrite struct {
 	// saved.
 	ExpectedRevision int64
 	Permissions      []RolePermissionInput
-	// Audit.TenantID is ignored; the write always audits against
-	// RoleMatrixWrite.TenantID so the two can never disagree.
+	// Audit.TenantID, Audit.RoleExternalID and Audit.ResourceActionKeys are
+	// ignored; the write always audits against RoleMatrixWrite.TenantID,
+	// RoleMatrixWrite.RoleExternalID and the resource:action keys named in
+	// Permissions, so none of the four can ever disagree.
 	Audit  AuditEvent
 	Outbox OutboxEvent
 }
@@ -208,9 +254,10 @@ type UserOverrideWrite struct {
 	// ExpectedRevision is the tenant permission revision the caller last
 	// read, the same expected-revision guard SaveRoleMatrix uses (§9.4).
 	ExpectedRevision int64
-	// Audit.TenantID and Audit.HospitalID are ignored; the write always
-	// audits against Key.TenantID and Key.HospitalID so the two can never
-	// disagree.
+	// Audit.TenantID, Audit.HospitalID, Audit.TargetUserID and
+	// Audit.ResourceActionKeys are ignored; the write always audits
+	// against Key.TenantID, Key.HospitalID, Key.UserExternalID and
+	// Key.ResourceKey/Key.ActionKey so none of them can ever disagree.
 	Audit  AuditEvent
 	Outbox OutboxEvent
 }
@@ -316,6 +363,14 @@ type Store interface {
 
 	AppendAuditEvent(ctx context.Context, event AuditEvent) error
 	AuditEvent(ctx context.Context, eventID string) (AuditEvent, bool, error)
+
+	// SearchAuditEvents searches the append-only administration audit
+	// (§9.1, §9.4) across every documented dimension, newest first.
+	// TotalCount is the count of every matching row, not just this page,
+	// so a caller can tell whether more pages remain. There is no path
+	// here, or anywhere else in this interface, to update or delete an
+	// audit row: the history is append-only by construction (§8.2).
+	SearchAuditEvents(ctx context.Context, query AuditEventSearchQuery) (page []AuditEvent, totalCount int, err error)
 
 	AppendOutboxEvent(ctx context.Context, event OutboxEvent) error
 	OutboxEvent(ctx context.Context, eventID string) (OutboxEvent, bool, error)

--- a/libs/assignmentstore/storecontract/contract.go
+++ b/libs/assignmentstore/storecontract/contract.go
@@ -1835,6 +1835,20 @@ func assertSearchAuditEventsFiltersAndPaginates(t *testing.T, store assignmentst
 		t.Errorf("action search = %+v (err=%v), want exactly search-1", page, err)
 	}
 
+	// A resource or action filter must match a whole key, not a substring
+	// of one: "record" must not match "patient_record", and "rea" (a
+	// prefix of "read") must not match it either.
+	if page, _, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", ResourceKey: "record",
+	}); err != nil || len(page) != 0 {
+		t.Errorf("resource search for a substring = %+v (err=%v), want no matches for 'record'", page, err)
+	}
+	if page, _, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", ActionKey: "rea",
+	}); err != nil || len(page) != 0 {
+		t.Errorf("action search for a prefix = %+v (err=%v), want no matches for 'rea'", page, err)
+	}
+
 	// Filtering by hospital finds only that hospital's events.
 	if page, _, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
 		TenantID: "tenant-a", HospitalID: "hospital-2",

--- a/libs/assignmentstore/storecontract/contract.go
+++ b/libs/assignmentstore/storecontract/contract.go
@@ -132,6 +132,18 @@ func Run(t *testing.T, newStore Factory) {
 	t.Run("SaveUserOverrideWrite with no effect clears an existing override row", func(t *testing.T) {
 		assertSaveUserOverrideWriteInheritClearsTheRow(t, newStore(t))
 	})
+	t.Run("SearchAuditEvents filters across every documented dimension and paginates", func(t *testing.T) {
+		assertSearchAuditEventsFiltersAndPaginates(t, newStore(t))
+	})
+	t.Run("SearchAuditEvents never returns audit events from another tenant", func(t *testing.T) {
+		assertSearchAuditEventsScopedToTenant(t, newStore(t))
+	})
+	t.Run("SaveRoleMatrix stamps its audit event with the role and every touched resource:action key", func(t *testing.T) {
+		assertSaveRoleMatrixAuditCarriesSearchDimensions(t, newStore(t))
+	})
+	t.Run("SaveUserOverrideWrite stamps its audit event with the target user and the resource:action key", func(t *testing.T) {
+		assertSaveUserOverrideWriteAuditCarriesSearchDimensions(t, newStore(t))
+	})
 }
 
 // The hot path resolves every role a principal holds at once (§11.2). What that
@@ -1740,6 +1752,260 @@ func assertSaveUserOverrideWriteInheritClearsTheRow(t *testing.T, store assignme
 		t.Fatalf("reading the cleared override: %v", err)
 	} else if found {
 		t.Error("the override row still exists after an INHERIT write")
+	}
+}
+
+// SearchAuditEvents must let an administrator filter across every dimension
+// §9.1's audit module names - actor, role, target user, resource, action,
+// tenant and date - and page through the results, newest first.
+func assertSearchAuditEventsFiltersAndPaginates(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "permission_audit_event")
+
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	events := []assignmentstore.AuditEvent{
+		{
+			EventID: "search-1", ActorID: "admin-1", Operation: "ROLE_MATRIX_SAVE",
+			TargetType: "role_permission", TenantID: "tenant-a", HospitalID: "hospital-1",
+			RoleExternalID: "role-doctor", ResourceActionKeys: "patient_record:read,patient_record:update",
+			CreatedAt: base,
+		},
+		{
+			EventID: "search-2", ActorID: "admin-2", Operation: "USER_OVERRIDE_SAVE",
+			TargetType: "user_permission_override", TenantID: "tenant-a", HospitalID: "hospital-1",
+			TargetUserID: "user-1", ResourceActionKeys: "patient_record:delete",
+			CreatedAt: base.Add(time.Hour),
+		},
+		{
+			EventID: "search-3", ActorID: "admin-1", Operation: "ROLE_MATRIX_SAVE",
+			TargetType: "role_permission", TenantID: "tenant-a", HospitalID: "hospital-2",
+			RoleExternalID: "role-nurse", ResourceActionKeys: "appointment:list",
+			CreatedAt: base.Add(2 * time.Hour),
+		},
+	}
+	for _, event := range events {
+		if err := store.AppendAuditEvent(ctx, event); err != nil {
+			t.Fatalf("appending %s: %v", event.EventID, err)
+		}
+	}
+
+	// Filtering by actor finds only that actor's events, newest first.
+	page, total, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", ActorID: "admin-1",
+	})
+	if err != nil {
+		t.Fatalf("searching by actor: %v", err)
+	}
+	if total != 2 || len(page) != 2 {
+		t.Fatalf("actor search: total=%d len=%d, want 2 and 2", total, len(page))
+	}
+	if page[0].EventID != "search-3" || page[1].EventID != "search-1" {
+		t.Errorf("actor search order = [%s %s], want [search-3 search-1] (newest first)",
+			page[0].EventID, page[1].EventID)
+	}
+
+	// Filtering by role finds only that role's events.
+	if page, _, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", RoleExternalID: "role-doctor",
+	}); err != nil || len(page) != 1 || page[0].EventID != "search-1" {
+		t.Errorf("role search = %+v (err=%v), want exactly search-1", page, err)
+	}
+
+	// Filtering by target user finds only that user's events.
+	if page, _, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", TargetUserID: "user-1",
+	}); err != nil || len(page) != 1 || page[0].EventID != "search-2" {
+		t.Errorf("target user search = %+v (err=%v), want exactly search-2", page, err)
+	}
+
+	// Filtering by resource finds every event that touched it, even inside
+	// a comma-separated multi-resource event.
+	if page, _, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", ResourceKey: "patient_record",
+	}); err != nil || len(page) != 2 {
+		t.Errorf("resource search = %+v (err=%v), want two events touching patient_record", page, err)
+	}
+
+	// Filtering by action finds every event that touched it.
+	if page, _, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", ActionKey: "update",
+	}); err != nil || len(page) != 1 || page[0].EventID != "search-1" {
+		t.Errorf("action search = %+v (err=%v), want exactly search-1", page, err)
+	}
+
+	// Filtering by hospital finds only that hospital's events.
+	if page, _, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", HospitalID: "hospital-2",
+	}); err != nil || len(page) != 1 || page[0].EventID != "search-3" {
+		t.Errorf("hospital search = %+v (err=%v), want exactly search-3", page, err)
+	}
+
+	// A date range excludes events outside it.
+	if page, _, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", CreatedFrom: base.Add(30 * time.Minute), CreatedTo: base.Add(90 * time.Minute),
+	}); err != nil || len(page) != 1 || page[0].EventID != "search-2" {
+		t.Errorf("date range search = %+v (err=%v), want exactly search-2", page, err)
+	}
+
+	// Pagination: Limit bounds the page, Offset advances it, and TotalCount
+	// always reports every matching row rather than just this page.
+	firstPage, total, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", Limit: 2, Offset: 0,
+	})
+	if err != nil {
+		t.Fatalf("searching page 1: %v", err)
+	}
+	if total != 3 || len(firstPage) != 2 {
+		t.Fatalf("page 1: total=%d len=%d, want 3 and 2", total, len(firstPage))
+	}
+	secondPage, total, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", Limit: 2, Offset: 2,
+	})
+	if err != nil {
+		t.Fatalf("searching page 2: %v", err)
+	}
+	if total != 3 || len(secondPage) != 1 {
+		t.Fatalf("page 2: total=%d len=%d, want 3 and 1", total, len(secondPage))
+	}
+	if firstPage[0].EventID == secondPage[0].EventID {
+		t.Error("page 1 and page 2 returned the same event")
+	}
+}
+
+// An administration query without a tenant predicate is exactly the mistake
+// §8.2 warns every administration query to guard against; SearchAuditEvents
+// must never let one tenant's audit search surface another tenant's events.
+func assertSearchAuditEventsScopedToTenant(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "permission_audit_event")
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	for _, tenant := range []string{"tenant-a", "tenant-b"} {
+		if err := store.AppendAuditEvent(ctx, assignmentstore.AuditEvent{
+			EventID: "tenant-scope-" + tenant, ActorID: "admin-1",
+			Operation: "ROLE_MATRIX_SAVE", TargetType: "role_permission",
+			TenantID: tenant, CreatedAt: created,
+		}); err != nil {
+			t.Fatalf("appending for %s: %v", tenant, err)
+		}
+	}
+
+	page, total, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{TenantID: "tenant-a"})
+	if err != nil {
+		t.Fatalf("searching tenant-a: %v", err)
+	}
+	if total != 1 || len(page) != 1 || page[0].EventID != "tenant-scope-tenant-a" {
+		t.Fatalf("tenant-a search = %+v (total=%d), want exactly tenant-scope-tenant-a", page, total)
+	}
+
+	if page, total, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{TenantID: ""}); err != nil {
+		t.Fatalf("searching with an empty tenant: %v", err)
+	} else if total != 0 || len(page) != 0 {
+		t.Errorf("an empty TenantID matched %d rows, want zero - it must match no tenant, not every tenant", total)
+	}
+}
+
+// SaveRoleMatrix must stamp its one audit event with the role and every
+// resource:action key the write touched, so the event is findable by any
+// of §9.1's audit search dimensions without the handler having to
+// duplicate what the write already knows.
+func assertSaveRoleMatrixAuditCarriesSearchDimensions(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "role_permission", "permission_audit_event", "outbox_event", "permission_revision")
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	write := assignmentstore.RoleMatrixWrite{
+		TenantID:         "tenant-a",
+		RoleExternalID:   "role-doctor",
+		ExpectedRevision: 0,
+		Permissions: []assignmentstore.RolePermissionInput{
+			{ResourceKey: "patient_record", ActionKey: "read", Enabled: true, ValidFrom: created},
+			{ResourceKey: "patient_record", ActionKey: "update", Enabled: true, ValidFrom: created},
+		},
+		Audit: assignmentstore.AuditEvent{
+			EventID: "audit-dimensions-role-1", Operation: "ROLE_MATRIX_SAVE",
+			// A caller-supplied RoleExternalID or ResourceActionKeys must be
+			// ignored: the write's own fields are authoritative.
+			RoleExternalID: "some-other-role", CreatedAt: created,
+		},
+		Outbox: assignmentstore.OutboxEvent{
+			EventID: "outbox-dimensions-role-1", AggregateKey: "tenant-a:role-doctor",
+			EventType: "permission.changed", Payload: `{}`, CreatedAt: created,
+		},
+	}
+	if _, err := store.SaveRoleMatrix(ctx, write); err != nil {
+		t.Fatalf("SaveRoleMatrix: %v", err)
+	}
+
+	audit, found, err := store.AuditEvent(ctx, "audit-dimensions-role-1")
+	if err != nil || !found {
+		t.Fatalf("reading the audit event back: found=%t err=%v", found, err)
+	}
+	if audit.RoleExternalID != "role-doctor" {
+		t.Errorf("audit.RoleExternalID = %q, want role-doctor (the write's own role, not the caller-supplied one)", audit.RoleExternalID)
+	}
+	if audit.ResourceActionKeys != "patient_record:read,patient_record:update" {
+		t.Errorf("audit.ResourceActionKeys = %q, want both touched pairs", audit.ResourceActionKeys)
+	}
+
+	if page, _, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", RoleExternalID: "role-doctor",
+	}); err != nil || len(page) != 1 || page[0].EventID != "audit-dimensions-role-1" {
+		t.Errorf("searching by the audited role = %+v (err=%v), want exactly the event just written", page, err)
+	}
+}
+
+// SaveUserOverrideWrite must stamp its one audit event with the target user
+// and the resource:action key the write touched.
+func assertSaveUserOverrideWriteAuditCarriesSearchDimensions(t *testing.T, store assignmentstore.Store) {
+	t.Helper()
+	defer closeStore(t, store)
+	ctx := context.Background()
+	truncate(t, store, "user_permission_override", "permission_audit_event", "outbox_event", "permission_revision")
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	write := assignmentstore.UserOverrideWrite{
+		Key: assignmentstore.UserOverrideKey{
+			TenantID: "tenant-a", HospitalID: "hospital-1", UserExternalID: "user-1",
+			ResourceKey: "patient_record", ActionKey: "delete",
+		},
+		Effect: assignmentstore.EffectRevoke, Reason: "under investigation",
+		ValidFrom: created, ExpectedRevision: 0,
+		Audit: assignmentstore.AuditEvent{
+			EventID: "audit-dimensions-override-1", Operation: "USER_OVERRIDE_SAVE",
+			// A caller-supplied TargetUserID must be ignored the same way.
+			TargetUserID: "some-other-user", CreatedAt: created,
+		},
+		Outbox: assignmentstore.OutboxEvent{
+			EventID: "outbox-dimensions-override-1", AggregateKey: "tenant-a:user-1",
+			EventType: "permission.changed", Payload: `{}`, CreatedAt: created,
+		},
+	}
+	if _, err := store.SaveUserOverrideWrite(ctx, write); err != nil {
+		t.Fatalf("SaveUserOverrideWrite: %v", err)
+	}
+
+	audit, found, err := store.AuditEvent(ctx, "audit-dimensions-override-1")
+	if err != nil || !found {
+		t.Fatalf("reading the audit event back: found=%t err=%v", found, err)
+	}
+	if audit.TargetUserID != "user-1" {
+		t.Errorf("audit.TargetUserID = %q, want user-1 (the write's own key, not the caller-supplied one)", audit.TargetUserID)
+	}
+	if audit.ResourceActionKeys != "patient_record:delete" {
+		t.Errorf("audit.ResourceActionKeys = %q, want patient_record:delete", audit.ResourceActionKeys)
+	}
+
+	if page, _, err := store.SearchAuditEvents(ctx, assignmentstore.AuditEventSearchQuery{
+		TenantID: "tenant-a", TargetUserID: "user-1", ActionKey: "delete",
+	}); err != nil || len(page) != 1 || page[0].EventID != "audit-dimensions-override-1" {
+		t.Errorf("searching by target user and action = %+v (err=%v), want exactly the event just written", page, err)
 	}
 }
 


### PR DESCRIPTION
## What changed

Adds searchable administration audit (§8.2, §9.1, §9.4, §17.3), kept separate from
the authorization decision audit but joinable to it by correlation ID.

- **`libs/assignmentstore`**: `AuditEvent` gains `RoleExternalID`, `TargetUserID`
  and `ResourceActionKeys` (comma-separated `resource:action` pairs). A new
  `Store.SearchAuditEvents` filters across every §9.1 dimension (actor, role,
  target user, resource, action, tenant, hospital, date range) and paginates,
  with a mandatory tenant predicate (§8.2: an empty tenant matches nothing, not
  everything). `SaveRoleMatrix` and `SaveUserOverrideWrite` now stamp these
  fields *authoritatively from the write itself* rather than trusting caller
  input, the same pattern already used for `Audit.TenantID`.
- **Liquibase changeset 010** adds the three nullable columns plus two indexes,
  applied and verified against PostgreSQL.
- **`apps/admin-service/internal/auditsearch`**: `GET /admin/authz/audit`
  (`?tenant=&hospital=&actor=&role=&user=&resource=&action=&from=&to=&limit=&offset=`).
  `tenant` is a required query parameter validated against the administrator's
  own authority before the store is asked. There is no update or delete route
  anywhere in the service for an audit event.
- **`apps/admin-console/src/app/audit-search`**: the Admin Console's audit
  module - filters, a results table and pagination, scoped to the
  administrator's own tenant. No control in the template edits or deletes an
  audit event (asserted by a test that scans the rendered template).

## Acceptance criteria

- [x] Audit search works across every documented dimension and paginates -
  `SearchAuditEvents` store contract case + `auditsearch` handler tests +
  Admin Console module.
- [x] Every administrative mutation produces exactly one audit event - already
  true (issue #13); unchanged by this PR, and asserted again by the new
  "stamps its audit event" contract cases.
- [x] Before and after state are both recorded and are accurate - unchanged
  from issue #13's `BeforeJSON`/`AfterJSON`; still covered by the existing
  contract cases.
- [x] Updating an assignment in place does not overwrite prior audit history -
  unchanged append-only guarantee (issue #13's contract case), still green.
- [x] No API path can delete or modify an audit event - `assignmentstore.Store`
  exposes `AppendAuditEvent`/`AuditEvent`/`SearchAuditEvents` only; the HTTP
  surface registers `GET /admin/authz/audit` and nothing else for it.
- [x] Administration and decision audit are separate and joinable by
  correlation ID - administration audit lives in `permission_audit_event`;
  decision audit is the ADS's structured log line carrying the same
  `X-Correlation-Id` (`apps/ads/internal/authz/authz.go`'s `correlationID`)
  alongside the Cerbos call ID (§17.2). Distinct stores, same join key.
- [x] Sensitive clinical attributes do not appear in administration audit
  records - structurally true: neither the role-matrix nor the user-override
  save request carries a resource-attribute field at all, so there is no path
  for clinical data to reach `BeforeJSON`/`AfterJSON`, which only ever hold
  booleans and effect labels.

## How it was verified

- `bash scripts/tests/migration-contract.sh postgres` - green.
- `bash scripts/tests/store-contract.sh postgres` - green, including the four
  new `SearchAuditEvents`/audit-dimension cases.
- `bash scripts/go.sh apps/admin-service test ./...` - green.
- `nx test/lint/build admin-console` - green (14 test files, 64 tests).

Oracle's side of the dual-dialect contract was not run live in this session
(no local Oracle container was brought up), but `oraclestore.go`'s
`SearchAuditEvents`/`AppendAuditEvent`/`AuditEvent` are written symmetrically
to the PostgreSQL adapter against the same port, and `CGO_ENABLED=0 go build
./...` passes for both adapters. Recommend running `make db-test-dual`
before this lands on `main` if Oracle capacity is available.

Closes #20


Closes #20
