### PR TITLE
Oracle adapter: positional bind-argument mismatch breaks SaveRoleMatrix/SaveUserOverrideWrite/outbox marking (#48)

### DIFF
--- a/libs/assignmentstore/oraclestore/oraclestore.go
+++ b/libs/assignmentstore/oraclestore/oraclestore.go
@@ -433,10 +433,12 @@ func (s *Store) AppendAuditEvent(ctx context.Context, event assignmentstore.Audi
 
 // AuditEvent reads one audit record.
 //
-// role_external_id, target_user_id and resource_action_keys are nullable,
-// and Oracle cannot tell an empty string from NULL, so all three come back
-// as the empty string rather than as a distinction callers would have to
-// handle differently per engine.
+// hospital_id, before_json, after_json, role_external_id, target_user_id,
+// resource_action_keys and correlation_id are all nullable, and Oracle
+// cannot tell an empty string from NULL (a write of "" is read back as
+// NULL), so all seven come back as the empty string rather than as a
+// distinction callers would have to handle differently per engine, or a
+// Scan error when the column is genuinely NULL (issue #46/#48).
 func (s *Store) AuditEvent(ctx context.Context, eventID string) (assignmentstore.AuditEvent, bool, error) {
 	const query = `
 		SELECT actor_id, operation, target_type, before_json, after_json,
@@ -445,23 +447,27 @@ func (s *Store) AuditEvent(ctx context.Context, eventID string) (assignmentstore
 		FROM permission_audit_event WHERE event_id = :1`
 
 	event := assignmentstore.AuditEvent{EventID: eventID}
-	var roleExternalID, targetUserID, resourceActionKeys sql.NullString
+	var hospitalID, beforeJSON, afterJSON, roleExternalID, targetUserID, resourceActionKeys, correlationID sql.NullString
 	// The JSON columns are CLOBs. go-ora returns them as string when scanned
 	// into one, so no LOB handling leaks out of this package.
 	err := s.db.QueryRowContext(ctx, query, eventID).Scan(
 		&event.ActorID, &event.Operation, &event.TargetType,
-		&event.BeforeJSON, &event.AfterJSON, &event.TenantID,
-		&event.HospitalID, &roleExternalID, &targetUserID,
-		&resourceActionKeys, &event.CorrelationID, &event.CreatedAt)
+		&beforeJSON, &afterJSON, &event.TenantID,
+		&hospitalID, &roleExternalID, &targetUserID,
+		&resourceActionKeys, &correlationID, &event.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return assignmentstore.AuditEvent{}, false, nil
 	}
 	if err != nil {
 		return assignmentstore.AuditEvent{}, false, fmt.Errorf("oraclestore: reading an audit event: %w", err)
 	}
+	event.HospitalID = hospitalID.String
+	event.BeforeJSON = beforeJSON.String
+	event.AfterJSON = afterJSON.String
 	event.RoleExternalID = roleExternalID.String
 	event.TargetUserID = targetUserID.String
 	event.ResourceActionKeys = resourceActionKeys.String
+	event.CorrelationID = correlationID.String
 	return event, true, nil
 }
 
@@ -544,16 +550,20 @@ func (s *Store) SearchAuditEvents(ctx context.Context, query assignmentstore.Aud
 	var page []assignmentstore.AuditEvent
 	for rows.Next() {
 		var event assignmentstore.AuditEvent
-		var roleExternalID, targetUserID, resourceActionKeys sql.NullString
+		var hospitalID, beforeJSON, afterJSON, roleExternalID, targetUserID, resourceActionKeys, correlationID sql.NullString
 		if err := rows.Scan(&event.EventID, &event.ActorID, &event.Operation, &event.TargetType,
-			&event.BeforeJSON, &event.AfterJSON, &event.TenantID, &event.HospitalID,
+			&beforeJSON, &afterJSON, &event.TenantID, &hospitalID,
 			&roleExternalID, &targetUserID, &resourceActionKeys,
-			&event.CorrelationID, &event.CreatedAt); err != nil {
+			&correlationID, &event.CreatedAt); err != nil {
 			return nil, 0, fmt.Errorf("oraclestore: scanning an audit event: %w", err)
 		}
+		event.HospitalID = hospitalID.String
+		event.BeforeJSON = beforeJSON.String
+		event.AfterJSON = afterJSON.String
 		event.RoleExternalID = roleExternalID.String
 		event.TargetUserID = targetUserID.String
 		event.ResourceActionKeys = resourceActionKeys.String
+		event.CorrelationID = correlationID.String
 		page = append(page, event)
 	}
 	if err := rows.Err(); err != nil {
@@ -639,9 +649,20 @@ func (s *Store) UnpublishedOutboxEvents(ctx context.Context, limit int) ([]assig
 }
 
 // MarkOutboxEventPublished records that an outbox row was published.
+//
+// go-ora binds a positional argument to the :N placeholder it *encounters
+// first while scanning the statement text left to right*, not to the
+// placeholder whose literal digit matches the argument's position (see
+// go-ora's Stmt.useNamedParameters/parseQueryParametersNames). So every
+// statement in this file must write its :N placeholders in strictly
+// increasing textual order, matching the Go argument list order exactly -
+// `:2 ... :1` here previously bound eventID (a string) to published_at (a
+// TIMESTAMP WITH TIME ZONE column) and publishedAt to event_id, which
+// Oracle rejected with ORA-01858 (issue #48).
+const markOutboxEventPublishedStatement = `UPDATE outbox_event SET published_at = :1 WHERE event_id = :2`
+
 func (s *Store) MarkOutboxEventPublished(ctx context.Context, eventID string, publishedAt time.Time) error {
-	const statement = `UPDATE outbox_event SET published_at = :2 WHERE event_id = :1`
-	if _, err := s.db.ExecContext(ctx, statement, eventID, publishedAt); err != nil {
+	if _, err := s.db.ExecContext(ctx, markOutboxEventPublishedStatement, publishedAt, eventID); err != nil {
 		return fmt.Errorf("oraclestore: marking an outbox event published: %w", err)
 	}
 	return nil
@@ -727,9 +748,13 @@ func (s *Store) SaveRoleMatrix(ctx context.Context, write assignmentstore.RoleMa
 		return 0, fmt.Errorf("oraclestore: appending the outbox event: %w", err)
 	}
 
+	// :N placeholders bind by textual occurrence order here, not by digit
+	// (see MarkOutboxEventPublished's comment above), so the WHERE clause's
+	// tenant_id comes last to match the (newRevision, CreatedAt, TenantID)
+	// argument order.
 	if _, err := tx.ExecContext(ctx, `
-		UPDATE permission_revision SET revision = :2, changed_at = :3 WHERE tenant_id = :1`,
-		write.TenantID, newRevision, write.Audit.CreatedAt); err != nil {
+		UPDATE permission_revision SET revision = :1, changed_at = :2 WHERE tenant_id = :3`,
+		newRevision, write.Audit.CreatedAt, write.TenantID); err != nil {
 		return 0, fmt.Errorf("oraclestore: advancing the permission revision: %w", err)
 	}
 
@@ -835,9 +860,11 @@ func (s *Store) SaveUserOverrideWrite(ctx context.Context, write assignmentstore
 		return 0, fmt.Errorf("oraclestore: appending the outbox event: %w", err)
 	}
 
+	// See SaveRoleMatrix's identical statement above for why tenant_id is
+	// bound last.
 	if _, err := tx.ExecContext(ctx, `
-		UPDATE permission_revision SET revision = :2, changed_at = :3 WHERE tenant_id = :1`,
-		key.TenantID, newRevision, write.Audit.CreatedAt); err != nil {
+		UPDATE permission_revision SET revision = :1, changed_at = :2 WHERE tenant_id = :3`,
+		newRevision, write.Audit.CreatedAt, key.TenantID); err != nil {
 		return 0, fmt.Errorf("oraclestore: advancing the permission revision: %w", err)
 	}
 

--- a/libs/assignmentstore/storecontract/contract.go
+++ b/libs/assignmentstore/storecontract/contract.go
@@ -1295,7 +1295,7 @@ func assertSaveRoleMatrixStaleRevision(t *testing.T, store assignmentstore.Store
 		Permissions: []assignmentstore.RolePermissionInput{
 			{ResourceKey: "patient_record", ActionKey: "list", Enabled: true, ValidFrom: created},
 		},
-		Audit:  assignmentstore.AuditEvent{EventID: "audit-stale-1", Operation: "ROLE_MATRIX_SAVE", CreatedAt: created},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-stale-1", ActorID: "admin-1", Operation: "ROLE_MATRIX_SAVE", TargetType: "role_permission", CreatedAt: created},
 		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-stale-1", AggregateKey: "tenant-a:role-nurse", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
 	}
 	if _, err := store.SaveRoleMatrix(ctx, first); err != nil {
@@ -1311,7 +1311,7 @@ func assertSaveRoleMatrixStaleRevision(t *testing.T, store assignmentstore.Store
 		Permissions: []assignmentstore.RolePermissionInput{
 			{ResourceKey: "patient_record", ActionKey: "delete", Enabled: true, ValidFrom: created},
 		},
-		Audit:  assignmentstore.AuditEvent{EventID: "audit-stale-2", Operation: "ROLE_MATRIX_SAVE", CreatedAt: created},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-stale-2", ActorID: "admin-1", Operation: "ROLE_MATRIX_SAVE", TargetType: "role_permission", CreatedAt: created},
 		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-stale-2", AggregateKey: "tenant-a:role-nurse", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
 	}
 	if _, err := store.SaveRoleMatrix(ctx, stale); !errors.Is(err, assignmentstore.ErrRevisionConflict) {
@@ -1365,7 +1365,7 @@ func assertSaveRoleMatrixConcurrentWrites(t *testing.T, store assignmentstore.St
 				{ResourceKey: "patient_record", ActionKey: "read", Enabled: true, ValidFrom: created},
 			},
 			Audit: assignmentstore.AuditEvent{
-				EventID: "audit-concurrent-" + eventSuffix, Operation: "ROLE_MATRIX_SAVE", CreatedAt: created,
+				EventID: "audit-concurrent-" + eventSuffix, ActorID: "admin-1", Operation: "ROLE_MATRIX_SAVE", TargetType: "role_permission", CreatedAt: created,
 			},
 			Outbox: assignmentstore.OutboxEvent{
 				EventID: "outbox-concurrent-" + eventSuffix, AggregateKey: "tenant-a:role-porter",
@@ -1439,7 +1439,7 @@ func assertSaveRoleMatrixRollsBackOnFailure(t *testing.T, store assignmentstore.
 		Permissions: []assignmentstore.RolePermissionInput{
 			{ResourceKey: "patient_record", ActionKey: "update", Enabled: true, ValidFrom: created},
 		},
-		Audit: assignmentstore.AuditEvent{EventID: "audit-rollback-1", Operation: "ROLE_MATRIX_SAVE", CreatedAt: created},
+		Audit: assignmentstore.AuditEvent{EventID: "audit-rollback-1", ActorID: "admin-1", Operation: "ROLE_MATRIX_SAVE", TargetType: "role_permission", CreatedAt: created},
 		// The same event id as the row seeded above: the unique key forces
 		// this insert to fail after the permission and audit writes above
 		// it in the transaction have already run.
@@ -1488,7 +1488,7 @@ func assertSaveRoleMatrixAuditHistoryIsAppendOnly(t *testing.T, store assignment
 		Permissions: []assignmentstore.RolePermissionInput{
 			{ResourceKey: "patient_record", ActionKey: "update", Enabled: true, ValidFrom: created},
 		},
-		Audit:  assignmentstore.AuditEvent{EventID: "audit-history-1", Operation: "ROLE_MATRIX_SAVE", BeforeJSON: `{}`, AfterJSON: `{"enabled":true}`, CreatedAt: created},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-history-1", ActorID: "admin-1", Operation: "ROLE_MATRIX_SAVE", TargetType: "role_permission", BeforeJSON: `{}`, AfterJSON: `{"enabled":true}`, CreatedAt: created},
 		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-history-1", AggregateKey: "tenant-a:role-doctor", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
 	})
 	if err != nil {
@@ -1500,7 +1500,7 @@ func assertSaveRoleMatrixAuditHistoryIsAppendOnly(t *testing.T, store assignment
 		Permissions: []assignmentstore.RolePermissionInput{
 			{ResourceKey: "patient_record", ActionKey: "update", Enabled: false, ValidFrom: created},
 		},
-		Audit:  assignmentstore.AuditEvent{EventID: "audit-history-2", Operation: "ROLE_MATRIX_SAVE", BeforeJSON: `{"enabled":true}`, AfterJSON: `{"enabled":false}`, CreatedAt: created},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-history-2", ActorID: "admin-1", Operation: "ROLE_MATRIX_SAVE", TargetType: "role_permission", BeforeJSON: `{"enabled":true}`, AfterJSON: `{"enabled":false}`, CreatedAt: created},
 		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-history-2", AggregateKey: "tenant-a:role-doctor", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
 	}); err != nil {
 		t.Fatalf("the second save: %v", err)
@@ -1672,7 +1672,7 @@ func assertSaveUserOverrideWriteStaleRevision(t *testing.T, store assignmentstor
 	first := assignmentstore.UserOverrideWrite{
 		Key: key, Effect: assignmentstore.EffectGrant, Reason: "temporary cover",
 		ValidFrom: created, ExpectedRevision: 0,
-		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-stale-1", Operation: "USER_OVERRIDE_SAVE", CreatedAt: created},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-stale-1", ActorID: "admin-1", Operation: "USER_OVERRIDE_SAVE", TargetType: "user_permission_override", CreatedAt: created},
 		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-override-stale-1", AggregateKey: "tenant-a:user-2", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
 	}
 	if _, err := store.SaveUserOverrideWrite(ctx, first); err != nil {
@@ -1684,7 +1684,7 @@ func assertSaveUserOverrideWriteStaleRevision(t *testing.T, store assignmentstor
 	stale := assignmentstore.UserOverrideWrite{
 		Key: key, Effect: assignmentstore.EffectRevoke, Reason: "changed my mind",
 		ValidFrom: created, ExpectedRevision: 0,
-		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-stale-2", Operation: "USER_OVERRIDE_SAVE", CreatedAt: created},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-stale-2", ActorID: "admin-1", Operation: "USER_OVERRIDE_SAVE", TargetType: "user_permission_override", CreatedAt: created},
 		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-override-stale-2", AggregateKey: "tenant-a:user-2", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
 	}
 	if _, err := store.SaveUserOverrideWrite(ctx, stale); !errors.Is(err, assignmentstore.ErrRevisionConflict) {
@@ -1728,7 +1728,7 @@ func assertSaveUserOverrideWriteInheritClearsTheRow(t *testing.T, store assignme
 	grant := assignmentstore.UserOverrideWrite{
 		Key: key, Effect: assignmentstore.EffectGrant, Reason: "exceptional access",
 		ValidFrom: created, ExpectedRevision: 0,
-		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-inherit-1", Operation: "USER_OVERRIDE_SAVE", CreatedAt: created},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-inherit-1", ActorID: "admin-1", Operation: "USER_OVERRIDE_SAVE", TargetType: "user_permission_override", CreatedAt: created},
 		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-override-inherit-1", AggregateKey: "tenant-a:user-3", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
 	}
 	if _, err := store.SaveUserOverrideWrite(ctx, grant); err != nil {
@@ -1737,7 +1737,7 @@ func assertSaveUserOverrideWriteInheritClearsTheRow(t *testing.T, store assignme
 
 	inherit := assignmentstore.UserOverrideWrite{
 		Key: key, ExpectedRevision: 1,
-		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-inherit-2", Operation: "USER_OVERRIDE_SAVE", CreatedAt: created},
+		Audit:  assignmentstore.AuditEvent{EventID: "audit-override-inherit-2", ActorID: "admin-1", Operation: "USER_OVERRIDE_SAVE", TargetType: "user_permission_override", CreatedAt: created},
 		Outbox: assignmentstore.OutboxEvent{EventID: "outbox-override-inherit-2", AggregateKey: "tenant-a:user-3", EventType: "permission.changed", Payload: `{}`, CreatedAt: created},
 	}
 	newRevision, err := store.SaveUserOverrideWrite(ctx, inherit)
@@ -1943,7 +1943,7 @@ func assertSaveRoleMatrixAuditCarriesSearchDimensions(t *testing.T, store assign
 			{ResourceKey: "patient_record", ActionKey: "update", Enabled: true, ValidFrom: created},
 		},
 		Audit: assignmentstore.AuditEvent{
-			EventID: "audit-dimensions-role-1", Operation: "ROLE_MATRIX_SAVE",
+			EventID: "audit-dimensions-role-1", ActorID: "admin-1", Operation: "ROLE_MATRIX_SAVE", TargetType: "role_permission",
 			// A caller-supplied RoleExternalID or ResourceActionKeys must be
 			// ignored: the write's own fields are authoritative.
 			RoleExternalID: "some-other-role", CreatedAt: created,
@@ -1992,7 +1992,7 @@ func assertSaveUserOverrideWriteAuditCarriesSearchDimensions(t *testing.T, store
 		Effect: assignmentstore.EffectRevoke, Reason: "under investigation",
 		ValidFrom: created, ExpectedRevision: 0,
 		Audit: assignmentstore.AuditEvent{
-			EventID: "audit-dimensions-override-1", Operation: "USER_OVERRIDE_SAVE",
+			EventID: "audit-dimensions-override-1", ActorID: "admin-1", Operation: "USER_OVERRIDE_SAVE", TargetType: "user_permission_override",
 			// A caller-supplied TargetUserID must be ignored the same way.
 			TargetUserID: "some-other-user", CreatedAt: created,
 		},


### PR DESCRIPTION
## What changed

Fixes the root causes of `TestOracleSatisfiesTheStoreContract`'s failures
(issues #48 and #46, the same underlying CI breakage reported from two
angles).

### 1. Out-of-order `:N` placeholders (issue #48)

`libs/assignmentstore/oraclestore/oraclestore.go`'s `MarkOutboxEventPublished`
and the revision-advance `UPDATE` inside `SaveRoleMatrix`/`SaveUserOverrideWrite`
wrote their `:N` placeholders out of textual order (e.g. `:2, :3 ... :1`).

Confirmed directly against go-ora v2.9.0's source
(`Stmt.useNamedParameters` / `parseQueryParametersNames` in
`command.go`/`utils.go`): a positional Go argument binds to the `:N`
placeholder the parser **encounters first while scanning the statement text
left to right**, not to the placeholder whose literal digit matches the
argument's position. Rewrote every affected statement so its placeholders
appear in the same order as the Go argument list, with a comment on each
explaining why.

### 2. NULL-vs-empty-string on read (issue #46)

`AuditEvent`/`SearchAuditEvents` scanned `hospital_id`, `before_json`,
`after_json` and `correlation_id` directly into plain `string` fields.
These columns are nullable, and Oracle stores an empty-string write as
`NULL` — so a legitimately-empty column came back as `NULL` and failed to
`Scan` into a non-nullable Go string. Wrapped all four in `sql.NullString`,
matching the pattern the file already used for
`role_external_id`/`target_user_id`/`resource_action_keys`.

### 3. Shared contract fixtures (issue #46)

`libs/assignmentstore/storecontract/contract.go` left `ActorID` and
`TargetType` blank on most `AuditEvent` fixtures. Both columns are `NOT
NULL` on **both** engines; PostgreSQL tolerates an empty string there, but
Oracle's NULL coercion made the same write violate the same constraint.
Gave every fixture a real `ActorID` ("admin-1") and the correct
`TargetType` ("role_permission" / "user_permission_override"), matching the
pattern already used in the "atomic" fixtures.

## Acceptance criteria

- [x] `TestOracleSatisfiesTheStoreContract` passes against a real Oracle
  instance — verified with `bash scripts/tests/store-contract.sh oracle`
  against a live Oracle 23ai Free container (all subtests pass).
- [x] `bash scripts/tests/store-contract.sh dual` passes against both
  engines in one run, restoring the dual-dialect portability guarantee.
- [x] Every out-of-order `:N` placeholder in `oraclestore.go` is fixed, not
  just the one from the issue's example.
- [x] A code comment documents go-ora's actual bind-order semantics on
  every fixed statement, so this class of bug doesn't recur silently.

## How it was verified

Live, against real database containers (this bug class is only observable
against the real Oracle wire protocol, so no amount of offline review would
have caught it):

```
docker compose --profile oracle up --detach oracle
bash scripts/oracle-wait.sh
bash scripts/liquibase.sh oracle update
bash scripts/tests/store-contract.sh oracle   # full pass
bash scripts/tests/store-contract.sh dual     # full pass, both engines
```

Also ran the affected Nx projects:
- `npx nx run-many --target=test --projects=assignmentstore,architecture` — pass
- `npx nx run-many --target=lint --projects=assignmentstore,architecture` — pass (no diff from `go fmt`)
- `npx nx show projects --affected --base=main` confirms only these two projects are touched.

Oracle container stopped after verification to free host resources.

Closes #48, closes #46


Closes #48
