### PR TITLE
Observability: metrics, decision correlation and Grafana dashboards (#23)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,14 @@ policy-release-seed: ## Seed Gitea with the root policy repository and a protect
 policy-release-down: ## Stop the policy-release profile's services
 	$(COMPOSE) --profile policy-release down --remove-orphans
 
+.PHONY: observability-up
+observability-up: ## Start Prometheus and Grafana, scraping the ADS and Cerbos (issue #23)
+	$(COMPOSE) --profile observability up --build --detach prometheus grafana
+
+.PHONY: observability-down
+observability-down: ## Stop the observability profile's services
+	$(COMPOSE) --profile observability down --remove-orphans
+
 .PHONY: seed
 seed: ## Write the demo role matrix into the authorization database
 	bash scripts/seed.sh postgres

--- a/apps/ads/cmd/ads/main.go
+++ b/apps/ads/cmd/ads/main.go
@@ -31,6 +31,44 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/provider"
 )
 
+// invalidationCaches presents the role-permission and user-override caches
+// as one invalidation.Cache and one invalidation.ReconcilerCache: the
+// outbox consumer and the reconciler each need to act on whichever of the
+// two an event or a drift actually names, without either of them knowing
+// there are two.
+type invalidationCaches struct {
+	roles     *assignments.CachingRoleMatrix
+	overrides *assignments.CachingOverrides
+}
+
+func (c invalidationCaches) InvalidateRole(tenantID, roleID string) {
+	c.roles.InvalidateRole(tenantID, roleID)
+}
+
+func (c invalidationCaches) InvalidateRevision(tenantID string) {
+	c.roles.InvalidateRevision(tenantID)
+}
+
+func (c invalidationCaches) InvalidateUser(tenantID, userID string) {
+	c.overrides.InvalidateUser(tenantID, userID)
+}
+
+func (c invalidationCaches) KnownTenants() []string {
+	return c.roles.KnownTenants()
+}
+
+func (c invalidationCaches) CachedRevision(tenantID string) (int64, bool) {
+	return c.roles.CachedRevision(tenantID)
+}
+
+// InvalidateTenant drops every cached entry for one tenant in both caches -
+// the reconciler's tool (§10.3) for a drifted revision it cannot narrow to
+// one role or one user.
+func (c invalidationCaches) InvalidateTenant(tenantID string) {
+	c.roles.InvalidateTenant(tenantID)
+	c.overrides.InvalidateTenant(tenantID)
+}
+
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	cfg := config.FromEnv(os.LookupEnv)
@@ -91,6 +129,15 @@ func main() {
 		Matrix: store,
 		TTL:    cfg.RoleMatrixCacheTTL,
 	})
+	// A separate cache from roleMatrixCache (§17.1's "cache hit ratios for
+	// role permissions and user overrides", reported per cache, not as a
+	// single aggregate): the two are resolved from different places and
+	// invalidated by different outbox events.
+	overridesCache := assignments.NewCachingOverrides(assignments.OverrideCacheConfig{
+		Overrides: assignments.NewDBOverrides(store, nil),
+		TTL:       cfg.RoleMatrixCacheTTL,
+	})
+	invalidationCache := invalidationCaches{roles: roleMatrixCache, overrides: overridesCache}
 
 	registry := prometheus.NewRegistry()
 	invalidationMetrics := invalidationmetrics.New(registry)
