### PR TITLE
k6 load suite at 1,000 virtual users with section 15.3 thresholds (#25)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ export PATH := $(CURDIR)/scripts/bin:$(PATH)
 COMPOSE ?= docker compose
 NX ?= npx nx
 PROFILE ?= demo
+# `make loadtest` defaults to the full §15 population, unlike loadtest-seed's
+# own demo default, because the whole point of this target is the 1,000-VU
+# measurement; pass LOADTEST_PROFILE=demo to exercise the harness itself.
+LOADTEST_PROFILE ?= load
 
 .DEFAULT_GOAL := help
 
@@ -72,6 +76,9 @@ ci: ## Run exactly what CI runs, so a green local run means a green pipeline
 	$(MAKE) policy-test
 	python3 scripts/tests/compose-contract.py
 	bash scripts/tests/nx-affected-isolation.sh
+	bash scripts/tests/loadtest-preflight-test.sh
+	bash scripts/tests/loadtest-k6-config-test.sh
+	bash scripts/tests/loadtest-run-test.sh
 
 .PHONY: migrate
 migrate: ## Apply the authorization schema to PostgreSQL
@@ -114,6 +121,13 @@ loadtest-seed: ## Seed the load-test population (issue #24); PROFILE=demo|load, 
 loadtest-down: ## Stop the loadtest profile's services only, leaving the rest of the stack up
 	$(COMPOSE) --profile loadtest stop keycloak-db keycloak-loadtest
 	$(COMPOSE) --profile loadtest rm -f keycloak-db keycloak-loadtest
+
+.PHONY: loadtest
+loadtest: ## Full §15.3 k6 run at 1,000 VUs from a clean state (issue #25); LOADTEST_PROFILE=demo for a small smoke run
+	bash scripts/loadtest-preflight.sh
+	$(MAKE) up
+	$(MAKE) loadtest-seed PROFILE=$(LOADTEST_PROFILE)
+	bash scripts/loadtest-run.sh
 
 .PHONY: seed
 seed: ## Write the demo role matrix into the authorization database

--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ The Nx graph spans both languages, but the projects stay independent: a change
 under `apps/admin-console` never marks the Go service as affected.
 `scripts/tests/nx-affected-isolation.sh` asserts exactly that, and CI runs it.
 
+## Load testing
+
+`make loadtest` runs the §15.3 k6 suite (`deploy/loadtest/k6`) at 1,000
+concurrent virtual users against a freshly seeded, full-scale (600,000-user)
+population: `scripts/loadtest-preflight.sh` refuses on an under-resourced
+host, `make up` brings the stack to a clean state, `loadtest-seed` bulk-loads
+the population, and `scripts/loadtest-run.sh` runs the suite and writes
+results to `dist/loadtest-results/<timestamp>-<git-sha>/`. The §15.3
+objectives (warm decision latency, permission convergence, fail-closed) are
+k6 `thresholds`, so a breach exits non-zero.
+
+```bash
+make loadtest                       # the full 1,000-VU run
+make loadtest LOADTEST_PROFILE=demo # exercise the harness against the small demo population
+```
+
+**This suite is marked HITL** (issue #25): the threshold values encode
+§15.3's suggested targets, but they will likely need renegotiating against
+the first real measurements taken on real hardware.
+
 ## Architectural constraints
 
 Permission precedence — mandatory deny beats user revoke beats user grant beats

--- a/deploy/loadtest/k6/lib/auth.js
+++ b/deploy/loadtest/k6/lib/auth.js
@@ -1,0 +1,78 @@
+// Token acquisition and refresh-token rotation (§15: "each VU performs one
+// password grant at start, then refresh-token rotation"). Every scenario
+// shares this so identity cost is exactly one password grant per VU, ever -
+// everything after that is a refresh, exactly like the token-baseline
+// scenario measures in isolation.
+import http from 'k6/http';
+import { check } from 'k6';
+import { KEYCLOAK_URL, REALM, CLIENT_ID, PASSWORD, TOKEN_REUSE_SECONDS } from './config.js';
+
+const TOKEN_URL = `${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/token`;
+
+// passwordGrant exchanges a username/password for a token pair. Called
+// exactly once per VU per scenario (in that scenario's setup/first
+// iteration), never per request.
+export function passwordGrant(username) {
+  const res = http.post(
+    TOKEN_URL,
+    {
+      grant_type: 'password',
+      client_id: CLIENT_ID,
+      username,
+      password: PASSWORD,
+    },
+    { tags: { name: 'token_password_grant' } }
+  );
+  check(res, { 'password grant returned a token': (r) => r.status === 200 && !!r.json('access_token') });
+  return tokenSetFrom(res);
+}
+
+// refreshGrant rotates a refresh token for a new token pair without a
+// password round trip.
+export function refreshGrant(refreshToken) {
+  const res = http.post(
+    TOKEN_URL,
+    {
+      grant_type: 'refresh_token',
+      client_id: CLIENT_ID,
+      refresh_token: refreshToken,
+    },
+    { tags: { name: 'token_refresh_grant' } }
+  );
+  check(res, { 'refresh grant returned a token': (r) => r.status === 200 && !!r.json('access_token') });
+  return tokenSetFrom(res);
+}
+
+function tokenSetFrom(res) {
+  if (res.status !== 200) {
+    return null;
+  }
+  const body = res.json();
+  return {
+    accessToken: body.access_token,
+    refreshToken: body.refresh_token,
+    obtainedAt: Date.now(),
+    expiresInSeconds: body.expires_in,
+  };
+}
+
+// ensureFreshToken returns a token set for `username`, minting one with a
+// password grant on first use and rotating it with a refresh grant once it
+// is within TOKEN_REUSE_SECONDS of expiry - the "refresh is a small fraction
+// of request volume" property, driven by the real per-VU call rate rather
+// than a fixed schedule.
+export function ensureFreshToken(username, current) {
+  if (!current) {
+    return passwordGrant(username);
+  }
+  const ageSeconds = (Date.now() - current.obtainedAt) / 1000;
+  if (ageSeconds < current.expiresInSeconds - TOKEN_REUSE_SECONDS) {
+    return current;
+  }
+  const refreshed = refreshGrant(current.refreshToken);
+  return refreshed || passwordGrant(username);
+}
+
+export function authHeader(tokenSet) {
+  return { Authorization: `Bearer ${tokenSet.accessToken}` };
+}

--- a/deploy/loadtest/k6/lib/config.js
+++ b/deploy/loadtest/k6/lib/config.js
@@ -1,0 +1,81 @@
+// Environment-derived configuration for the §15.3 k6 load suite (issue #25).
+// Every value has a load-profile-shaped default so `make loadtest` needs no
+// extra flags, but every value is overridable so the harness itself can be
+// exercised against the small demo profile (scripts/loadtest-seed.sh demo).
+
+// Where the business endpoints live. The Admin Console's nginx proxies both
+// the ADS (`/api/ads/...`) and the Administration Service (`/api/admin/...`)
+// exactly like a real browser session (apps/admin-console/nginx.conf.template),
+// so the load suite never talks to either backend directly.
+export const BASE_URL = __ENV.LOADTEST_BASE_URL || 'http://ads:8080';
+export const ADMIN_SERVICE_URL = __ENV.LOADTEST_ADMIN_SERVICE_URL || 'http://admin-service:8081';
+
+// The load-test identity provider (issue #24), not the demo Keycloak: the
+// full population only exists there.
+export const KEYCLOAK_URL = __ENV.LOADTEST_KEYCLOAK_URL || 'http://keycloak-loadtest:8080';
+export const REALM = __ENV.LOADTEST_REALM || 'cerbos-poc-loadtest';
+export const CLIENT_ID = __ENV.LOADTEST_CLIENT_ID || 'patient-app';
+export const PASSWORD = __ENV.LOADTEST_PASSWORD || 'Load-Test-Only-P@ss1';
+
+// libs/loadmodel.FullLoadConfig: 600,000 users named load-user-0000000
+// through load-user-0599999 (libs/loadmodel.loadmodel.go's Username format).
+export const TOTAL_LOAD_USERS = Number(__ENV.LOADTEST_TOTAL_USERS || 600000);
+export const USERNAME_PREFIX = __ENV.LOADTEST_USERNAME_PREFIX || 'load-user-';
+export const USERNAME_DIGITS = Number(__ENV.LOADTEST_USERNAME_DIGITS || 7);
+
+export const TENANT_ID = __ENV.LOADTEST_TENANT_ID || 'tenant-0';
+export const HOSPITAL_ID = __ENV.LOADTEST_HOSPITAL_ID || 'hospital-0-0';
+
+// The role matrix row the mutation-convergence scenario flips mid-run
+// (§10, §15.3's "permission convergence" objective).
+export const MUTATION_ROLE = __ENV.LOADTEST_MUTATION_ROLE || 'canonical-role-0000';
+export const MUTATION_RESOURCE = __ENV.LOADTEST_MUTATION_RESOURCE || 'patient_record';
+export const MUTATION_ACTION = __ENV.LOADTEST_MUTATION_ACTION || 'read';
+
+// §15.3: "sustain 1,000 concurrent virtual users". Split across the scenario
+// mix (§12.7's three snapshot shapes, the business endpoint, the token
+// baseline and the mutation scenario) so the *sum* sustains the target
+// rather than each scenario individually chasing it.
+export const VUS = {
+  businessAuthz: Number(__ENV.LOADTEST_VUS_BUSINESS || 600),
+  capabilityModule: Number(__ENV.LOADTEST_VUS_MODULE || 100),
+  capabilityInstance: Number(__ENV.LOADTEST_VUS_INSTANCE || 100),
+  capabilityRow: Number(__ENV.LOADTEST_VUS_ROW || 100),
+  tokenBaseline: Number(__ENV.LOADTEST_VUS_TOKEN || 70),
+  mutationConvergence: Number(__ENV.LOADTEST_VUS_MUTATION || 30),
+};
+
+export const TOTAL_VUS = Object.values(VUS).reduce((sum, n) => sum + n, 0);
+
+// Ramp-up, steady state and ramp-down (§15: "defined ramp-up, steady state
+// and ramp-down").
+export const RAMP_UP = __ENV.LOADTEST_RAMP_UP || '2m';
+export const STEADY_STATE = __ENV.LOADTEST_STEADY_STATE || '5m';
+export const RAMP_DOWN = __ENV.LOADTEST_RAMP_DOWN || '1m';
+
+// Access token lifespan tuned so refresh-token rotation is a small fraction
+// of request volume (§15: "identity provider is not the bottleneck"). A VU
+// refreshes once its token is within this many seconds of the realm's
+// configured access-token lifespan; the realm itself controls the real
+// expiry, this only bounds how long one VU keeps reusing a token before
+// asking again.
+export const TOKEN_REUSE_SECONDS = Number(__ENV.LOADTEST_TOKEN_REUSE_SECONDS || 240);
+
+// stagesFor builds the ramping-vus executor stages one scenario needs to
+// reach `target` and hold it for the steady state, shared so every scenario
+// ramps and drains on the same schedule.
+export function stagesFor(target) {
+  return [
+    { duration: RAMP_UP, target },
+    { duration: STEADY_STATE, target },
+    { duration: RAMP_DOWN, target: 0 },
+  ];
+}
+
+// usernameFor derives one deterministic load-model username from a
+// scenario-scoped counter, matching libs/loadmodel's `load-user-%07d`
+// format so every request authenticates as a user the seed actually wrote.
+export function usernameFor(counter) {
+  const index = counter % TOTAL_LOAD_USERS;
+  return USERNAME_PREFIX + String(index).padStart(USERNAME_DIGITS, '0');
+}

--- a/deploy/loadtest/k6/lib/identity.js
+++ b/deploy/loadtest/k6/lib/identity.js
@@ -1,0 +1,11 @@
+// Deterministic per-VU identity, shared by every scenario so the same VU
+// always authenticates as the same load-model user for the run's duration
+// (one password grant per VU, per §15).
+import { usernameFor } from './config.js';
+
+// __VU is unique across every active VU in the run, including across
+// scenarios executing concurrently, so this never collides between the
+// business, capability and token-baseline scenario pools.
+export function usernameForVU() {
+  return usernameFor(__VU);
+}

--- a/deploy/loadtest/k6/lib/metrics.js
+++ b/deploy/loadtest/k6/lib/metrics.js
@@ -1,0 +1,36 @@
+// Custom metrics the §15.3 thresholds are enforced against, plus the
+// §17.1 attribution metrics (issue #25 acceptance criterion: "observed
+// bottlenecks are identified by component using the exported metrics").
+import { Trend, Counter } from 'k6/metrics';
+
+// Warm decision latency: the ADS's own decision endpoint only, never
+// including a token grant/refresh call, so this measures exactly what
+// §15.1's hot path measures (backend -> ADS cache -> Cerbos gRPC -> backend).
+export const warmDecisionLatency = new Trend('warm_decision_latency_ms', true);
+
+// Permission convergence: time from a mid-run mutation's write commit to the
+// first authz decision that reflects it, on a healthy ADS replica.
+export const permissionConvergenceLatency = new Trend('permission_convergence_ms', true);
+
+// Revocation is a mutation too (a permission going from enabled to
+// disabled); tracked separately because §15.3 names both and a suite that
+// only ever tests grants could hide a revocation-specific bug.
+export const revocationConvergenceLatency = new Trend('revocation_convergence_ms', true);
+
+// §15.3 "fail closed": incremented only if a scenario's own code proceeds to
+// simulate a business operation without having received an explicit allow
+// first. Every scenario below gates its simulated write behind the decision
+// it just received, so a non-zero count here is a defect in this harness or
+// the system under test, never a benign outcome.
+export const businessOpWithoutAllow = new Counter('business_op_without_allow');
+
+// Per-component attribution (§15.2, §17.1): the ADS reports its own cache
+// hit ratio and Cerbos engine time on /metrics (apps/ads/internal/adsmetrics),
+// scraped by Prometheus during the run rather than measured here - these
+// counters instead attribute where *this suite* spent time, so a scrape-side
+// dashboard and this suite's own summary agree on which endpoint was asked.
+export const businessAuthzRequests = new Counter('scenario_business_authz_requests');
+export const capabilityModuleRequests = new Counter('scenario_capability_module_requests');
+export const capabilityInstanceRequests = new Counter('scenario_capability_instance_requests');
+export const capabilityRowRequests = new Counter('scenario_capability_row_requests');
+export const tokenBaselineRequests = new Counter('scenario_token_baseline_requests');

--- a/deploy/loadtest/k6/main.js
+++ b/deploy/loadtest/k6/main.js
@@ -1,0 +1,106 @@
+// The §15.3 k6 load suite (issue #25): 1,000 concurrent virtual users,
+// protocol-level only, covering the business endpoint, all three §12.7
+// capability snapshot shapes, a token-endpoint baseline and a mid-run
+// permission-mutation scenario, with the §15.3 objectives enforced as k6
+// thresholds so a run returns a pass/fail verdict.
+//
+//   make loadtest                 - seeds the full population, then runs this
+//   scripts/loadtest-run.sh       - runs this suite alone against a stack
+//                                   already seeded (`PROFILE=load`)
+//
+// Every scenario, VU count, stage duration and target host is in
+// lib/config.js, driven entirely by environment variables so this file
+// never has to change between the demo-population smoke run the harness is
+// exercised with and the full 1,000-VU run.
+import { VUS, TOTAL_VUS, stagesFor } from './lib/config.js';
+import { businessAuthz } from './scenarios/business_authz.js';
+import { capabilityModule } from './scenarios/capability_module.js';
+import { capabilityInstance } from './scenarios/capability_instance.js';
+import { capabilityRow } from './scenarios/capability_row.js';
+import { tokenBaseline } from './scenarios/token_baseline.js';
+import { mutationConvergence } from './scenarios/mutation_convergence.js';
+
+export { businessAuthz, capabilityModule, capabilityInstance, capabilityRow, tokenBaseline, mutationConvergence };
+
+export const options = {
+  scenarios: {
+    business_authz: {
+      executor: 'ramping-vus',
+      exec: 'businessAuthz',
+      startVUs: 0,
+      stages: stagesFor(VUS.businessAuthz),
+    },
+    capability_module: {
+      executor: 'ramping-vus',
+      exec: 'capabilityModule',
+      startVUs: 0,
+      stages: stagesFor(VUS.capabilityModule),
+    },
+    capability_instance: {
+      executor: 'ramping-vus',
+      exec: 'capabilityInstance',
+      startVUs: 0,
+      stages: stagesFor(VUS.capabilityInstance),
+    },
+    capability_row: {
+      executor: 'ramping-vus',
+      exec: 'capabilityRow',
+      startVUs: 0,
+      stages: stagesFor(VUS.capabilityRow),
+    },
+    token_baseline: {
+      executor: 'ramping-vus',
+      exec: 'tokenBaseline',
+      startVUs: 0,
+      stages: stagesFor(VUS.tokenBaseline),
+    },
+    mutation_convergence: {
+      executor: 'ramping-vus',
+      exec: 'mutationConvergence',
+      startVUs: 0,
+      stages: stagesFor(VUS.mutationConvergence),
+    },
+  },
+  thresholds: {
+    // §15.3: warm decision latency, measured on the ADS decision endpoint
+    // only (lib/metrics.js's warmDecisionLatency), never including a token
+    // grant or refresh call.
+    warm_decision_latency_ms: ['p(95)<15', 'p(99)<30'],
+    // §15.3: 99% of committed permission updates visible within 5 seconds.
+    permission_convergence_ms: ['p(99)<5000'],
+    revocation_convergence_ms: ['p(99)<5000'],
+    // §15.3: no business operation proceeds without an explicit allow.
+    business_op_without_allow: ['count==0'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+};
+
+// Logged once at the top of every run so `make loadtest`'s own console
+// output states the target concurrency without needing the summary.
+export function setup() {
+  console.log(`loadtest: targeting ${TOTAL_VUS} concurrent virtual users across ${Object.keys(VUS).length} scenarios`);
+}
+
+// handleSummary prints the sizing outputs issue #25 asks for (achieved
+// throughput, latency distribution and the objectives' pass/fail state)
+// alongside k6's own summary. The full result set is written by the
+// `--summary-export` flag scripts/loadtest-run.sh passes, into the versioned
+// results directory that script builds - never a path this file hardcodes,
+// so the same script works unchanged whether it runs against a live stack
+// or under `k6 inspect`, which never calls handleSummary at all.
+export function handleSummary(data) {
+  return {
+    stdout: JSON.stringify(summarize(data), null, 2),
+  };
+}
+
+function summarize(data) {
+  const metrics = data.metrics || {};
+  const pick = (name, stat) => (metrics[name] && metrics[name].values ? metrics[name].values[stat] : undefined);
+  return {
+    warmDecisionLatencyMs: { p95: pick('warm_decision_latency_ms', 'p(95)'), p99: pick('warm_decision_latency_ms', 'p(99)') },
+    permissionConvergenceMs: { p99: pick('permission_convergence_ms', 'p(99)') },
+    revocationConvergenceMs: { p99: pick('revocation_convergence_ms', 'p(99)') },
+    businessOpsWithoutAllow: pick('business_op_without_allow', 'count'),
+  };
+}

--- a/deploy/loadtest/k6/scenarios/business_authz.js
+++ b/deploy/loadtest/k6/scenarios/business_authz.js
@@ -1,0 +1,58 @@
+// Scenario: business endpoint authorization (§12.7's "Backend operation"
+// row) - the POST /internal/authz/check path every write and read API calls
+// on every request, exercised here exactly the way apps/ads/internal/authz
+// serves it.
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { BASE_URL, TENANT_ID, HOSPITAL_ID } from '../lib/config.js';
+import { ensureFreshToken, authHeader } from '../lib/auth.js';
+import { warmDecisionLatency, businessOpWithoutAllow, businessAuthzRequests } from '../lib/metrics.js';
+import { usernameForVU } from '../lib/identity.js';
+
+// Each VU is its own JS VM instance in k6, so this module-level state is
+// already per-VU - no VU-indexed map is needed.
+let tokenSet = null;
+
+export function businessAuthz() {
+  const username = usernameForVU();
+  tokenSet = ensureFreshToken(username, tokenSet);
+  if (!tokenSet) {
+    sleep(1);
+    return;
+  }
+
+  const payload = JSON.stringify({
+    resources: [
+      {
+        kind: 'patient_record',
+        id: `loadtest-patient-${__VU}`,
+        attributes: { tenantId: TENANT_ID, hospitalId: HOSPITAL_ID, status: 'ACTIVE' },
+        actions: ['read'],
+      },
+    ],
+  });
+
+  const res = http.post(`${BASE_URL}/internal/authz/check`, payload, {
+    headers: { 'Content-Type': 'application/json', ...authHeader(tokenSet) },
+    tags: { name: 'business_authz_check' },
+  });
+  businessAuthzRequests.add(1);
+
+  const ok = check(res, { 'business authz check answered 200': (r) => r.status === 200 });
+  if (ok) {
+    warmDecisionLatency.add(res.timings.duration);
+    const allowed = res.json('resources.0.actions.read.allowed');
+    // §15.3 fail-closed, enforced as code rather than only asserted: the
+    // simulated business read only ever "proceeds" inside this branch, so a
+    // proceed without an explicit allow is structurally impossible unless
+    // this gate itself is broken - the case businessOpWithoutAllow exists to
+    // catch.
+    if (allowed === true) {
+      // The business read proceeds here in a real caller.
+    } else if (allowed !== false) {
+      businessOpWithoutAllow.add(1);
+    }
+  }
+
+  sleep(1);
+}

--- a/deploy/loadtest/k6/scenarios/capability_instance.js
+++ b/deploy/loadtest/k6/scenarios/capability_instance.js
@@ -1,0 +1,35 @@
+// Scenario: instance composite capability snapshot (§12.7's "Instance
+// composite" row) - fetched once per page-resource load, reused across
+// child routes and tabs.
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { BASE_URL } from '../lib/config.js';
+import { ensureFreshToken, authHeader } from '../lib/auth.js';
+import { capabilityInstanceRequests } from '../lib/metrics.js';
+import { usernameForVU } from '../lib/identity.js';
+
+let tokenSet = null;
+
+export function capabilityInstance() {
+  const username = usernameForVU();
+  tokenSet = ensureFreshToken(username, tokenSet);
+  if (!tokenSet) {
+    sleep(1);
+    return;
+  }
+
+  const payload = JSON.stringify({
+    module: 'financial',
+    capabilityKeys: ['account.route.edit'],
+    context: { accountId: `loadtest-account-${__VU}` },
+  });
+
+  const res = http.post(`${BASE_URL}/internal/capabilities/evaluate`, payload, {
+    headers: { 'Content-Type': 'application/json', ...authHeader(tokenSet) },
+    tags: { name: 'capability_instance_snapshot' },
+  });
+  capabilityInstanceRequests.add(1);
+
+  check(res, { 'instance snapshot answered 200': (r) => r.status === 200 });
+  sleep(3);
+}

--- a/deploy/loadtest/k6/scenarios/capability_module.js
+++ b/deploy/loadtest/k6/scenarios/capability_module.js
@@ -1,0 +1,35 @@
+// Scenario: module/collection composite capability snapshot (§12.7's
+// "Module/collection composite" row) - loaded at login, tenant switch or
+// hospital switch, never per navigation.
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { BASE_URL } from '../lib/config.js';
+import { ensureFreshToken, authHeader } from '../lib/auth.js';
+import { capabilityModuleRequests } from '../lib/metrics.js';
+import { usernameForVU } from '../lib/identity.js';
+
+let tokenSet = null;
+
+export function capabilityModule() {
+  const username = usernameForVU();
+  tokenSet = ensureFreshToken(username, tokenSet);
+  if (!tokenSet) {
+    sleep(1);
+    return;
+  }
+
+  const payload = JSON.stringify({
+    module: 'financial',
+    capabilityKeys: ['account.route.list'],
+    context: {},
+  });
+
+  const res = http.post(`${BASE_URL}/internal/capabilities/evaluate`, payload, {
+    headers: { 'Content-Type': 'application/json', ...authHeader(tokenSet) },
+    tags: { name: 'capability_module_snapshot' },
+  });
+  capabilityModuleRequests.add(1);
+
+  check(res, { 'module snapshot answered 200': (r) => r.status === 200 });
+  sleep(2);
+}

--- a/deploy/loadtest/k6/scenarios/capability_row.js
+++ b/deploy/loadtest/k6/scenarios/capability_row.js
@@ -1,0 +1,36 @@
+// Scenario: row-level composite capability snapshot (§12.7's "Row-level
+// composite" row) - one call renders a row's whole menu (read plus every
+// workflow action) instead of N browser calls, so this scenario requests
+// every row-menu capability for one instance in a single batch.
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { BASE_URL } from '../lib/config.js';
+import { ensureFreshToken, authHeader } from '../lib/auth.js';
+import { capabilityRowRequests } from '../lib/metrics.js';
+import { usernameForVU } from '../lib/identity.js';
+
+let tokenSet = null;
+
+export function capabilityRow() {
+  const username = usernameForVU();
+  tokenSet = ensureFreshToken(username, tokenSet);
+  if (!tokenSet) {
+    sleep(1);
+    return;
+  }
+
+  const payload = JSON.stringify({
+    module: 'financial',
+    capabilityKeys: ['account.action.delete', 'account.button.assign'],
+    context: { accountId: `loadtest-account-${__VU}` },
+  });
+
+  const res = http.post(`${BASE_URL}/internal/capabilities/evaluate`, payload, {
+    headers: { 'Content-Type': 'application/json', ...authHeader(tokenSet) },
+    tags: { name: 'capability_row_snapshot' },
+  });
+  capabilityRowRequests.add(1);
+
+  check(res, { 'row snapshot answered 200': (r) => r.status === 200 });
+  sleep(2);
+}

--- a/deploy/loadtest/k6/scenarios/mutation_convergence.js
+++ b/deploy/loadtest/k6/scenarios/mutation_convergence.js
@@ -1,0 +1,127 @@
+// Scenario: mid-run permission mutation and convergence/revocation latency
+// (§15.3: "99% of committed permission updates visible on healthy ADS
+// replicas within 5 seconds", measured under load rather than only at rest).
+//
+// Each iteration flips one role permission's `enabled` flag through the
+// Administration Service, then polls the ADS decision endpoint - as the
+// probe user libs/loadmodel deterministically assigns that role to - until
+// the decision reflects the flip, recording the time between the two.
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import {
+  ADMIN_SERVICE_URL,
+  BASE_URL,
+  TENANT_ID,
+  HOSPITAL_ID,
+  MUTATION_ROLE,
+  MUTATION_RESOURCE,
+  MUTATION_ACTION,
+} from '../lib/config.js';
+import { ensureFreshToken, authHeader } from '../lib/auth.js';
+import { permissionConvergenceLatency, revocationConvergenceLatency } from '../lib/metrics.js';
+import { usernameFor } from '../lib/config.js';
+
+// libs/loadmodel assigns canonical role index 0 - MUTATION_ROLE's default -
+// to user index 0 by construction (role step 7, j=0 selects role index 0),
+// so this probe user is deterministic without a directory lookup.
+const PROBE_USER = usernameFor(0);
+const POLL_TIMEOUT_MS = 10000;
+const POLL_INTERVAL_MS = 200;
+
+let adminTokenSet = null;
+let probeTokenSet = null;
+
+export function mutationConvergence() {
+  adminTokenSet = ensureFreshToken(PROBE_USER, adminTokenSet);
+  probeTokenSet = ensureFreshToken(PROBE_USER, probeTokenSet);
+  if (!adminTokenSet || !probeTokenSet) {
+    sleep(2);
+    return;
+  }
+
+  const readRes = http.get(
+    `${ADMIN_SERVICE_URL}/admin/authz/tenants/${TENANT_ID}/roles/${MUTATION_ROLE}/permissions`,
+    { headers: authHeader(adminTokenSet), tags: { name: 'mutation_read_permissions' } }
+  );
+  if (!check(readRes, { 'reading the role matrix answered 200': (r) => r.status === 200 })) {
+    sleep(2);
+    return;
+  }
+
+  const body = readRes.json();
+  const revision = body.revision;
+  const permissions = body.permissions || [];
+  const existing = permissions.find(
+    (p) => p.resourceKey === MUTATION_RESOURCE && p.actionKey === MUTATION_ACTION
+  );
+  const wasEnabled = existing ? existing.enabled : false;
+  const nextEnabled = !wasEnabled;
+
+  const writeRes = http.put(
+    `${ADMIN_SERVICE_URL}/admin/authz/tenants/${TENANT_ID}/roles/${MUTATION_ROLE}/permissions`,
+    JSON.stringify({
+      expectedRevision: revision,
+      permissions: [
+        {
+          resourceKey: MUTATION_RESOURCE,
+          actionKey: MUTATION_ACTION,
+          enabled: nextEnabled,
+          validFrom: new Date().toISOString(),
+        },
+      ],
+    }),
+    {
+      headers: { 'Content-Type': 'application/json', ...authHeader(adminTokenSet) },
+      tags: { name: 'mutation_write_permissions' },
+    }
+  );
+  if (!check(writeRes, { 'writing the mutation answered 200': (r) => r.status === 200 })) {
+    sleep(2);
+    return;
+  }
+
+  const mutatedAt = Date.now();
+  const converged = pollForDecision(nextEnabled);
+  if (converged) {
+    const latencyMs = Date.now() - mutatedAt;
+    if (nextEnabled) {
+      permissionConvergenceLatency.add(latencyMs);
+    } else {
+      revocationConvergenceLatency.add(latencyMs);
+    }
+  }
+  check(converged, { 'the decision converged within the poll window': (c) => c === true });
+
+  sleep(2);
+}
+
+function pollForDecision(expectAllowed) {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const res = http.post(
+      `${BASE_URL}/internal/authz/check`,
+      JSON.stringify({
+        resources: [
+          {
+            kind: MUTATION_RESOURCE,
+            id: 'loadtest-convergence-probe',
+            attributes: { tenantId: TENANT_ID, hospitalId: HOSPITAL_ID, status: 'ACTIVE' },
+            actions: [MUTATION_ACTION],
+          },
+        ],
+      }),
+      {
+        headers: { 'Content-Type': 'application/json', ...authHeader(probeTokenSet) },
+        tags: { name: 'mutation_poll_decision' },
+      }
+    );
+    if (res.status === 200) {
+      const allowed = res.json(`resources.0.actions.${MUTATION_ACTION}.allowed`);
+      if (allowed === expectAllowed) {
+        return true;
+      }
+    }
+    sleep(POLL_INTERVAL_MS / 1000);
+  }
+  return false;
+}

--- a/deploy/loadtest/k6/scenarios/token_baseline.js
+++ b/deploy/loadtest/k6/scenarios/token_baseline.js
@@ -1,0 +1,24 @@
+// Scenario: token endpoint baseline (§15: "a separate scenario that
+// benchmarks the token endpoint alone, so identity cost is attributable and
+// separable from authorization cost"). Every iteration is a fresh password
+// grant against a distinct load-model user - deliberately never a refresh -
+// so this scenario's own latency is exactly Keycloak's password-grant cost,
+// uncontaminated by anything else this suite measures.
+import { passwordGrant } from '../lib/auth.js';
+import { tokenBaselineRequests } from '../lib/metrics.js';
+import { usernameFor } from '../lib/config.js';
+import { sleep } from 'k6';
+
+let counter = 0;
+
+export function tokenBaseline() {
+  // A distinct user per iteration (not just per VU) so the baseline never
+  // degenerates into measuring one cached session.
+  const username = usernameFor(__VU * 1000000 + counter);
+  counter += 1;
+
+  passwordGrant(username);
+  tokenBaselineRequests.add(1);
+
+  sleep(1);
+}

--- a/scripts/k6.sh
+++ b/scripts/k6.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Runs k6 in a container so no host install is needed, the same pattern as
+# scripts/cerbos.sh and scripts/go.sh.
+#
+#   scripts/k6.sh <k6-args...>
+#
+# K6_NETWORK attaches the container to a compose network, needed for `run`
+# against a live stack but not for `inspect`, which only parses the script.
+# K6_RESULTS_DIR, if set, is mounted at /output for --summary-export and
+# handleSummary's own file output.
+set -euo pipefail
+
+DOCKER="${DOCKER:-docker}"
+K6_IMAGE="${K6_IMAGE:-docker.io/grafana/k6:0.54.0}"
+
+if ! command -v "${DOCKER}" >/dev/null 2>&1; then
+  echo "scripts/k6.sh: '${DOCKER}' not found on PATH" >&2
+  exit 127
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+network_args=()
+if [[ -n "${K6_NETWORK:-}" ]]; then
+  network_args=(--network "${K6_NETWORK}")
+fi
+
+results_args=()
+if [[ -n "${K6_RESULTS_DIR:-}" ]]; then
+  mkdir -p "${K6_RESULTS_DIR}"
+  results_args=(-v "$(cd "${K6_RESULTS_DIR}" && pwd):/output:z")
+fi
+
+env_args=()
+for name in ${K6_ENV_PASS:-}; do
+  if [[ -n "${!name:-}" ]]; then
+    env_args+=(-e "${name}=${!name}")
+  fi
+done
+
+exec "${DOCKER}" run --rm \
+  "${network_args[@]}" \
+  "${results_args[@]}" \
+  "${env_args[@]}" \
+  -v "${repo_root}/deploy/loadtest/k6:/scripts:ro,z" \
+  "${K6_IMAGE}" "$@"

--- a/scripts/loadtest-preflight.sh
+++ b/scripts/loadtest-preflight.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Refuses a `make loadtest` run before it starts wasting time on a host that
+# cannot sustain it (§15: "a documented minimum host specification and a
+# preflight check, so that a run either starts valid or refuses clearly").
+#
+#   scripts/loadtest-preflight.sh
+#
+# Reads free memory from /proc/meminfo and free disk from `df` on the
+# repository's own filesystem. Both paths are overridable so the check itself
+# can be tested without depleting the host's real resources:
+#   LOADTEST_PREFLIGHT_MEMINFO   - path to a /proc/meminfo-shaped file
+#   LOADTEST_PREFLIGHT_DISK_PATH - path `df` is run against
+#   LOADTEST_MIN_FREE_MEM_KB     - minimum free+cached memory required
+#   LOADTEST_MIN_FREE_DISK_KB    - minimum free disk required
+set -euo pipefail
+
+# The full §15 load model (600,000 Keycloak users, 42,000,000 role mappings,
+# 1,000 concurrent k6 VUs against the control plane) is the documented
+# minimum this preflight enforces: 8 GiB of free/reclaimable memory and 10 GiB
+# of free disk for the seeded databases, Kafka and the results directory.
+MIN_FREE_MEM_KB="${LOADTEST_MIN_FREE_MEM_KB:-8388608}"
+MIN_FREE_DISK_KB="${LOADTEST_MIN_FREE_DISK_KB:-10485760}"
+
+meminfo_path="${LOADTEST_PREFLIGHT_MEMINFO:-/proc/meminfo}"
+disk_path="${LOADTEST_PREFLIGHT_DISK_PATH:-.}"
+
+if [[ ! -r "${meminfo_path}" ]]; then
+  echo "loadtest-preflight: cannot read ${meminfo_path}" >&2
+  exit 1
+fi
+
+# MemAvailable already accounts for reclaimable cache the kernel would hand
+# back under pressure, which is what the load model actually gets to use.
+free_mem_kb="$(awk '/^MemAvailable:/ {print $2}' "${meminfo_path}")"
+if [[ -z "${free_mem_kb}" ]]; then
+  echo "loadtest-preflight: ${meminfo_path} has no MemAvailable line" >&2
+  exit 1
+fi
+
+free_disk_kb="$(df -Pk "${disk_path}" | awk 'NR==2 {print $4}')"
+if [[ -z "${free_disk_kb}" ]]; then
+  echo "loadtest-preflight: could not read free disk space for ${disk_path}" >&2
+  exit 1
+fi
+
+failures=0
+
+if (( free_mem_kb < MIN_FREE_MEM_KB )); then
+  echo "FAIL available memory ${free_mem_kb}KB is below the ${MIN_FREE_MEM_KB}KB minimum for the §15 load profile" >&2
+  failures=$((failures + 1))
+else
+  echo "ok   available memory ${free_mem_kb}KB meets the ${MIN_FREE_MEM_KB}KB minimum"
+fi
+
+if (( free_disk_kb < MIN_FREE_DISK_KB )); then
+  echo "FAIL free disk ${free_disk_kb}KB is below the ${MIN_FREE_DISK_KB}KB minimum for the §15 load profile" >&2
+  failures=$((failures + 1))
+else
+  echo "ok   free disk ${free_disk_kb}KB meets the ${MIN_FREE_DISK_KB}KB minimum"
+fi
+
+if (( failures > 0 )); then
+  echo
+  echo "loadtest-preflight: refusing to start (${failures} check(s) failed)" >&2
+  exit 1
+fi
+
+echo
+echo "loadtest-preflight: host meets the documented minimum for a full loadtest run"

--- a/scripts/loadtest-run.sh
+++ b/scripts/loadtest-run.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Runs the §15.3 k6 load suite (deploy/loadtest/k6/main.js) against a
+# running, seeded stack and writes the result into a versioned directory
+# tagged with the git SHA and the run's full configuration (§15: "results
+# written to a versioned results directory with the git SHA and
+# configuration, so that numbers remain traceable to what produced them").
+#
+#   scripts/loadtest-run.sh
+#
+# Every LOADTEST_* / K6_* environment variable deploy/loadtest/k6/lib/config.js
+# reads is forwarded into the container and recorded in the results
+# directory's config.json. GO_NETWORK selects the compose network the k6
+# container joins, matching scripts/go.sh and scripts/loadtest-seed.sh.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+if [[ -f "${repo_root}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${repo_root}/.env"
+  set +a
+fi
+
+# The environment variables the k6 scripts themselves read (deploy/loadtest/k6/lib/config.js).
+# Forwarded to the container when set, and always recorded in config.json
+# below (even when unset, so a config.json documents the *default* that
+# applied, not just what the operator overrode).
+LOADTEST_ENV_NAMES=(
+  LOADTEST_BASE_URL LOADTEST_ADMIN_SERVICE_URL LOADTEST_KEYCLOAK_URL LOADTEST_REALM
+  LOADTEST_CLIENT_ID LOADTEST_PASSWORD LOADTEST_TOTAL_USERS LOADTEST_USERNAME_PREFIX
+  LOADTEST_USERNAME_DIGITS LOADTEST_TENANT_ID LOADTEST_HOSPITAL_ID LOADTEST_MUTATION_ROLE
+  LOADTEST_MUTATION_RESOURCE LOADTEST_MUTATION_ACTION LOADTEST_VUS_BUSINESS
+  LOADTEST_VUS_MODULE LOADTEST_VUS_INSTANCE LOADTEST_VUS_ROW LOADTEST_VUS_TOKEN
+  LOADTEST_VUS_MUTATION LOADTEST_RAMP_UP LOADTEST_STEADY_STATE LOADTEST_RAMP_DOWN
+  LOADTEST_TOKEN_REUSE_SECONDS
+)
+
+git_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+results_dir="${LOADTEST_RESULTS_ROOT:-dist/loadtest-results}/${timestamp}-${git_sha}"
+mkdir -p "${results_dir}"
+
+# Build config.json from this run's actual environment: every LOADTEST_*
+# variable that resolved to a value (operator-set or the k6 script's own
+# default, read back from the running suite via `k6 inspect` would be
+# circular, so the operator-visible half - what was actually asked for - is
+# what gets recorded here).
+{
+  echo "{"
+  echo "  \"gitSha\": \"${git_sha}\","
+  echo "  \"timestamp\": \"${timestamp}\","
+  echo "  \"environment\": {"
+  first=true
+  for name in "${LOADTEST_ENV_NAMES[@]}"; do
+    value="${!name:-}"
+    if [[ -n "${value}" ]]; then
+      [[ "${first}" == true ]] && first=false || echo ","
+      printf '    "%s": "%s"' "${name}" "${value}"
+    fi
+  done
+  echo
+  echo "  }"
+  echo "}"
+} >"${results_dir}/config.json"
+
+export K6_NETWORK="${K6_NETWORK:-${GO_NETWORK:-${COMPOSE_PROJECT_NAME:-cerbos-poc}_default}}"
+export K6_ENV_PASS="${LOADTEST_ENV_NAMES[*]}"
+export K6_RESULTS_DIR="${repo_root}/${results_dir}"
+
+K6_SH="${K6_SH:-${repo_root}/scripts/k6.sh}"
+
+echo "--- running the k6 load suite, results in ${results_dir} ---"
+set +e
+bash "${K6_SH}" run \
+  --summary-export=/output/summary.json \
+  /scripts/main.js
+status=$?
+set -e
+
+echo "${status}" >"${results_dir}/exit-code"
+echo "loadtest-run: results written to ${results_dir} (exit ${status})"
+exit "${status}"

--- a/scripts/tests/loadtest-k6-config-test.sh
+++ b/scripts/tests/loadtest-k6-config-test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Behaviour tests for the k6 load suite's structure (issue #25): scenario
+# mix, thresholds and total concurrency. Runs `k6 inspect`, which parses the
+# script's exported `options` without ever making a network call, so this is
+# offline with respect to any running stack - it only needs Docker and the
+# k6 image scripts/k6.sh already pins.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+K6="${repo_root}/scripts/k6.sh"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "loadtest-k6-config-test: docker not found on PATH; skipping" >&2
+  exit 0
+fi
+
+passed=0
+failed=0
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "${expected}" == "${actual}" ]]; then
+    printf 'ok   %s\n' "${name}"
+    passed=$((passed + 1))
+  else
+    printf 'FAIL %s\n     expected: %s\n     actual:   %s\n' "${name}" "${expected}" "${actual}"
+    failed=$((failed + 1))
+  fi
+}
+
+inspect_output="$("${K6}" inspect --execution-requirements /scripts/main.js 2>/dev/null)"
+if [[ -z "${inspect_output}" ]]; then
+  echo "loadtest-k6-config-test: k6 inspect produced no output" >&2
+  exit 1
+fi
+
+check "the run sustains 1,000 concurrent virtual users" \
+  "1000" \
+  "$(jq -r '.maxVUs' <<<"${inspect_output}")"
+
+check "the business endpoint authorization scenario is present" \
+  "true" \
+  "$(jq -r 'has("business_authz")' <<<"$(jq '.scenarios' <<<"${inspect_output}")")"
+
+check "all three capability snapshot shapes are present in the same run" \
+  "capability_instance
+capability_module
+capability_row" \
+  "$(jq -r '.scenarios | keys[]' <<<"${inspect_output}" | grep '^capability_' | sort)"
+
+check "the token endpoint baseline scenario is present" \
+  "true" \
+  "$(jq -r 'has("token_baseline")' <<<"$(jq '.scenarios' <<<"${inspect_output}")")"
+
+check "the mid-run mutation/convergence scenario is present" \
+  "true" \
+  "$(jq -r 'has("mutation_convergence")' <<<"$(jq '.scenarios' <<<"${inspect_output}")")"
+
+check "warm decision latency is enforced at p95<15ms and p99<30ms" \
+  '["p(95)<15","p(99)<30"]' \
+  "$(jq -c '.thresholds.warm_decision_latency_ms' <<<"${inspect_output}")"
+
+check "permission convergence is enforced within 5 seconds at p99" \
+  '["p(99)<5000"]' \
+  "$(jq -c '.thresholds.permission_convergence_ms' <<<"${inspect_output}")"
+
+check "revocation convergence is enforced within 5 seconds at p99" \
+  '["p(99)<5000"]' \
+  "$(jq -c '.thresholds.revocation_convergence_ms' <<<"${inspect_output}")"
+
+check "no business operation proceeding without an explicit allow is a hard threshold" \
+  '["count==0"]' \
+  "$(jq -c '.thresholds.business_op_without_allow' <<<"${inspect_output}")"
+
+check "every scenario defines a ramp-up, steady state and ramp-down" \
+  "true" \
+  "$(jq -r '[.scenarios[].stages | length == 3] | all' <<<"${inspect_output}")"
+
+check "the ramp-down stage always targets zero VUs" \
+  "true" \
+  "$(jq -r '[.scenarios[].stages[-1].target == 0] | all' <<<"${inspect_output}")"
+
+echo
+echo "${passed} passed, ${failed} failed"
+[[ "${failed}" -eq 0 ]]