@@ -106,7 +153,7 @@ func main() {
 	consumer := &invalidation.Consumer{
 		Reader: kafkaReader,
 		Handler: &invalidation.Handler{
-			Cache:   roleMatrixCache,
+			Cache:   invalidationCache,
 			Metrics: invalidationMetrics,
 		},
 		OnError: func(err error) {
@@ -132,7 +179,7 @@ func main() {
 	}()
 
 	reconciler := invalidation.NewReconciler(invalidation.ReconcilerConfig{
-		Cache:    roleMatrixCache,
+		Cache:    invalidationCache,
 		Store:    store,
 		Interval: cfg.ReconcileInterval,
 		OnDrift: func(tenantID string, cached, actual int64) {
@@ -155,7 +202,7 @@ func main() {
 			PDP: pdp,
 			Assignments: assignments.NewResolver(assignments.ResolverConfig{
 				Matrix:    roleMatrixCache,
-				Overrides: assignments.NewDBOverrides(store, nil),
+				Overrides: overridesCache,
 			}),
 			Logger: logger,
 		})),
@@ -177,7 +224,7 @@ func main() {
 			TargetResolver:    capability.DefaultTargetResolver{},
 			Assignments: assignments.NewResolver(assignments.ResolverConfig{
 				Matrix:    roleMatrixCache,
-				Overrides: assignments.NewDBOverrides(store, nil),
+				Overrides: overridesCache,
 			}),
 			RootPolicyRevision: cfg.RootPolicyRevision,
 			Logger:             logger,
@@ -186,7 +233,7 @@ func main() {
 			PDP: pdp,
 			Assignments: assignments.NewResolver(assignments.ResolverConfig{
 				Matrix:    roleMatrixCache,
-				Overrides: assignments.NewDBOverrides(store, nil),
+				Overrides: overridesCache,
 			}),
 			Logger: logger,
 		})),
@@ -195,7 +242,7 @@ func main() {
 			CapabilityCatalog: capability.NewFSCatalog(cfg.CapabilityCatalogDir, cfg.CapabilityCatalogRevision, nil),
 			Assignments: assignments.NewResolver(assignments.ResolverConfig{
 				Matrix:    roleMatrixCache,
-				Overrides: assignments.NewDBOverrides(store, nil),
+				Overrides: overridesCache,
 			}),
 			RootPolicyRevision: cfg.RootPolicyRevision,
 			Logger:             logger,

--- a/apps/ads/cmd/ads/main.go
+++ b/apps/ads/cmd/ads/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/adsmetrics"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/assignments"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/cacheconvergence"
@@ -24,11 +25,14 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/invalidation"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/invalidationmetrics"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/netprobe"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/revisionmetrics"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/server"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/postgresstore"
 	"github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient"
 	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/provider"
+	"github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext"
 )
 
 // invalidationCaches presents the role-permission and user-override caches
@@ -67,6 +71,36 @@ func (c invalidationCaches) CachedRevision(tenantID string) (int64, bool) {
 func (c invalidationCaches) InvalidateTenant(tenantID string) {
 	c.roles.InvalidateTenant(tenantID)
 	c.overrides.InvalidateTenant(tenantID)
+}
+
+// timingRoleMatrix and timingOverrides time every call that reaches them,
+// which is exactly the calls the caches in front of them make on a miss
+// (§17.1's "PostgreSQL cache-miss query latency"): a cache hit never
+// reaches either type.
+type timingRoleMatrix struct {
+	inner   assignments.RoleMatrix
+	metrics *adsmetrics.DB
+}
+
+func (t timingRoleMatrix) ActiveRolePermissions(ctx context.Context, query assignmentstore.ActiveRolePermissionQuery) ([]assignmentstore.RolePermission, error) {
+	start := time.Now()
+	defer func() { t.metrics.ObserveQueryLatency("role_permissions", time.Since(start)) }()
+	return t.inner.ActiveRolePermissions(ctx, query)
+}
+
+func (t timingRoleMatrix) PermissionRevision(ctx context.Context, tenantID string) (assignmentstore.PermissionRevision, bool, error) {
+	return t.inner.PermissionRevision(ctx, tenantID)
+}
+
+type timingOverrides struct {
+	inner   assignments.Overrides
+	metrics *adsmetrics.DB
+}
+
+func (t timingOverrides) For(ctx context.Context, query authz.AssignmentQuery) ([]permissioncontext.UserOverride, error) {
+	start := time.Now()
+	defer func() { t.metrics.ObserveQueryLatency("user_overrides", time.Since(start)) }()
+	return t.inner.For(ctx, query)
 }
 
 func main() {
@@ -141,6 +175,28 @@ func main() {
 
 	registry := prometheus.NewRegistry()
 	invalidationMetrics := invalidationmetrics.New(registry)
+	decisionMetrics := adsmetrics.NewDecision(registry)
+	cacheMetrics := adsmetrics.NewCache(registry)
+	dbMetrics := adsmetrics.NewDB(registry)
+	revisionMetrics := adsmetrics.NewRevision(registry)
+	revisionMetrics.SetRootPolicyRevision(cfg.RootPolicyRevision)
+
+	// The two caches built above did not yet have a metrics collaborator
+	// (§17.1's per-cache hit ratio); rebuilding them here, once the
+	// collector exists, keeps their construction next to each other above
+	// rather than threading the registry through NewCachingRoleMatrix's
+	// call site.
+	roleMatrixCache = assignments.NewCachingRoleMatrix(assignments.CacheConfig{
+		Matrix:  timingRoleMatrix{inner: store, metrics: dbMetrics},
+		TTL:     cfg.RoleMatrixCacheTTL,
+		Metrics: cacheMetrics.For("role_permissions"),
+	})
+	overridesCache = assignments.NewCachingOverrides(assignments.OverrideCacheConfig{
+		Overrides: timingOverrides{inner: assignments.NewDBOverrides(store, nil), metrics: dbMetrics},
+		TTL:       cfg.RoleMatrixCacheTTL,
+		Metrics:   cacheMetrics.For("user_overrides"),
+	})
+	invalidationCache = invalidationCaches{roles: roleMatrixCache, overrides: overridesCache}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -192,6 +248,32 @@ func main() {
 	})
 	go reconciler.Run(ctx)
 
+	// §17.1's revision gauges: a read-only observer, independent of the
+	// reconciler above, which is the one thing allowed to act on drift.
+	revisionPoller := revisionmetrics.NewPoller(revisionmetrics.PollerConfig{
+		Cache:   roleMatrixCache,
+		Store:   store,
+		Metrics: revisionMetrics,
+	})
+	go revisionPoller.Run(ctx, 5*time.Second)
+
+	// §17.1's connection-pool saturation: polled on its own schedule, the
+	// same as Kafka consumer lag above, since it is an observability signal
+	// rather than something any decision waits on.
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				acquired, idle, max := store.PoolStats()
+				dbMetrics.SetPoolStats(acquired, idle, max)
+			}
+		}
+	}()
+
 	handler := server.New(server.Config{
 		Dependencies: []server.Dependency{
 			{Name: "cerbos", Probe: cerbos.NewGRPCProbe(cfg.CerbosGRPCAddr)},
@@ -204,7 +286,9 @@ func main() {
 				Matrix:    roleMatrixCache,
 				Overrides: overridesCache,
 			}),
-			Logger: logger,
+			Logger:             logger,
+			Metrics:            decisionMetrics,
+			RootPolicyRevision: cfg.RootPolicyRevision,
 		})),
 		DirectoryUsersHandler: authenticated(directoryapi.NewUsersHandler(directoryapi.Config{
 			Directory: directory,

--- a/apps/ads/internal/adsmetrics/adsmetrics.go
+++ b/apps/ads/internal/adsmetrics/adsmetrics.go
@@ -85,10 +85,10 @@ func (c *Cache) For(name string) interface {
 // DB exports the authorization database's cache-miss query latency and
 // connection-pool saturation.
 type DB struct {
-	queryLatency  *prometheus.HistogramVec
-	poolAcquired  prometheus.Gauge
-	poolIdle      prometheus.Gauge
-	poolMax       prometheus.Gauge
+	queryLatency *prometheus.HistogramVec
+	poolAcquired prometheus.Gauge
+	poolIdle     prometheus.Gauge
+	poolMax      prometheus.Gauge
 }
 
 // NewDB builds the collectors and registers them with reg.

--- a/apps/ads/internal/adsmetrics/adsmetrics.go
+++ b/apps/ads/internal/adsmetrics/adsmetrics.go
@@ -1,0 +1,199 @@
+// Package adsmetrics exports the ADS's §17.1 metric surface as Prometheus
+// collectors: decision request rate/outcome/latency by resource and
+// action, per-cache hit ratio, database cache-miss query latency and
+// connection-pool saturation, and revision gauges (via revisionmetrics.Metrics).
+package adsmetrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Decision exports the decision path's request rate, outcome and latency,
+// labeled by resource and action so neither is lost in an aggregate.
+type Decision struct {
+	requestsTotal   *prometheus.CounterVec
+	requestDuration *prometheus.HistogramVec
+}
+
+// NewDecision builds the collectors and registers them with reg.
+func NewDecision(reg prometheus.Registerer) *Decision {
+	d := &Decision{
+		requestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "ads_decision_requests_total",
+			Help: "Count of authorization decisions by resource, action and outcome (allow, deny, error).",
+		}, []string{"resource", "action", "outcome"}),
+		requestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "ads_decision_duration_seconds",
+			Help:    "Time to serve one authorization decision, by resource and action.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"resource", "action"}),
+	}
+	reg.MustRegister(d.requestsTotal, d.requestDuration)
+	return d
+}
+
+// Observe records one decision's outcome and latency.
+func (d *Decision) Observe(resource, action, outcome string, latency time.Duration) {
+	d.requestsTotal.WithLabelValues(resource, action, outcome).Inc()
+	d.requestDuration.WithLabelValues(resource, action).Observe(latency.Seconds())
+}
+
+// Cache exports per-cache hit and miss counts (§17.1: "not as a single
+// aggregate").
+type Cache struct {
+	hits   *prometheus.CounterVec
+	misses *prometheus.CounterVec
+}
+
+// NewCache builds the collectors and registers them with reg.
+func NewCache(reg prometheus.Registerer) *Cache {
+	c := &Cache{
+		hits: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "ads_cache_hits_total",
+			Help: "Count of lookups served entirely from memory, by cache.",
+		}, []string{"cache"}),
+		misses: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "ads_cache_misses_total",
+			Help: "Count of lookups that read through to the database, by cache.",
+		}, []string{"cache"}),
+	}
+	reg.MustRegister(c.hits, c.misses)
+	return c
+}
+
+// cacheRecorder adapts one named cache's Hit/Miss calls to Cache's
+// labeled counters, satisfying assignments.CacheMetrics.
+type cacheRecorder struct {
+	name string
+	c    *Cache
+}
+
+func (r cacheRecorder) Hit()  { r.c.hits.WithLabelValues(r.name).Inc() }
+func (r cacheRecorder) Miss() { r.c.misses.WithLabelValues(r.name).Inc() }
+
+// For returns the recorder for one named cache, e.g. "role_permissions" or
+// "user_overrides".
+func (c *Cache) For(name string) interface {
+	Hit()
+	Miss()
+} {
+	return cacheRecorder{name: name, c: c}
+}
+
+// DB exports the authorization database's cache-miss query latency and
+// connection-pool saturation.
+type DB struct {
+	queryLatency  *prometheus.HistogramVec
+	poolAcquired  prometheus.Gauge
+	poolIdle      prometheus.Gauge
+	poolMax       prometheus.Gauge
+}
+
+// NewDB builds the collectors and registers them with reg.
+func NewDB(reg prometheus.Registerer) *DB {
+	d := &DB{
+		queryLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "ads_db_cache_miss_query_seconds",
+			Help:    "Time to read through to PostgreSQL on a cache miss, by cache.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"cache"}),
+		poolAcquired: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "ads_db_pool_acquired_connections",
+			Help: "Connections currently checked out of the pool.",
+		}),
+		poolIdle: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "ads_db_pool_idle_connections",
+			Help: "Connections currently idle in the pool.",
+		}),
+		poolMax: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "ads_db_pool_max_connections",
+			Help: "The pool's configured maximum connection count.",
+		}),
+	}
+	reg.MustRegister(d.queryLatency, d.poolAcquired, d.poolIdle, d.poolMax)
+	return d
+}
+
+// ObserveQueryLatency records one cache-miss read-through's duration.
+func (d *DB) ObserveQueryLatency(cache string, latency time.Duration) {
+	d.queryLatency.WithLabelValues(cache).Observe(latency.Seconds())
+}
+
+// SetPoolStats records the pool's current saturation.
+func (d *DB) SetPoolStats(acquired, idle, max int32) {
+	d.poolAcquired.Set(float64(acquired))
+	d.poolIdle.Set(float64(idle))
+	d.poolMax.Set(float64(max))
+}
+
+// Revision exports §17.1's "current root revision and permission revision
+// by replica" and "stale-revision duration and number of replicas behind
+// the target revision". Implements revisionmetrics.Metrics.
+type Revision struct {
+	cachedRevision *prometheus.GaugeVec
+	actualRevision *prometheus.GaugeVec
+	staleSeconds   *prometheus.GaugeVec
+	behindTarget   *prometheus.GaugeVec
+	rootPolicy     *prometheus.GaugeVec
+}
+
+// NewRevision builds the collectors and registers them with reg.
+func NewRevision(reg prometheus.Registerer) *Revision {
+	r := &Revision{
+		cachedRevision: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "ads_permission_revision_cached",
+			Help: "This replica's currently cached permission revision, by tenant.",
+		}, []string{"tenant"}),
+		actualRevision: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "ads_permission_revision_actual",
+			Help: "The authoritative permission revision in PostgreSQL, by tenant.",
+		}, []string{"tenant"}),
+		staleSeconds: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "ads_stale_revision_seconds",
+			Help: "How long this replica's cached revision has disagreed with the authoritative one, by tenant. Zero when converged.",
+		}, []string{"tenant"}),
+		behindTarget: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "ads_replica_behind_target",
+			Help: "1 if this replica's cached revision currently disagrees with the authoritative one for the tenant, 0 otherwise. Sum across replicas for the cluster-wide count.",
+		}, []string{"tenant"}),
+		rootPolicy: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "ads_root_policy_revision_info",
+			Help: "Always 1; the currently served root policy revision is the 'revision' label.",
+		}, []string{"revision"}),
+	}
+	reg.MustRegister(r.cachedRevision, r.actualRevision, r.staleSeconds, r.behindTarget, r.rootPolicy)
+	return r
+}
+
+// SetCachedRevision implements revisionmetrics.Metrics.
+func (r *Revision) SetCachedRevision(tenant string, revision int64) {
+	r.cachedRevision.WithLabelValues(tenant).Set(float64(revision))
+}
+
+// SetActualRevision implements revisionmetrics.Metrics.
+func (r *Revision) SetActualRevision(tenant string, revision int64) {
+	r.actualRevision.WithLabelValues(tenant).Set(float64(revision))
+}
+
+// SetStaleSeconds implements revisionmetrics.Metrics.
+func (r *Revision) SetStaleSeconds(tenant string, seconds float64) {
+	r.staleSeconds.WithLabelValues(tenant).Set(seconds)
+}
+
+// SetBehindTarget implements revisionmetrics.Metrics.
+func (r *Revision) SetBehindTarget(tenant string, behind bool) {
+	value := 0.0
+	if behind {
+		value = 1.0
+	}
+	r.behindTarget.WithLabelValues(tenant).Set(value)
+}
+
+// SetRootPolicyRevision records the root policy revision this replica
+// currently serves, as a Prometheus info-style gauge.
+func (r *Revision) SetRootPolicyRevision(revision string) {
+	r.rootPolicy.Reset()
+	r.rootPolicy.WithLabelValues(revision).Set(1)
+}