--- a/scripts/tests/loadtest-preflight-test.sh
+++ b/scripts/tests/loadtest-preflight-test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Behaviour tests for the loadtest host preflight check. Runs entirely
+# offline against fake meminfo/disk paths; never touches the real host's
+# resources or a running stack.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PREFLIGHT="${repo_root}/scripts/loadtest-preflight.sh"
+
+passed=0
+failed=0
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "${expected}" == "${actual}" ]]; then
+    printf 'ok   %s\n' "${name}"
+    passed=$((passed + 1))
+  else
+    printf 'FAIL %s\n     expected: %s\n     actual:   %s\n' "${name}" "${expected}" "${actual}"
+    failed=$((failed + 1))
+  fi
+}
+
+meminfo_with() {
+  local kb="$1"
+  local path="${tmp}/meminfo-${kb}"
+  printf 'MemTotal:       16384000 kB\nMemAvailable:   %s kB\n' "${kb}" >"${path}"
+  printf '%s' "${path}"
+}
+
+# A directory whose free space `df` reports as plenty, for tests that only
+# want to exercise the memory branch.
+roomy_disk="${tmp}"
+
+run_preflight() {
+  LOADTEST_PREFLIGHT_MEMINFO="$1" \
+  LOADTEST_PREFLIGHT_DISK_PATH="$2" \
+  LOADTEST_MIN_FREE_MEM_KB="${3:-8388608}" \
+  LOADTEST_MIN_FREE_DISK_KB="${4:-10485760}" \
+  "${PREFLIGHT}" >/dev/null 2>&1
+  echo "$?"
+}
+
+check "a host with plenty of free memory and disk passes" \
+  "0" \
+  "$(run_preflight "$(meminfo_with 16000000)" "${roomy_disk}")"
+
+check "a host below the memory minimum refuses" \
+  "1" \
+  "$(run_preflight "$(meminfo_with 1000)" "${roomy_disk}")"
+
+check "a host below the disk minimum refuses" \
+  "1" \
+  "$(run_preflight "$(meminfo_with 16000000)" "${roomy_disk}" 8388608 999999999999)"
+
+check "the memory threshold is configurable" \
+  "0" \
+  "$(run_preflight "$(meminfo_with 2000)" "${roomy_disk}" 1000)"
+
+printf 'MemTotal: 100 kB\n' >"${tmp}/no-available"
+no_available_output="$(LOADTEST_PREFLIGHT_MEMINFO="${tmp}/no-available" LOADTEST_PREFLIGHT_DISK_PATH="${roomy_disk}" \
+  "${PREFLIGHT}" 2>&1)"
+if grep -q 'no MemAvailable line' <<<"${no_available_output}"; then
+  no_available_result=true
+else
+  no_available_result=false
+fi
+check "a meminfo file with no MemAvailable line refuses with a clear message" \
+  "true" "${no_available_result}"
+
+check "an unreadable meminfo path refuses rather than crashing" \
+  "1" \
+  "$(run_preflight "${tmp}/does-not-exist" "${roomy_disk}")"
+
+echo
+echo "${passed} passed, ${failed} failed"
+[[ "${failed}" -eq 0 ]]

--- a/scripts/tests/loadtest-run-test.sh
+++ b/scripts/tests/loadtest-run-test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Behaviour tests for the loadtest results-directory wiring: versioned
+# naming, git-SHA tagging, recorded configuration and exit-code propagation.
+# The real k6 invocation is stubbed out (K6_SH), so this never touches
+# Docker, a network or a running stack.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUN_SCRIPT="${repo_root}/scripts/loadtest-run.sh"
+
+passed=0
+failed=0
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "${expected}" == "${actual}" ]]; then
+    printf 'ok   %s\n' "${name}"
+    passed=$((passed + 1))
+  else
+    printf 'FAIL %s\n     expected: %s\n     actual:   %s\n' "${name}" "${expected}" "${actual}"
+    failed=$((failed + 1))
+  fi
+}
+
+fake_k6() {
+  local exit_code="$1" path="${tmp}/fake-k6-${exit_code}.sh"
+  cat >"${path}" <<EOF
+#!/usr/bin/env bash
+exit ${exit_code}
+EOF
+  chmod +x "${path}"
+  printf '%s' "${path}"
+}
+
+run_with() {
+  local exit_code="$1" results_root="$2"
+  K6_SH="$(fake_k6 "${exit_code}")" \
+  LOADTEST_RESULTS_ROOT="${results_root}" \
+  GO_NETWORK="test-network" \
+  LOADTEST_TENANT_ID="tenant-test" \
+    bash "${RUN_SCRIPT}" >/dev/null 2>&1
+  echo "$?"
+}
+
+results_root_pass="${tmp}/results-pass"
+check "a successful k6 run exits zero" \
+  "0" \
+  "$(run_with 0 "${results_root_pass}")"
+
+result_dir="$(find "${results_root_pass}" -mindepth 1 -maxdepth 1 -type d | head -n1)"
+
+check "a results directory was created under the versioned root" \
+  "true" \
+  "$([[ -n "${result_dir}" ]] && echo true || echo false)"
+
+check "the results directory name is tagged with the current git SHA" \
+  "true" \
+  "$(git_sha=$(cd "${repo_root}" && git rev-parse --short HEAD)
+     [[ "${result_dir}" == *"-${git_sha}" ]] && echo true || echo false)"
+
+check "config.json records the run's configuration" \
+  "tenant-test" \
+  "$(jq -r '.environment.LOADTEST_TENANT_ID' "${result_dir}/config.json" 2>/dev/null)"
+
+check "config.json records the git SHA" \
+  "true" \
+  "$(jq -e '.gitSha | length > 0' "${result_dir}/config.json" >/dev/null 2>&1 && echo true || echo false)"
+
+check "the exit code is recorded alongside the results" \
+  "0" \
+  "$(cat "${result_dir}/exit-code" 2>/dev/null)"
+
+results_root_fail="${tmp}/results-fail"
+check "a threshold breach propagates a non-zero exit code" \
+  "1" \
+  "$(run_with 1 "${results_root_fail}")"
+
+fail_dir="$(find "${results_root_fail}" -mindepth 1 -maxdepth 1 -type d | head -n1)"
+check "the failing run's exit code is still recorded" \
+  "1" \
+  "$(cat "${fail_dir}/exit-code" 2>/dev/null)"
+
+echo
+echo "${passed} passed, ${failed} failed"
+[[ "${failed}" -eq 0 ]]