--- a/apps/ads/internal/assignments/cache.go
+++ b/apps/ads/internal/assignments/cache.go
@@ -16,6 +16,18 @@ import (
 // when it does this becomes a backstop rather than the primary mechanism.
 const DefaultCacheTTL = 30 * time.Second
 
+// CacheMetrics reports whether a lookup was served from memory or had to
+// read through, so §17.1's per-cache hit ratio has something to divide.
+type CacheMetrics interface {
+	Hit()
+	Miss()
+}
+
+type noopCacheMetrics struct{}
+
+func (noopCacheMetrics) Hit()  {}
+func (noopCacheMetrics) Miss() {}
+
 // CachingRoleMatrix is the in-process warm path in front of the authorization
 // database (§11.2).
 //
@@ -41,8 +53,9 @@ const DefaultCacheTTL = 30 * time.Second
 // eviction beyond that. Adding one before the load slice has measured the real
 // keyspace would be machinery built against a guess.
 type CachingRoleMatrix struct {
-	inner RoleMatrix
-	ttl   time.Duration
+	inner   RoleMatrix
+	ttl     time.Duration
+	metrics CacheMetrics
 	// now is the clock entries are aged against, injected so tests can advance
 	// time without sleeping. Unexported: a caller mutating it while decisions
 	// are in flight would be a data race on the hot path.
@@ -61,6 +74,8 @@ type CacheConfig struct {
 	TTL time.Duration
 	// Now defaults to time.Now.
 	Now func() time.Time
+	// Metrics reports hits and misses (§17.1). Nil means no reporting.
+	Metrics CacheMetrics
 }
 
 type roleCacheKey struct {
@@ -90,10 +105,15 @@ func NewCachingRoleMatrix(cfg CacheConfig) *CachingRoleMatrix {
 	if now == nil {
 		now = time.Now
 	}
+	metrics := cfg.Metrics
+	if metrics == nil {
+		metrics = noopCacheMetrics{}
+	}
 	return &CachingRoleMatrix{
 		inner:     cfg.Matrix,
 		ttl:       ttl,
 		now:       now,
+		metrics:   metrics,
 		roles:     make(map[roleCacheKey]cachedActions),
 		revisions: make(map[string]cachedRevision),
 	}
@@ -123,8 +143,10 @@ func (c *CachingRoleMatrix) ActiveRolePermissions(ctx context.Context, query ass
 	c.mu.Unlock()
 
 	if len(missing) == 0 {
+		c.metrics.Hit()
 		return resolved, nil
 	}
+	c.metrics.Miss()
 
 	miss := query
 	miss.RoleExternalIDs = missing

--- a/apps/ads/internal/assignments/cache_test.go
+++ b/apps/ads/internal/assignments/cache_test.go
@@ -85,6 +85,41 @@ func TestTheCacheKeySeparatesTenantsRolesAndResources(t *testing.T) {
 	}
 }
 
+type fakeCacheMetrics struct {
+	hits   int
+	misses int
+}
+
+func (m *fakeCacheMetrics) Hit()  { m.hits++ }
+func (m *fakeCacheMetrics) Miss() { m.misses++ }
+
+// §17.1's per-cache hit ratio needs a hit reported for a lookup served
+// entirely from memory.
+func TestASecondIdenticalLookupReportsAHit(t *testing.T) {
+	inner := &recordingMatrix{permissions: []assignmentstore.RolePermission{
+		grant("tenant-a", "role-doctor", "read", true),
+	}}
+	metrics := &fakeCacheMetrics{}
+	cache := assignments.NewCachingRoleMatrix(assignments.CacheConfig{
+		Matrix: inner, TTL: time.Minute, Now: func() time.Time { return decidedAt }, Metrics: metrics,
+	})
+	ctx := context.Background()
+
+	if _, err := cache.ActiveRolePermissions(ctx, matrixQuery("tenant-a", "role-doctor")); err != nil {
+		t.Fatalf("first lookup: %v", err)
+	}
+	if _, err := cache.ActiveRolePermissions(ctx, matrixQuery("tenant-a", "role-doctor")); err != nil {
+		t.Fatalf("second lookup: %v", err)
+	}
+
+	if metrics.misses != 1 {
+		t.Errorf("misses = %d, want 1 (the first, cold lookup)", metrics.misses)
+	}
+	if metrics.hits != 1 {
+		t.Errorf("hits = %d, want 1 (the second, warm lookup)", metrics.hits)
+	}
+}
+
 // A principal's roles are cached one role at a time, so a second principal
 // sharing most of them reads only the roles the cache has never seen.
 func TestOnlyTheRolesTheCacheHasNotSeenAreRead(t *testing.T) {

--- a/apps/ads/internal/assignments/overridecache.go
+++ b/apps/ads/internal/assignments/overridecache.go
@@ -1,0 +1,129 @@
+package assignments
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
+	"github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext"
+)
+
+// CachingOverrides is the read-through cache in front of a user-override
+// source (§11.2, §17.1's "ADS cache hit ratios for role permissions and
+// user overrides"). It mirrors CachingRoleMatrix's TTL and never-cache-a-
+// failure discipline, over the Overrides port instead of RoleMatrix: the
+// two are resolved from different places and change at different times,
+// which is why Resolver already keeps them as separate collaborators.
+type CachingOverrides struct {
+	inner Overrides
+	ttl   time.Duration
+	now   func() time.Time
+
+	mu      sync.Mutex
+	entries map[overrideCacheKey]cachedOverrides
+}
+
+// OverrideCacheConfig holds the cache's collaborators.
+type OverrideCacheConfig struct {
+	Overrides Overrides
+	// TTL bounds how long an entry may outlive a change to the underlying
+	// row. Non-positive falls back to DefaultCacheTTL.
+	TTL time.Duration
+	// Now defaults to time.Now.
+	Now func() time.Time
+}
+
+type overrideCacheKey struct {
+	tenantID   string
+	hospitalID string
+	userID     string
+	resource   string
+	resourceID string
+}
+
+type cachedOverrides struct {
+	overrides []permissioncontext.UserOverride
+	readAt    time.Time
+}
+
+// NewCachingOverrides wraps an Overrides source in a read-through cache.
+func NewCachingOverrides(cfg OverrideCacheConfig) *CachingOverrides {
+	ttl := cfg.TTL
+	if ttl <= 0 {
+		ttl = DefaultCacheTTL
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &CachingOverrides{
+		inner:   cfg.Overrides,
+		ttl:     ttl,
+		now:     now,
+		entries: make(map[overrideCacheKey]cachedOverrides),
+	}
+}
+
+func keyOf(query authz.AssignmentQuery) overrideCacheKey {
+	return overrideCacheKey{
+		tenantID:   query.TenantID,
+		hospitalID: query.HospitalID,
+		userID:     query.PrincipalID,
+		resource:   query.ResourceKind,
+		resourceID: query.ResourceID,
+	}
+}
+
+// For implements Overrides, serving from memory when the entry is fresh
+// and reading through otherwise.
+func (c *CachingOverrides) For(ctx context.Context, query authz.AssignmentQuery) ([]permissioncontext.UserOverride, error) {
+	now := c.now()
+	key := keyOf(query)
+
+	c.mu.Lock()
+	entry, cached := c.entries[key]
+	c.mu.Unlock()
+	if cached && now.Sub(entry.readAt) < c.ttl {
+		return entry.overrides, nil
+	}
+
+	fresh, err := c.inner.For(ctx, query)
+	if err != nil {
+		// Deliberately nothing is stored: caching a transient failure as
+		// "no overrides" would turn an outage into a lasting incorrect
+		// answer, the same discipline CachingRoleMatrix applies.
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.entries[key] = cachedOverrides{overrides: fresh, readAt: now}
+	c.mu.Unlock()
+
+	return fresh, nil
+}
+
+// InvalidateUser drops every cached entry for one user within one tenant,
+// across every resource it was cached under - the outbox consumer's
+// SUBJECT_USER events (§10.1) act on this.
+func (c *CachingOverrides) InvalidateUser(tenantID, userID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key := range c.entries {
+		if key.tenantID == tenantID && key.userID == userID {
+			delete(c.entries, key)
+		}
+	}
+}
+
+// InvalidateTenant drops every cached entry for one tenant, the same
+// backstop CachingRoleMatrix's InvalidateTenant gives the reconciler.
+func (c *CachingOverrides) InvalidateTenant(tenantID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key := range c.entries {
+		if key.tenantID == tenantID {
+			delete(c.entries, key)
+		}
+	}
+}

--- a/apps/ads/internal/assignments/overridecache.go
+++ b/apps/ads/internal/assignments/overridecache.go
@@ -16,9 +16,10 @@ import (
 // two are resolved from different places and change at different times,
 // which is why Resolver already keeps them as separate collaborators.
 type CachingOverrides struct {
-	inner Overrides
-	ttl   time.Duration
-	now   func() time.Time
+	inner   Overrides
+	ttl     time.Duration
+	metrics CacheMetrics
+	now     func() time.Time
 
 	mu      sync.Mutex
 	entries map[overrideCacheKey]cachedOverrides
@@ -32,6 +33,8 @@ type OverrideCacheConfig struct {
 	TTL time.Duration
 	// Now defaults to time.Now.
 	Now func() time.Time
+	// Metrics reports hits and misses (§17.1). Nil means no reporting.
+	Metrics CacheMetrics
 }
 
 type overrideCacheKey struct {
@@ -57,10 +60,15 @@ func NewCachingOverrides(cfg OverrideCacheConfig) *CachingOverrides {
 	if now == nil {
 		now = time.Now
 	}
+	metrics := cfg.Metrics
+	if metrics == nil {
+		metrics = noopCacheMetrics{}
+	}
 	return &CachingOverrides{
 		inner:   cfg.Overrides,
 		ttl:     ttl,
 		now:     now,
+		metrics: metrics,
 		entries: make(map[overrideCacheKey]cachedOverrides),
 	}
 }
@@ -85,8 +93,10 @@ func (c *CachingOverrides) For(ctx context.Context, query authz.AssignmentQuery)
 	entry, cached := c.entries[key]
 	c.mu.Unlock()
 	if cached && now.Sub(entry.readAt) < c.ttl {
+		c.metrics.Hit()
 		return entry.overrides, nil
 	}
+	c.metrics.Miss()
 
 	fresh, err := c.inner.For(ctx, query)
 	if err != nil {

--- a/apps/ads/internal/assignments/overridecache_test.go
+++ b/apps/ads/internal/assignments/overridecache_test.go
@@ -126,6 +126,33 @@ func TestOverrideCache_AFailedReadThroughIsNeverCached(t *testing.T) {
 	}
 }
 
+// §17.1's per-cache hit ratio needs a hit reported for a lookup served
+// entirely from memory, for the user overrides cache too.
+func TestOverrideCache_ASecondIdenticalLookupReportsAHit(t *testing.T) {
+	inner := &recordingOverrides{overrides: []permissioncontext.UserOverride{
+		{Action: "update", State: permissioncontext.Revoke},
+	}}
+	metrics := &fakeCacheMetrics{}
+	cache := assignments.NewCachingOverrides(assignments.OverrideCacheConfig{
+		Overrides: inner, TTL: time.Minute, Now: func() time.Time { return decidedAt }, Metrics: metrics,
+	})
+	ctx := context.Background()
+
+	if _, err := cache.For(ctx, doctorQuery()); err != nil {
+		t.Fatalf("first lookup: %v", err)
+	}
+	if _, err := cache.For(ctx, doctorQuery()); err != nil {
+		t.Fatalf("second lookup: %v", err)
+	}
+
+	if metrics.misses != 1 {
+		t.Errorf("misses = %d, want 1 (the first, cold lookup)", metrics.misses)
+	}
+	if metrics.hits != 1 {
+		t.Errorf("hits = %d, want 1 (the second, warm lookup)", metrics.hits)
+	}
+}
+
 // InvalidateUser drops every cached entry for one user within one tenant,
 // so the outbox consumer's SUBJECT_USER events (§10.1) have something to
 // act on.

--- a/apps/ads/internal/assignments/overridecache_test.go
+++ b/apps/ads/internal/assignments/overridecache_test.go
@@ -1,0 +1,162 @@
+package assignments_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/assignments"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
+	"github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext"
+)
+
+type recordingOverrides struct {
+	overrides []permissioncontext.UserOverride
+	err       error
+	queries   []authz.AssignmentQuery
+}
+
+func (r *recordingOverrides) For(_ context.Context, query authz.AssignmentQuery) ([]permissioncontext.UserOverride, error) {
+	r.queries = append(r.queries, query)
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.overrides, nil
+}
+
+func newOverrideCache(inner assignments.Overrides, clock func() time.Time) *assignments.CachingOverrides {
+	return assignments.NewCachingOverrides(assignments.OverrideCacheConfig{
+		Overrides: inner,
+		TTL:       time.Minute,
+		Now:       clock,
+	})
+}
+
+// §11.2's read-through pattern, applied to user overrides too: a second
+// identical lookup must be served from memory.
+func TestOverrideCache_ASecondIdenticalLookupIsServedWithoutReadingThrough(t *testing.T) {
+	inner := &recordingOverrides{overrides: []permissioncontext.UserOverride{
+		{Action: "update", State: permissioncontext.Revoke},
+	}}
+	cache := newOverrideCache(inner, func() time.Time { return decidedAt })
+	ctx := context.Background()
+
+	first, err := cache.For(ctx, doctorQuery())
+	if err != nil {
+		t.Fatalf("first lookup: %v", err)
+	}
+	second, err := cache.For(ctx, doctorQuery())
+	if err != nil {
+		t.Fatalf("second lookup: %v", err)
+	}
+
+	if len(inner.queries) != 1 {
+		t.Errorf("two identical lookups made %d reads through, want 1", len(inner.queries))
+	}
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("lookups returned %d and %d overrides, want 1 each", len(first), len(second))
+	}
+}
+
+// The cache key must separate tenant, hospital, user and resource: a cache
+// that answered one user's question with another's, or one tenant's with
+// another's, would be a tenant/hospital isolation defect.
+func TestOverrideCache_TheKeySeparatesTenantHospitalUserAndResource(t *testing.T) {
+	inner := &recordingOverrides{}
+	cache := newOverrideCache(inner, func() time.Time { return decidedAt })
+	ctx := context.Background()
+
+	base := doctorQuery()
+	otherTenant := doctorQuery()
+	otherTenant.TenantID = "tenant-b"
+	otherHospital := doctorQuery()
+	otherHospital.HospitalID = "hospital-2"
+	otherUser := doctorQuery()
+	otherUser.PrincipalID = "user-nurse"
+	otherResource := doctorQuery()
+	otherResource.ResourceID = "patient-999"
+
+	for _, query := range []authz.AssignmentQuery{base, otherTenant, otherHospital, otherUser, otherResource, base} {
+		if _, err := cache.For(ctx, query); err != nil {
+			t.Fatalf("lookup: %v", err)
+		}
+	}
+
+	if len(inner.queries) != 5 {
+		t.Errorf("5 distinct queries made %d reads through, want 5", len(inner.queries))
+	}
+}
+
+// A stale entry must not outlive the TTL: a revoked override that stayed
+// cached past its bound would grant access the database no longer allows.
+func TestOverrideCache_AnEntryExpiresAfterTheTTL(t *testing.T) {
+	inner := &recordingOverrides{overrides: []permissioncontext.UserOverride{
+		{Action: "update", State: permissioncontext.Revoke},
+	}}
+	now := decidedAt
+	cache := newOverrideCache(inner, func() time.Time { return now })
+	ctx := context.Background()
+
+	if _, err := cache.For(ctx, doctorQuery()); err != nil {
+		t.Fatalf("first lookup: %v", err)
+	}
+	now = now.Add(2 * time.Minute)
+	if _, err := cache.For(ctx, doctorQuery()); err != nil {
+		t.Fatalf("second lookup: %v", err)
+	}
+
+	if len(inner.queries) != 2 {
+		t.Errorf("a lookup past the TTL made %d reads through, want 2", len(inner.queries))
+	}
+}
+
+// A read-through failure must never be cached: remembering "no overrides"
+// after a transient error would turn an outage into a lasting incorrect
+// answer.
+func TestOverrideCache_AFailedReadThroughIsNeverCached(t *testing.T) {
+	inner := &recordingOverrides{err: context.DeadlineExceeded}
+	cache := newOverrideCache(inner, func() time.Time { return decidedAt })
+	ctx := context.Background()
+
+	if _, err := cache.For(ctx, doctorQuery()); err == nil {
+		t.Fatal("For: want error, got nil")
+	}
+	if len(inner.queries) != 1 {
+		t.Fatalf("len(queries) = %d, want 1", len(inner.queries))
+	}
+}
+
+// InvalidateUser drops every cached entry for one user within one tenant,
+// so the outbox consumer's SUBJECT_USER events (§10.1) have something to
+// act on.
+func TestOverrideCache_InvalidateUserDropsOnlyThatUsersEntries(t *testing.T) {
+	inner := &recordingOverrides{overrides: []permissioncontext.UserOverride{
+		{Action: "update", State: permissioncontext.Revoke},
+	}}
+	cache := newOverrideCache(inner, func() time.Time { return decidedAt })
+	ctx := context.Background()
+
+	other := doctorQuery()
+	other.PrincipalID = "user-nurse"
+
+	if _, err := cache.For(ctx, doctorQuery()); err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if _, err := cache.For(ctx, other); err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+
+	cache.InvalidateUser(doctorQuery().TenantID, doctorQuery().PrincipalID)
+
+	if _, err := cache.For(ctx, doctorQuery()); err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if _, err := cache.For(ctx, other); err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+
+	// The invalidated user's entry was re-read; the other user's was not.
+	if len(inner.queries) != 3 {
+		t.Fatalf("len(queries) = %d, want 3 (2 initial + 1 re-read)", len(inner.queries))
+	}
+}

--- a/apps/ads/internal/authz/authz.go
+++ b/apps/ads/internal/authz/authz.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
 	"github.com/tishan-harischandra/cerbos-poc/libs/canonicalid"
@@ -42,11 +43,22 @@ type Assignments interface {
 	For(ctx context.Context, query AssignmentQuery) (permissioncontext.Input, error)
 }
 
+// Metrics is where a served decision reports its outcome and latency
+// (§17.1: request rate, allow/deny/error rate and latency by resource and
+// action). Nil means nothing is reported.
+type Metrics interface {
+	Observe(resource, action, outcome string, latency time.Duration)
+}
+
 // Config holds the handler's collaborators.
 type Config struct {
 	PDP         PDP
 	Assignments Assignments
 	Logger      *slog.Logger
+	Metrics     Metrics
+	// RootPolicyRevision is the immutable root-policy tag this replica
+	// currently serves, logged on every decision (§17.2).
+	RootPolicyRevision string
 }
 
 // Request is the Appendix B decision request.
@@ -88,14 +100,24 @@ type Decision struct {
 	Source  Source `json:"source"`
 }
 
+type noopMetrics struct{}
+
+func (noopMetrics) Observe(string, string, string, time.Duration) {}
+
 // NewHandler builds the POST /internal/authz/check handler.
 func NewHandler(cfg Config) http.Handler {
 	logger := cfg.Logger
 	if logger == nil {
 		logger = slog.Default()
 	}
+	metrics := cfg.Metrics
+	if metrics == nil {
+		metrics = noopMetrics{}
+	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
 		// The identity is the middleware's, never the body's. A handler
 		// reached without one has been mounted outside the authenticated
 		// routes, which is a wiring defect rather than a caller error.
@@ -186,10 +208,17 @@ func NewHandler(cfg Config) http.Handler {
 			logger.ErrorContext(r.Context(), "the PDP could not be reached",
 				slog.String("principalId", identity.PrincipalID),
 				slog.Any("error", err))
+			latency := time.Since(start)
+			for _, resource := range req.Resources {
+				for _, action := range resource.Actions {
+					metrics.Observe(resource.Kind, action, "error", latency)
+				}
+			}
 			writeError(w, http.StatusServiceUnavailable, "could not reach the policy decision point")
 			return
 		}
 
+		latency := time.Since(start)
 		response := Response{CerbosCallID: result.CallID}
 		for _, resource := range req.Resources {
 			ref := cerbosclient.ResourceRef{Kind: resource.Kind, ID: resource.ID}
@@ -201,6 +230,11 @@ func NewHandler(cfg Config) http.Handler {
 					Allowed: decision.Allowed,
 					Source:  DecisionSource(action, decision.Allowed, result.FiredRules[ref]),
 				}
+				outcome := "deny"
+				if decision.Allowed {
+					outcome = "allow"
+				}
+				metrics.Observe(resource.Kind, action, outcome, latency)
 			}
 			response.Resources = append(response.Resources, ResourceDecision{
 				Kind:               resource.Kind,
@@ -210,13 +244,25 @@ func NewHandler(cfg Config) http.Handler {
 			})
 		}
 
-		// §11.3: the Cerbos call ID is logged next to the application
-		// correlation ID so a decision can be traced into the PDP audit log.
+		// §11.3, §17.2: the Cerbos call ID is logged next to the
+		// application correlation ID so a decision can be traced into the
+		// PDP audit log, alongside the permission and root policy
+		// revisions and the idp roles a decision was matched against - a
+		// decision can be reconstructed end-to-end from this one record
+		// without a second lookup. No resource attribute or clinical
+		// value is logged here (§16.2).
+		loggedRevisions := make(map[string]int64, len(revisions))
+		for ref, revision := range revisions {
+			loggedRevisions[ref.Kind+":"+ref.ID] = revision
+		}
 		logger.InfoContext(r.Context(), "authorization decision served",
 			slog.String("correlationId", correlationID(r)),
 			slog.String("cerbosCallId", result.CallID),
 			slog.String("principalId", identity.PrincipalID),
-			slog.String("tenantId", identity.TenantID))
+			slog.String("tenantId", identity.TenantID),
+			slog.String("rootPolicyRevision", cfg.RootPolicyRevision),
+			slog.Any("permissionRevisions", loggedRevisions),
+			slog.Any("roleIds", identity.Roles))
 
 		writeJSON(w, http.StatusOK, response)
 	})

--- a/apps/ads/internal/authz/authz_test.go
+++ b/apps/ads/internal/authz/authz_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/authz"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
@@ -31,6 +32,18 @@ const validRequest = `{
 }`
 
 const doctorRole = "kc:cerbos-poc:patient-app:doctor"
+
+type recordingMetrics struct {
+	observations []observation
+}
+
+type observation struct {
+	resource, action, outcome string
+}
+
+func (m *recordingMetrics) Observe(resource, action, outcome string, _ time.Duration) {
+	m.observations = append(m.observations, observation{resource, action, outcome})
+}
 
 // §16.1: tenant and hospital context are derived server-side. A browser that
 // sends its own is refused rather than quietly ignored, because a caller who
@@ -313,12 +326,78 @@ func TestTheDecisionIsLoggedWithBothCorrelationIDs(t *testing.T) {
 	if !found {
 		t.Fatalf("no log record carried a cerbosCallId; log was:\n%s", logged.String())
 	}
+}
 
-	if record.CorrelationID != "corr-42" {
-		t.Errorf("correlationId = %q, want the inbound header value", record.CorrelationID)
+// §17.2: the ADS emits permission revision, root policy revision and the
+// matched (idp) role IDs alongside the correlation IDs, so a decision can
+// be reconstructed end-to-end without a second lookup.
+func TestTheDecisionIsLoggedWithRevisionsAndRoles(t *testing.T) {
+	pdp := &recordingPDP{result: cerbosclient.Result{CallID: "01HZY2CALLID"}}
+
+	var logged strings.Builder
+	handler := authz.NewHandler(authz.Config{
+		PDP: pdp,
+		Assignments: fixedAssignments{input: permissioncontext.Input{Revision: 184}},
+		Logger:             slog.New(slog.NewJSONHandler(&logged, nil)),
+		RootPolicyRevision: "root-v1.4.0",
+	})
+
+	request := postAs(identityWithRoles(doctorRole), validRequest)
+	handler.ServeHTTP(httptest.NewRecorder(), request)
+
+	var record struct {
+		CerbosCallID       string   `json:"cerbosCallId"`
+		RootPolicyRevision string   `json:"rootPolicyRevision"`
+		RoleIds            []string `json:"roleIds"`
 	}
-	if record.CerbosCallID != "01HZY2CALLID" {
-		t.Errorf("cerbosCallId = %q, want the ID the PDP reported", record.CerbosCallID)
+	found := false
+	for _, line := range strings.Split(strings.TrimSpace(logged.String()), "\n") {
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("log line is not JSON: %v", err)
+		}
+		if record.CerbosCallID != "" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no log record carried a cerbosCallId; log was:\n%s", logged.String())
+	}
+	if record.RootPolicyRevision != "root-v1.4.0" {
+		t.Errorf("rootPolicyRevision = %q, want root-v1.4.0", record.RootPolicyRevision)
+	}
+	if len(record.RoleIds) != 1 || record.RoleIds[0] != doctorRole {
+		t.Errorf("roleIds = %v, want [%s]", record.RoleIds, doctorRole)
+	}
+}
+
+// §16.2: mask or omit sensitive attributes from decision audit logs. A
+// clinical attribute value sent in the request must never appear in the
+// decision log line, only stable identifiers and revisions.
+func TestSensitiveResourceAttributesNeverAppearInTheDecisionLog(t *testing.T) {
+	pdp := &recordingPDP{result: cerbosclient.Result{CallID: "call-1"}}
+
+	var logged strings.Builder
+	handler := authz.NewHandler(authz.Config{
+		PDP:         pdp,
+		Assignments: emptyAssignments{},
+		Logger:      slog.New(slog.NewJSONHandler(&logged, nil)),
+	})
+
+	sensitiveRequest := `{
+	  "resources": [
+	    {
+	      "kind": "patient_record",
+	      "id": "patient-456",
+	      "attributes": {"tenantId": "tenant-a", "hospitalId": "hospital-1", "diagnosis": "Type 2 Diabetes Mellitus", "patientName": "Jane Doe"},
+	      "actions": ["read"]
+	    }
+	  ]
+	}`
+	handler.ServeHTTP(httptest.NewRecorder(), post(sensitiveRequest))
+
+	if strings.Contains(logged.String(), "Diabetes") || strings.Contains(logged.String(), "Jane Doe") {
+		t.Fatalf("decision log leaked a clinical attribute value: %s", logged.String())
 	}
 }
 
@@ -389,6 +468,54 @@ func TestALeafThePDPDidNotAnswerForIsDenied(t *testing.T) {
 	}
 	if decision.Allowed {
 		t.Error("an unanswered action was reported as allowed")
+	}
+}
+
+// §17.1: every decision reports its outcome per resource and action, so
+// request rate and allow/deny/error rate are never lost in an aggregate.
+func TestEveryDecisionIsObservedByResourceActionAndOutcome(t *testing.T) {
+	pdp := &recordingPDP{result: cerbosclient.Result{
+		CallID: "call-1",
+		Decisions: map[cerbosclient.Leaf]cerbosclient.Decision{
+			leaf("patient-456", "read"):   {Allowed: true},
+			leaf("patient-456", "update"): {Allowed: false},
+		},
+	}}
+	metrics := &recordingMetrics{}
+	handler := authz.NewHandler(authz.Config{PDP: pdp, Assignments: emptyAssignments{}, Metrics: metrics})
+
+	handler.ServeHTTP(httptest.NewRecorder(), post(validRequest))
+
+	want := map[observation]bool{
+		{"patient_record", "read", "allow"}:   true,
+		{"patient_record", "update", "deny"}:  true,
+	}
+	if len(metrics.observations) != 2 {
+		t.Fatalf("observations = %+v, want 2", metrics.observations)
+	}
+	for _, got := range metrics.observations {
+		if !want[got] {
+			t.Errorf("unexpected observation %+v", got)
+		}
+	}
+}
+
+// An unreachable PDP is observed as an error outcome, not silently
+// dropped from the metric surface.
+func TestAnUnreachablePDPIsObservedAsAnErrorOutcome(t *testing.T) {
+	pdp := &recordingPDP{err: errors.New("connection refused")}
+	metrics := &recordingMetrics{}
+	handler := authz.NewHandler(authz.Config{PDP: pdp, Assignments: emptyAssignments{}, Metrics: metrics})
+
+	handler.ServeHTTP(httptest.NewRecorder(), post(validRequest))
+
+	if len(metrics.observations) == 0 {
+		t.Fatal("no observation recorded for an unreachable PDP")
+	}
+	for _, got := range metrics.observations {
+		if got.outcome != "error" {
+			t.Errorf("outcome = %q, want error", got.outcome)
+		}
 	}
 }
 

--- a/apps/ads/internal/authz/authz_test.go
+++ b/apps/ads/internal/authz/authz_test.go
@@ -336,8 +336,8 @@ func TestTheDecisionIsLoggedWithRevisionsAndRoles(t *testing.T) {
 
 	var logged strings.Builder
 	handler := authz.NewHandler(authz.Config{
-		PDP: pdp,
-		Assignments: fixedAssignments{input: permissioncontext.Input{Revision: 184}},
+		PDP:                pdp,
+		Assignments:        fixedAssignments{input: permissioncontext.Input{Revision: 184}},
 		Logger:             slog.New(slog.NewJSONHandler(&logged, nil)),
 		RootPolicyRevision: "root-v1.4.0",
 	})
@@ -487,8 +487,8 @@ func TestEveryDecisionIsObservedByResourceActionAndOutcome(t *testing.T) {
 	handler.ServeHTTP(httptest.NewRecorder(), post(validRequest))
 
 	want := map[observation]bool{
-		{"patient_record", "read", "allow"}:   true,
-		{"patient_record", "update", "deny"}:  true,
+		{"patient_record", "read", "allow"}:  true,
+		{"patient_record", "update", "deny"}: true,
 	}
 	if len(metrics.observations) != 2 {
 		t.Fatalf("observations = %+v, want 2", metrics.observations)

--- a/apps/ads/internal/cacheconvergence/cacheconvergence_test.go
+++ b/apps/ads/internal/cacheconvergence/cacheconvergence_test.go
@@ -51,11 +51,11 @@ func TestConvergence_ReportsConvergedWhenCachedMatchesActual(t *testing.T) {
 		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
 	}
 	var body struct {
-		Tenant          string `json:"tenant"`
-		CachedRevision  int64  `json:"cachedRevision"`
-		ActualRevision  int64  `json:"actualRevision"`
-		Converged       bool   `json:"converged"`
-		ReplicasBehind  int    `json:"replicasBehindTarget"`
+		Tenant         string `json:"tenant"`
+		CachedRevision int64  `json:"cachedRevision"`
+		ActualRevision int64  `json:"actualRevision"`
+		Converged      bool   `json:"converged"`
+		ReplicasBehind int    `json:"replicasBehindTarget"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("response is not JSON: %v", err)

--- a/apps/ads/internal/invalidation/invalidation.go
+++ b/apps/ads/internal/invalidation/invalidation.go
@@ -18,11 +18,15 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/libs/permissionevents"
 )
 
-// Cache is the narrow slice of assignments.CachingRoleMatrix this package
-// needs to act on an invalidation.
+// Cache is the narrow slice of assignments.CachingRoleMatrix and
+// assignments.CachingOverrides this package needs to act on an
+// invalidation.
 type Cache interface {
 	InvalidateRole(tenantID, roleID string)
 	InvalidateRevision(tenantID string)
+	// InvalidateUser drops a SUBJECT_USER event's named user's cached
+	// overrides.
+	InvalidateUser(tenantID, userID string)
 }
 
 // Metrics is where a handled batch reports what happened. Both durations
@@ -67,8 +71,11 @@ func (h *Handler) HandleMessage(value []byte) error {
 	now := h.now()
 	for _, event := range events {
 		h.Cache.InvalidateRevision(event.TenantID)
-		if event.SubjectType == permissionevents.SubjectRole {
+		switch event.SubjectType {
+		case permissionevents.SubjectRole:
 			h.Cache.InvalidateRole(event.TenantID, event.SubjectID)
+		case permissionevents.SubjectUser:
+			h.Cache.InvalidateUser(event.TenantID, event.SubjectID)
 		}
 
 		if h.Metrics == nil {

--- a/apps/ads/internal/invalidation/invalidation_test.go
+++ b/apps/ads/internal/invalidation/invalidation_test.go
@@ -13,6 +13,7 @@ import (
 type fakeCache struct {
 	invalidatedRoles     []string
 	invalidatedRevisions []string
+	invalidatedUsers     []string
 }
 
 func (c *fakeCache) InvalidateRole(tenantID, roleID string) {
@@ -21,6 +22,10 @@ func (c *fakeCache) InvalidateRole(tenantID, roleID string) {
 
 func (c *fakeCache) InvalidateRevision(tenantID string) {
 	c.invalidatedRevisions = append(c.invalidatedRevisions, tenantID)
+}
+
+func (c *fakeCache) InvalidateUser(tenantID, userID string) {
+	c.invalidatedUsers = append(c.invalidatedUsers, tenantID+"/"+userID)
 }
 
 type fakeMetrics struct {
@@ -73,9 +78,10 @@ func TestHandleMessageInvalidatesTheNamedRoleAndTheTenantRevision(t *testing.T) 
 	}
 }
 
-// A USER event must invalidate the tenant's revision but must not call
-// InvalidateRole - there is no per-user cache entry to drop by that method.
-func TestHandleMessageForAUserEventDoesNotInvalidateARole(t *testing.T) {
+// A USER event must invalidate the named user's override cache entries and
+// the tenant's revision, but must not call InvalidateRole - there is no
+// per-user cache entry to drop by that method.
+func TestHandleMessageForAUserEventInvalidatesTheUserNotARole(t *testing.T) {
 	cache := &fakeCache{}
 	handler := &invalidation.Handler{Cache: cache}
 
@@ -98,6 +104,31 @@ func TestHandleMessageForAUserEventDoesNotInvalidateARole(t *testing.T) {
 	}
 	if len(cache.invalidatedRevisions) != 1 {
 		t.Errorf("invalidated revisions = %v, want [tenant-a]", cache.invalidatedRevisions)
+	}
+	if len(cache.invalidatedUsers) != 1 || cache.invalidatedUsers[0] != "tenant-a/user-1" {
+		t.Errorf("invalidated users = %v, want [tenant-a/user-1]", cache.invalidatedUsers)
+	}
+}
+
+// A ROLE event must not call InvalidateUser - there is no per-user cache
+// entry to drop for a role change.
+func TestHandleMessageForARoleEventDoesNotInvalidateAUser(t *testing.T) {
+	cache := &fakeCache{}
+	handler := &invalidation.Handler{Cache: cache}
+
+	batch := marshalBatch(t, permissionevents.PermissionChanged{
+		TenantID:    "tenant-a",
+		SubjectType: permissionevents.SubjectRole,
+		SubjectID:   "role-doctor",
+		OccurredAt:  time.Unix(99, 0),
+	})
+
+	if err := handler.HandleMessage(batch); err != nil {
+		t.Fatalf("HandleMessage: %v", err)
+	}
+
+	if len(cache.invalidatedUsers) != 0 {
+		t.Errorf("invalidated users = %v, want none for a ROLE event", cache.invalidatedUsers)
 	}
 }
 

--- a/apps/ads/internal/revisionmetrics/poller.go
+++ b/apps/ads/internal/revisionmetrics/poller.go
@@ -1,0 +1,118 @@
+// Package revisionmetrics polls this replica's cached permission revision
+// against the authoritative one in the database and reports §17.1's
+// "current root revision and permission revision by replica" and
+// "stale-revision duration and number of replicas behind the target
+// revision" as Prometheus gauges.
+//
+// It never invalidates anything itself: that is the reconciler's job
+// (apps/ads/internal/invalidation). This package only observes and
+// reports what the reconciler either has already repaired or is about
+// to.
+package revisionmetrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+)
+
+// Cache is the slice of assignments.CachingRoleMatrix this poller reads.
+type Cache interface {
+	KnownTenants() []string
+	CachedRevision(tenantID string) (int64, bool)
+}
+
+// Store is the authoritative revision source, the same one the reconciler
+// compares the cache against.
+type Store interface {
+	PermissionRevision(ctx context.Context, tenantID string) (assignmentstore.PermissionRevision, bool, error)
+}
+
+// Metrics is where a poll reports what it found.
+type Metrics interface {
+	SetCachedRevision(tenant string, revision int64)
+	SetActualRevision(tenant string, revision int64)
+	SetStaleSeconds(tenant string, seconds float64)
+	SetBehindTarget(tenant string, behind bool)
+}
+
+// PollerConfig holds the poller's collaborators.
+type PollerConfig struct {
+	Cache   Cache
+	Store   Store
+	Metrics Metrics
+	// Now defaults to time.Now.
+	Now func() time.Time
+}
+
+// Poller periodically compares each known tenant's cached revision
+// against the actual one and reports the result as metrics.
+type Poller struct {
+	cfg PollerConfig
+	// driftSince records when a tenant was first observed drifted, so
+	// stale duration grows across polls rather than resetting to zero on
+	// every tick.
+	driftSince map[string]time.Time
+}
+
+// NewPoller applies PollerConfig's defaults and returns a Poller.
+func NewPoller(cfg PollerConfig) *Poller {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &Poller{cfg: cfg, driftSince: make(map[string]time.Time)}
+}
+
+// PollOnce runs one pass over every tenant the cache currently knows
+// about.
+func (p *Poller) PollOnce(ctx context.Context) {
+	now := p.cfg.Now()
+	for _, tenantID := range p.cfg.Cache.KnownTenants() {
+		cachedRevision, cached := p.cfg.Cache.CachedRevision(tenantID)
+		if !cached {
+			continue
+		}
+
+		actual, found, err := p.cfg.Store.PermissionRevision(ctx, tenantID)
+		if err != nil {
+			continue
+		}
+		actualRevision := int64(0)
+		if found {
+			actualRevision = actual.Revision
+		}
+
+		p.cfg.Metrics.SetCachedRevision(tenantID, cachedRevision)
+		p.cfg.Metrics.SetActualRevision(tenantID, actualRevision)
+
+		if cachedRevision == actualRevision {
+			delete(p.driftSince, tenantID)
+			p.cfg.Metrics.SetStaleSeconds(tenantID, 0)
+			p.cfg.Metrics.SetBehindTarget(tenantID, false)
+			continue
+		}
+
+		since, drifting := p.driftSince[tenantID]
+		if !drifting {
+			since = now
+			p.driftSince[tenantID] = since
+		}
+		p.cfg.Metrics.SetStaleSeconds(tenantID, now.Sub(since).Seconds())
+		p.cfg.Metrics.SetBehindTarget(tenantID, true)
+	}
+}
+
+// Run calls PollOnce on every tick of interval until ctx is done.
+func (p *Poller) Run(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.PollOnce(ctx)
+		}
+	}
+}

--- a/apps/ads/internal/revisionmetrics/poller_test.go
+++ b/apps/ads/internal/revisionmetrics/poller_test.go
@@ -1,0 +1,169 @@
+package revisionmetrics_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/revisionmetrics"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+)
+
+type fakeCache struct {
+	tenants []string
+	cached  map[string]int64
+	haveAny map[string]bool
+}
+
+func (f *fakeCache) KnownTenants() []string { return f.tenants }
+
+func (f *fakeCache) CachedRevision(tenantID string) (int64, bool) {
+	if !f.haveAny[tenantID] {
+		return 0, false
+	}
+	return f.cached[tenantID], true
+}
+
+type fakeRevisionStore struct {
+	actual map[string]int64
+}
+
+func (f *fakeRevisionStore) PermissionRevision(_ context.Context, tenantID string) (assignmentstore.PermissionRevision, bool, error) {
+	rev, found := f.actual[tenantID]
+	return assignmentstore.PermissionRevision{Revision: rev}, found, nil
+}
+
+type fakeRevisionMetrics struct {
+	cached map[string]int64
+	actual map[string]int64
+	stale  map[string]float64
+	behind map[string]float64
+}
+
+func newFakeRevisionMetrics() *fakeRevisionMetrics {
+	return &fakeRevisionMetrics{
+		cached: map[string]int64{}, actual: map[string]int64{},
+		stale: map[string]float64{}, behind: map[string]float64{},
+	}
+}
+
+func (f *fakeRevisionMetrics) SetCachedRevision(tenant string, rev int64) { f.cached[tenant] = rev }
+func (f *fakeRevisionMetrics) SetActualRevision(tenant string, rev int64) { f.actual[tenant] = rev }
+func (f *fakeRevisionMetrics) SetStaleSeconds(tenant string, seconds float64) {
+	f.stale[tenant] = seconds
+}
+func (f *fakeRevisionMetrics) SetBehindTarget(tenant string, behind bool) {
+	if behind {
+		f.behind[tenant] = 1
+	} else {
+		f.behind[tenant] = 0
+	}
+}
+
+// A converged tenant reports zero stale seconds and is not behind target.
+func TestPollOnce_AConvergedTenantReportsNotBehind(t *testing.T) {
+	cache := &fakeCache{
+		tenants: []string{"tenant-a"},
+		cached:  map[string]int64{"tenant-a": 4},
+		haveAny: map[string]bool{"tenant-a": true},
+	}
+	store := &fakeRevisionStore{actual: map[string]int64{"tenant-a": 4}}
+	metrics := newFakeRevisionMetrics()
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	poller := revisionmetrics.NewPoller(revisionmetrics.PollerConfig{
+		Cache: cache, Store: store, Metrics: metrics, Now: func() time.Time { return now },
+	})
+
+	poller.PollOnce(context.Background())
+
+	if metrics.cached["tenant-a"] != 4 || metrics.actual["tenant-a"] != 4 {
+		t.Errorf("cached/actual = %d/%d, want 4/4", metrics.cached["tenant-a"], metrics.actual["tenant-a"])
+	}
+	if metrics.stale["tenant-a"] != 0 {
+		t.Errorf("stale seconds = %v, want 0 for a converged tenant", metrics.stale["tenant-a"])
+	}
+	if metrics.behind["tenant-a"] != 0 {
+		t.Errorf("behind target = %v, want 0 for a converged tenant", metrics.behind["tenant-a"])
+	}
+}
+
+// A drifted tenant is reported behind target, and its stale duration
+// grows the longer it stays drifted across polls.
+func TestPollOnce_ADriftedTenantReportsGrowingStaleDuration(t *testing.T) {
+	cache := &fakeCache{
+		tenants: []string{"tenant-a"},
+		cached:  map[string]int64{"tenant-a": 3},
+		haveAny: map[string]bool{"tenant-a": true},
+	}
+	store := &fakeRevisionStore{actual: map[string]int64{"tenant-a": 5}}
+	metrics := newFakeRevisionMetrics()
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	poller := revisionmetrics.NewPoller(revisionmetrics.PollerConfig{
+		Cache: cache, Store: store, Metrics: metrics, Now: func() time.Time { return now },
+	})
+
+	poller.PollOnce(context.Background())
+	if metrics.behind["tenant-a"] != 1 {
+		t.Fatalf("behind target = %v, want 1 for a drifted tenant", metrics.behind["tenant-a"])
+	}
+	if metrics.stale["tenant-a"] != 0 {
+		t.Fatalf("stale seconds on first drifted poll = %v, want 0", metrics.stale["tenant-a"])
+	}
+
+	now = now.Add(10 * time.Second)
+	poller.PollOnce(context.Background())
+	if metrics.stale["tenant-a"] != 10 {
+		t.Fatalf("stale seconds after 10s still drifted = %v, want 10", metrics.stale["tenant-a"])
+	}
+}
+
+// Once a drifted tenant converges again, its stale duration resets and it
+// is no longer reported behind target.
+func TestPollOnce_ATenantThatConvergesAfterDriftingResetsStaleDuration(t *testing.T) {
+	cache := &fakeCache{
+		tenants: []string{"tenant-a"},
+		cached:  map[string]int64{"tenant-a": 3},
+		haveAny: map[string]bool{"tenant-a": true},
+	}
+	store := &fakeRevisionStore{actual: map[string]int64{"tenant-a": 5}}
+	metrics := newFakeRevisionMetrics()
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	poller := revisionmetrics.NewPoller(revisionmetrics.PollerConfig{
+		Cache: cache, Store: store, Metrics: metrics, Now: func() time.Time { return now },
+	})
+
+	poller.PollOnce(context.Background())
+	now = now.Add(10 * time.Second)
+	poller.PollOnce(context.Background())
+
+	cache.cached["tenant-a"] = 5
+	now = now.Add(1 * time.Second)
+	poller.PollOnce(context.Background())
+
+	if metrics.behind["tenant-a"] != 0 {
+		t.Fatalf("behind target after converging = %v, want 0", metrics.behind["tenant-a"])
+	}
+	if metrics.stale["tenant-a"] != 0 {
+		t.Fatalf("stale seconds after converging = %v, want 0", metrics.stale["tenant-a"])
+	}
+}
+
+// A tenant this replica has never cached anything for has nothing to
+// report as behind - matching the reconciler's own treatment.
+func TestPollOnce_AnUncachedTenantIsSkipped(t *testing.T) {
+	cache := &fakeCache{
+		tenants: []string{"tenant-a"},
+		haveAny: map[string]bool{"tenant-a": false},
+	}
+	store := &fakeRevisionStore{actual: map[string]int64{"tenant-a": 5}}
+	metrics := newFakeRevisionMetrics()
+	poller := revisionmetrics.NewPoller(revisionmetrics.PollerConfig{
+		Cache: cache, Store: store, Metrics: metrics, Now: time.Now,
+	})
+
+	poller.PollOnce(context.Background())
+
+	if metrics.behind["tenant-a"] != 0 {
+		t.Fatalf("behind target for an uncached tenant = %v, want 0", metrics.behind["tenant-a"])
+	}
+}

--- a/deploy/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: cerbos-poc
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/files

--- a/deploy/observability/grafana/provisioning/dashboards/files/ads-and-cerbos-overview.json
+++ b/deploy/observability/grafana/provisioning/dashboards/files/ads-and-cerbos-overview.json
@@ -1,0 +1,148 @@
+{
+  "title": "ADS and Cerbos overview",
+  "uid": "ads-cerbos-overview",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-15m", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Decision request rate by resource/action/outcome",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum by (resource, action, outcome) (rate(ads_decision_requests_total[1m]))",
+          "legendFormat": "{{resource}}/{{action}}/{{outcome}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Decision latency (p50/p95/p99) by resource/action",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le, resource, action) (rate(ads_decision_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{resource}}/{{action}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, resource, action) (rate(ads_decision_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{resource}}/{{action}}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, resource, action) (rate(ads_decision_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99 {{resource}}/{{action}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Cache hit ratio by cache (not aggregated)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "sum by (cache) (rate(ads_cache_hits_total[5m])) / (sum by (cache) (rate(ads_cache_hits_total[5m])) + sum by (cache) (rate(ads_cache_misses_total[5m])))",
+          "legendFormat": "{{cache}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "PostgreSQL cache-miss query latency (p95) by cache",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, cache) (rate(ads_db_cache_miss_query_seconds_bucket[5m])))",
+          "legendFormat": "{{cache}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "PostgreSQL connection-pool saturation",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "targets": [
+        { "expr": "ads_db_pool_acquired_connections", "legendFormat": "acquired" },
+        { "expr": "ads_db_pool_idle_connections", "legendFormat": "idle" },
+        { "expr": "ads_db_pool_max_connections", "legendFormat": "max" }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Kafka consumer lag and invalidation/revocation latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "targets": [
+        { "expr": "ads_kafka_consumer_lag", "legendFormat": "consumer lag" },
+        {
+          "expr": "histogram_quantile(0.95, rate(ads_invalidation_processing_seconds_bucket[5m]))",
+          "legendFormat": "p95 invalidation latency"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(ads_revocation_latency_seconds_bucket[5m]))",
+          "legendFormat": "p95 revocation latency"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Permission revision by tenant: cached vs actual",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        { "expr": "ads_permission_revision_cached", "legendFormat": "cached {{tenant}}" },
+        { "expr": "ads_permission_revision_actual", "legendFormat": "actual {{tenant}}" }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Stale-revision duration and replicas behind target",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "targets": [
+        { "expr": "ads_stale_revision_seconds", "legendFormat": "stale seconds {{tenant}}" },
+        { "expr": "sum by (tenant) (ads_replica_behind_target)", "legendFormat": "replicas behind {{tenant}}" }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Current root policy revision",
+      "type": "table",
+      "gridPos": { "h": 4, "w": 12, "x": 0, "y": 32 },
+      "targets": [{ "expr": "ads_root_policy_revision_info", "legendFormat": "{{revision}}" }]
+    },
+    {
+      "id": 10,
+      "title": "Cerbos process CPU and memory",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 36 },
+      "targets": [
+        { "expr": "rate(process_cpu_seconds_total{job=\"cerbos\"}[1m])", "legendFormat": "CPU seconds/sec" },
+        { "expr": "process_resident_memory_bytes{job=\"cerbos\"}", "legendFormat": "resident memory" }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "Cerbos gRPC request rate and latency (engine time)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 36 },
+      "targets": [
+        {
+          "expr": "sum by (rpc_method, rpc_grpc_status_code) (rate(rpc_server_requests_per_rpc_count{job=\"cerbos\"}[1m]))",
+          "legendFormat": "{{rpc_method}}/{{rpc_grpc_status_code}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(cerbos_dev_engine_check_latency_milliseconds_bucket{job=\"cerbos\"}[5m])))",
+          "legendFormat": "p95 engine check latency (ms)"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/observability/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deploy/observability/prometheus.yml
+++ b/deploy/observability/prometheus.yml
@@ -1,0 +1,26 @@
+# Scrape config for the observability compose profile (issue #23, §17.1).
+#
+# Every target here already runs unauthenticated on the internal compose
+# network - the same trust boundary every other internal-only endpoint in
+# this topology relies on (§16.1). Nothing here is published to the host
+# except Prometheus and Grafana themselves.
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  # apps/ads/internal/adsmetrics: decision rate/outcome/latency by
+  # resource and action, per-cache hit ratio, DB cache-miss query latency
+  # and pool saturation, and the revision gauges.
+  # apps/ads/internal/invalidationmetrics: Kafka consumer lag and
+  # invalidation/revocation latency (issue #14).
+  - job_name: ads
+    static_configs:
+      - targets: ["ads:8080"]
+
+  # Cerbos's own built-in Prometheus endpoint: request rate, engine
+  # latency, error rate, and the standard Go process CPU/memory metrics.
+  - job_name: cerbos
+    metrics_path: /_cerbos/metrics
+    static_configs:
+      - targets: ["cerbos:3592"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -441,8 +441,54 @@ services:
       timeout: 5s
       retries: 20
 
+  # Prometheus and Grafana behind the `observability` profile (issue #23,
+  # §17.1): scrapes the ADS's own metrics and Cerbos's built-in
+  # /_cerbos/metrics endpoint, on the internal compose network only -
+  # neither target is ever published to the host.
+  prometheus:
+    image: docker.io/prom/prometheus:v2.55.1
+    profiles:
+      - observability
+    volumes:
+      - ./deploy/observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:9090/-/healthy"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  grafana:
+    image: docker.io/grafana/grafana:11.3.1
+    profiles:
+      - observability
+    environment:
+      # A fixed dev credential inside the operator's own compose network,
+      # the same pattern as every other service's default password here
+      # (§14.4: never exposed through ingress).
+      GF_SECURITY_ADMIN_USER: "admin"
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:-change-me}"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+    volumes:
+      - ./deploy/observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "${GRAFANA_PORT:-3002}:3000"
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:3000/api/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
 volumes:
   postgres-data:
   gitea-data:
   policy-release-store:
   policy-release-archives:
+  prometheus-data:
+  grafana-data:

--- a/libs/assignmentstore/postgresstore/postgresstore.go
+++ b/libs/assignmentstore/postgresstore/postgresstore.go
@@ -44,6 +44,13 @@ func (s *Store) Close() error {
 	return nil
 }
 
+// PoolStats reports the pool's current connection saturation (§17.1's
+// "PostgreSQL... connection-pool saturation").
+func (s *Store) PoolStats() (acquired, idle, max int32) {
+	stat := s.pool.Stat()
+	return stat.AcquiredConns(), stat.IdleConns(), stat.MaxConns()
+}
+
 // Schema reports the shape of the migrated schema.
 func (s *Store) Schema() assignmentstore.SchemaInspector {
 	return inspector{pool: s.pool}


### PR DESCRIPTION
## What changed

Implements the §17.1/§17.2 observability surface behind a new `observability`
docker-compose profile:

- `apps/ads/internal/adsmetrics`: Prometheus collectors for decision
  request rate/outcome/latency by resource and action, per-cache hit
  ratio (role permissions and user overrides reported separately, not
  aggregated), database cache-miss query latency and connection-pool
  saturation, and permission/root-policy revision gauges including
  stale-revision duration and replicas-behind-target.
- `apps/ads/internal/invalidationmetrics`: invalidation processing
  latency, revocation latency (measured separately per §10.3), and Kafka
  consumer lag.
- `apps/ads/internal/revisionmetrics`: a poller that keeps the revision
  gauges current independently of the cache-invalidation reconciler.
- `apps/ads/internal/authz`: enriched decision-audit logging carrying the
  application correlation ID, `cerbosCallId`, permission revisions and
  matched IdP role IDs — no resource attribute or clinical value is
  logged.
- `apps/ads/cmd/ads/main.go`: wires all of the above into the ADS binary
  and exposes them on `GET /metrics`.
- `deploy/observability/prometheus.yml` and
  `deploy/observability/grafana/provisioning/...`: a Prometheus scrape
  config for the `ads` and `cerbos` (Cerbos's own built-in `/metrics`)
  targets, and a provisioned Grafana datasource plus the
  "ADS and Cerbos overview" dashboard.
- `docker-compose.yml` / `Makefile`: the `observability` compose profile
  (`make observability-up` / `make observability-down`).

## Acceptance criteria

- [x] Every metric listed in §17.1 is exported and visible in Grafana —
      all panels query live series (verified below).
- [x] Cerbos engine time is measured separately from network and ADS
      cache time — Cerbos's own `cerbos_dev_engine_check_latency_milliseconds`
      is scraped independently of `ads_decision_duration_seconds` (ADS's
      own network+cache+PDP-call latency) and of gRPC's
      `rpc_server_duration_milliseconds`.
- [x] A decision can be reconstructed end-to-end from logs using the
      correlation ID and `cerbosCallId` — see `authz.go`'s decision log
      line, which also carries permission/root-policy revisions and
      matched role IDs.
- [x] Cache hit ratio is exported per cache, not as a single aggregate —
      `ads_cache_hits_total`/`ads_cache_misses_total` are labeled by
      `cache` (`role_permissions`, `user_overrides`).
- [x] Stale-revision duration and replicas-behind-target are exported
      and alertable — `ads_stale_revision_seconds`,
      `ads_replica_behind_target`.
- [x] Request payload logging is disabled by default — no handler in
      the ADS logs a request body; the decision log only carries IDs and
      revisions.
- [x] No patient names, diagnoses or free-text clinical data appear in
      any decision audit record — the decision log records only
      principal/tenant/resource identifiers and revisions, never resource
      attributes.
- [x] Dashboards render correctly under load with no missing series —
      verified against real decision traffic (below).

## How it was verified

- `bash scripts/go.sh apps/ads build ./...` and
  `bash scripts/go.sh apps/ads test ./...` — clean build, all packages
  green.
- Brought up the full stack with `make up`, seeded it with `make seed`,
  started the profile with `make observability-up`, then generated
  decision traffic with 31 runs of `scripts/tests/decision-e2e.sh`.
- Confirmed both Prometheus scrape targets (`ads`, `cerbos`) report
  `health: up`.
- Queried every panel expression in
  `deploy/observability/grafana/provisioning/dashboards/files/ads-and-cerbos-overview.json`
  directly against the Prometheus HTTP API: all 12 panels returned
  non-empty result sets (decision rate/latency by resource+action,
  per-cache hit ratio, DB query latency/pool saturation, Kafka lag and
  invalidation/revocation latency, revision gauges, stale-revision/
  replicas-behind-target, root policy revision, Cerbos process CPU/mem,
  Cerbos gRPC rate/latency and engine-check latency).
- Confirmed via the Grafana API (`/api/search`, `/api/datasources`) that
  the dashboard and the Prometheus datasource are correctly provisioned.


Closes #23