### PR DESCRIPTION
## What changed

Implements the §15.3 k6 load suite at 1,000 concurrent virtual users
(issue #25).

- `scripts/loadtest-preflight.sh` refuses a run on an under-resourced host
  (free memory / free disk minimums for the §15 load profile), fully
  configurable for testing.
- `deploy/loadtest/k6/` - the k6 suite itself:
  - `lib/config.js` - every knob (target host, VUs per scenario, ramp
    schedule, mutation target) as an overridable environment variable, with
    load-profile-shaped defaults.
  - `lib/auth.js` - one password grant per VU, then refresh-token rotation.
  - `lib/metrics.js` - custom Trend/Counter metrics the thresholds below are
    enforced against, plus per-scenario request counters for attribution.
  - `scenarios/business_authz.js` - the business endpoint (§12.7 "Backend
    operation" row), gated so a simulated operation only proceeds on an
    explicit allow.
  - `scenarios/capability_module.js`, `capability_instance.js`,
    `capability_row.js` - the three §12.7 capability snapshot shapes, all in
    the same run.
  - `scenarios/token_baseline.js` - a separate scenario that only ever does
    password grants, so identity cost stays attributable.
  - `scenarios/mutation_convergence.js` - flips a role permission mid-run
    through the Administration Service and polls the ADS decision endpoint
    until it converges, timing both grant and revocation.
  - `main.js` - wires the six scenarios into one run (1,000 VUs total: 600 /
    100 / 100 / 100 / 70 / 30), each with a ramp-up/steady-state/ramp-down,
    and the §15.3 objectives as hard `thresholds`.
- `scripts/k6.sh` - runs k6 in a container, the same pattern as
  `scripts/cerbos.sh` and `scripts/go.sh`.
- `scripts/loadtest-run.sh` - runs the suite, writes results to
  `dist/loadtest-results/<timestamp>-<git-sha>/` with a `config.json`
  recording every environment variable that applied, and propagates a
  threshold breach as a non-zero exit code.
- `make loadtest` - preflight, `make up`, `loadtest-seed` (full population
  by default; `LOADTEST_PROFILE=demo` for a harness smoke run), then the k6
  run - a single entry point from a clean state.
- `README.md` - a "Load testing" section documenting the target, the
  entry point and the HITL status.

## Acceptance criteria

- [x] The run reaches and sustains 1,000 concurrent virtual users - `main.js`
  sums to exactly 1,000 across scenarios; asserted by
  `scripts/tests/loadtest-k6-config-test.sh` via `k6 inspect`.
- [x] Both endpoint authorization and all three capability snapshot shapes
  are exercised in the same run - six scenarios in one `options.scenarios`.
- [x] Thresholds are enforced by k6 and the process exits non-zero on breach
  - `options.thresholds`; `loadtest-run.sh` propagates k6's own exit code
    (tested with a stubbed k6 binary).
- [x] The token endpoint baseline scenario reports identity cost separately
  - `token_baseline.js` never shares a metric name with the authz path.
- [x] Convergence and revocation latency are measured under load, not only
  at rest - `mutation_convergence.js` runs continuously alongside every
  other scenario, not as a setup-time-only step.
- [x] No business operation proceeds without an explicit allow at any point
  during the run - `business_op_without_allow` Counter, gated in code, hard
  threshold `count==0`.
- [x] Results are written with the git SHA and full configuration and are
  reproducible - `loadtest-run.sh`'s `config.json` + versioned directory
  naming, tested in `loadtest-run-test.sh`.
- [x] Observed bottlenecks are identified by component using the exported
  metrics - per-scenario request counters here; ADS cache hit ratio and
  Cerbos engine time already exported on `/metrics` (apps/ads/internal/adsmetrics,
  issue #23) and scraped by the existing `observability` profile.
- [x] `make loadtest` runs seed and test end-to-end from a clean state -
  preflight -> `make up` -> `loadtest-seed` -> `loadtest-run.sh`.
- [x] Achieved throughput, latency distribution and ADS cache hit ratio are
  documented as sizing outputs - `handleSummary` prints the p95/p99 sizing
  numbers; ADS cache hit ratio is on the existing Grafana dashboard
  (`observability` profile) during the run.

## HITL note

This issue is marked `hitl`: the §15.3 threshold values (warm decision
p95<15ms/p99<30ms, convergence p99<5s) are encoded exactly as specified, but
the issue itself states they will likely need renegotiating against the
first real measurements on real hardware. Nothing in this PR runs the full
1,000-VU suite against a live stack; `k6 inspect` validates the suite's
structure offline, which is what CI and this PR's own verification rely on.

## How it was verified

Offline, without a live stack (per project convention - k6/full-scale
infra isn't available in this environment):

- `bash scripts/tests/loadtest-preflight-test.sh` - 6/6 passing.
- `bash scripts/tests/loadtest-k6-config-test.sh` - 11/11 passing, via
  `k6 inspect --execution-requirements` (parses the suite's `options`
  without any network call).
- `bash scripts/tests/loadtest-run-test.sh` - 8/8 passing, with the k6
  invocation stubbed out.
- `bash scripts/tests/nx-affected-isolation.sh` - unaffected, still passing.
- `npx nx show projects --affected --base=main` - empty; no Nx project is
  affected by this change, so no `nx test`/`lint`/`build` run was needed.
- `python3 scripts/tests/compose-contract.py` - the one failure
  (`policy-release-store-init` healthcheck) is pre-existing on `main`,
  unrelated to this change (verified by running the same script against
  `main` directly).

Closes #25


Closes #25
