### PR TITLE
Kubernetes deployment: kustomize base + dev/prod overlays with KEDA autoscaling (#55)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ ci: ## Run exactly what CI runs, so a green local run means a green pipeline
 	bash scripts/tests/loadtest-preflight-test.sh
 	bash scripts/tests/loadtest-k6-config-test.sh
 	bash scripts/tests/loadtest-run-test.sh
+	$(MAKE) k8s-validate
 
 .PHONY: migrate
 migrate: ## Apply the authorization schema to PostgreSQL
@@ -159,3 +160,7 @@ gen: ## Run every project's code generators
 .PHONY: graph
 graph: ## Open the single Go plus Angular dependency graph
 	$(NX) graph
+
+.PHONY: k8s-validate
+k8s-validate: ## Render both deploy/k8s overlays and validate every resource against the Kubernetes API schema
+	bash scripts/tests/k8s-manifests-test.sh

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ apps/admin-console    Angular app: live platform status
 libs/permissioncontext  Assembles permissionContext data; never a verdict
 libs/cerbosclient     Long-lived gRPC channel to the PDP
 deploy/cerbos         Cerbos config, the served policy bundle and the ADR-003 control
+deploy/k8s            kustomize layout for a real cluster (see "Kubernetes deployment")
 tests/architecture    Executable checks for constraints no compiler enforces
 scripts/              Container-backed toolchain helpers and infrastructure tests
 ```
@@ -145,6 +146,65 @@ make loadtest LOADTEST_PROFILE=demo # exercise the harness against the small dem
 **This suite is marked HITL** (issue #25): the threshold values encode
 §15.3's suggested targets, but they will likely need renegotiating against
 the first real measurements taken on real hardware.
+
+## Kubernetes deployment
+
+`deploy/k8s` is a `kustomize` layout for running the same core walking-skeleton
+services docker-compose brings up by default — `postgres`, `cerbos`,
+`keycloak`, `redpanda`, `ads`, `admin-service`, `resource-service`,
+`admin-console` and `business-ui` — on a real cluster instead. The `oracle`,
+`loadtest`, `policy-release` and `observability` compose profiles are out of
+scope for this layout (see issue #55).
+
+```
+deploy/k8s/base/<service>/   One Deployment or StatefulSet, Service, and
+                             (for scalable services) a KEDA ScaledObject
+                             per directory.
+deploy/k8s/base/common/      Shared IdP config/credential and Postgres DSN
+                             every Go service consumes.
+deploy/k8s/overlays/dev/     kind/minikube: 1 replica per service, `:dev`
+                             image tags.
+deploy/k8s/overlays/prod/    A real cluster: 3+ replica floors, pinned
+                             image tags (edit REGISTRY/TAG first).
+```
+
+Cerbos's committed policy tree and the ADS/admin-service capability and
+authorization catalogs are baked into a small `cerbos-poc/cerbos-assets`
+image (`deploy/cerbos/Dockerfile`) and copied into an `emptyDir` by an
+initContainer on every pod that needs one, standing in for compose's host
+bind mounts — the combined tree is well over the ~1MiB a ConfigMap allows,
+and its per-resource directory structure (ADR-006) doesn't survive a flat
+ConfigMap's key space anyway.
+
+To run locally against `kind` or `minikube`:
+
+```bash
+docker build -f deploy/cerbos/Dockerfile -t cerbos-poc/cerbos-assets:dev .
+docker build -f apps/ads/Dockerfile -t cerbos-poc/ads:dev .
+docker build -f apps/admin-service/Dockerfile -t cerbos-poc/admin-service:dev .
+docker build -f apps/resource-service/Dockerfile -t cerbos-poc/resource-service:dev .
+docker build -f apps/admin-console/Dockerfile -t cerbos-poc/admin-console:dev .
+docker build -f apps/business-ui/Dockerfile -t cerbos-poc/business-ui:dev .
+kind load docker-image cerbos-poc/cerbos-assets:dev cerbos-poc/ads:dev \
+  cerbos-poc/admin-service:dev cerbos-poc/resource-service:dev \
+  cerbos-poc/admin-console:dev cerbos-poc/business-ui:dev
+kubectl apply -k deploy/k8s/overlays/dev
+```
+
+`make k8s-validate` (wired into `make ci`) renders both overlays with
+`kustomize` and validates every resource against the Kubernetes API schema
+(KEDA's `ScaledObject` CRD is skipped — no cluster is required, everything
+runs through Docker via `scripts/kustomize.sh`/`scripts/kubeconform.sh`, the
+same pattern as `scripts/go.sh`/`scripts/k6.sh`).
+
+**Remaining manual steps before a real cluster deploy:** a KEDA operator
+installed cluster-wide; the `prod` overlay's `REGISTRY`/`TAG` image
+placeholders replaced (or set with `kustomize edit set image`); an Ingress or
+LoadBalancer Service in front of `admin-console`/`business-ui` (compose's
+host port publishing has no direct equivalent here and isn't defined by this
+layout); and the dev-only fixture credentials in `deploy/k8s/base/common` and
+`deploy/k8s/base/postgres` replaced with real secrets from a cluster secret
+manager.
 
 ## Architectural constraints
 

--- a/deploy/cerbos/Dockerfile
+++ b/deploy/cerbos/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+#
+# Packages the committed Cerbos policy tree and capability/authorization
+# catalogs as a small "assets" image. docker-compose bind-mounts
+# deploy/cerbos/policies and deploy/cerbos/catalog straight from the host,
+# which has no equivalent in Kubernetes; this image is copied into an
+# emptyDir by an initContainer on every pod that needs one of these trees
+# instead (see deploy/k8s/base/*/deployment.yaml), because the combined
+# tree is well over the ~1MiB ConfigMap size Kubernetes enforces and its
+# subdirectory structure (one policy file per resource, ADR-006) doesn't
+# survive a flat ConfigMap's key space anyway.
+#
+# Build context is the repository root, matching every other Dockerfile
+# here, so this can sit alongside deploy/cerbos/config.yaml unmodified.
+FROM docker.io/library/alpine:3.20
+
+COPY deploy/cerbos/policies /assets/policies
+COPY deploy/cerbos/catalog /assets/catalog
+COPY deploy/cerbos/config.yaml /assets/config.yaml
+COPY deploy/cerbos/config-managed.yaml /assets/config-managed.yaml
+
+ENTRYPOINT ["/bin/sh"]

--- a/deploy/k8s/base/admin-console/deployment.yaml
+++ b/deploy/k8s/base/admin-console/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: admin-console
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: admin-console
+  template:
+    metadata:
+      labels:
+        app: admin-console
+    spec:
+      containers:
+        - name: admin-console
+          image: cerbos-poc/admin-console:dev
+          envFrom:
+            - configMapRef:
+                name: admin-console-config
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 20
+          livenessProbe:
+            httpGet:
+              path: /index.html
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi

--- a/deploy/k8s/base/admin-console/kustomization.yaml
+++ b/deploy/k8s/base/admin-console/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - scaledobject.yaml
+configMapGenerator:
+  - name: admin-console-config
+    literals:
+      - OIDC_ISSUER=http://localhost:8081/realms/cerbos-poc
+      - OIDC_CLIENT_ID=patient-app
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/k8s/base/admin-console/scaledobject.yaml
+++ b/deploy/k8s/base/admin-console/scaledobject.yaml
@@ -1,0 +1,14 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: admin-console
+spec:
+  scaleTargetRef:
+    name: admin-console
+  minReplicaCount: 2
+  maxReplicaCount: 4
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "80"

--- a/deploy/k8s/base/admin-console/service.yaml
+++ b/deploy/k8s/base/admin-console/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: admin-console
+spec:
+  selector:
+    app: admin-console
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/deploy/k8s/base/admin-service/deployment.yaml
+++ b/deploy/k8s/base/admin-service/deployment.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: admin-service
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: admin-service
+  template:
+    metadata:
+      labels:
+        app: admin-service
+    spec:
+      # See deploy/k8s/base/ads/deployment.yaml's comment: this copies the
+      # committed authorization catalog (resources) and capability catalog
+      # (ui-capabilities) the same way, since admin-service reads both
+      # (§9.1's impact preview and capability impact endpoints).
+      initContainers:
+        - name: assets
+          image: cerbos-poc/cerbos-assets:dev
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp -r /assets/catalog/resources/* /authorization-catalog/
+              cp -r /assets/catalog/ui-capabilities/* /capability-catalog/
+          volumeMounts:
+            - name: authorization-catalog
+              mountPath: /authorization-catalog
+            - name: capability-catalog
+              mountPath: /capability-catalog
+      containers:
+        - name: admin-service
+          image: cerbos-poc/admin-service:dev
+          envFrom:
+            - configMapRef:
+                name: admin-service-config
+            - configMapRef:
+                name: idp-config
+            - secretRef:
+                name: postgres-dsn
+          env:
+            - name: IDP_CREDENTIALS_SECRET_REF
+              value: /run/secrets/idp-admin-credentials
+          volumeMounts:
+            - name: authorization-catalog
+              mountPath: /authorization-catalog
+              readOnly: true
+            - name: capability-catalog
+              mountPath: /capability-catalog
+              readOnly: true
+            - name: idp-admin-credentials
+              mountPath: /run/secrets/idp-admin-credentials
+              subPath: idp-admin-credentials
+              readOnly: true
+            - name: policy-release-archives
+              mountPath: /var/lib/policy-controller/archives
+              readOnly: true
+          ports:
+            - name: http
+              containerPort: 8081
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 20
+          livenessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: authorization-catalog
+          emptyDir: {}
+        - name: capability-catalog
+          emptyDir: {}
+        - name: idp-admin-credentials
+          secret:
+            secretName: idp-admin-credentials
+        # Empty until the (out-of-scope-for-this-slice) policy-controller
+        # ever runs; admin-service's revision module already handles that
+        # by reporting no current revision rather than erroring (see
+        # docker-compose.yml's admin-service comment).
+        - name: policy-release-archives
+          emptyDir: {}

--- a/deploy/k8s/base/admin-service/kustomization.yaml
+++ b/deploy/k8s/base/admin-service/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - scaledobject.yaml
+configMapGenerator:
+  - name: admin-service-config
+    literals:
+      - ADMIN_SERVICE_HTTP_ADDR=:8081
+      - POSTGRES_ADDR=postgres:5432
+      - AUTHORIZATION_CATALOG_DIR=/authorization-catalog
+      - CAPABILITY_CATALOG_DIR=/capability-catalog
+      - KAFKA_BROKERS=redpanda:9092
+      - KAFKA_PERMISSION_CHANGED_TOPIC=permission-changed
+      - USER_OVERRIDE_HIGH_RISK_ACTIONS=update,delete,assign
+      - USER_OVERRIDE_HIGH_RISK_VALIDITY=2160h
+      - ADS_ADDR=http://ads:8080
+      - POLICY_ARCHIVE_STORE_DIR=/var/lib/policy-controller/archives
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/k8s/base/admin-service/scaledobject.yaml
+++ b/deploy/k8s/base/admin-service/scaledobject.yaml
@@ -1,0 +1,14 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: admin-service
+spec:
+  scaleTargetRef:
+    name: admin-service
+  minReplicaCount: 2
+  maxReplicaCount: 4
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "75"

--- a/deploy/k8s/base/admin-service/service.yaml
+++ b/deploy/k8s/base/admin-service/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: admin-service
+spec:
+  selector:
+    app: admin-service
+  ports:
+    - name: http
+      port: 8081
+      targetPort: 8081

--- a/deploy/k8s/base/ads/deployment.yaml
+++ b/deploy/k8s/base/ads/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ads
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ads
+  template:
+    metadata:
+      labels:
+        app: ads
+    spec:
+      # The capability snapshot endpoint (§12.3) reads the same committed
+      # capability catalog Cerbos reads its policies from; see
+      # deploy/cerbos/Dockerfile for why this is an initContainer copy
+      # rather than a ConfigMap mount.
+      initContainers:
+        - name: assets
+          image: cerbos-poc/cerbos-assets:dev
+          command:
+            - /bin/sh
+            - -c
+            - "cp -r /assets/catalog/ui-capabilities/* /capability-catalog/"
+          volumeMounts:
+            - name: capability-catalog
+              mountPath: /capability-catalog
+      containers:
+        - name: ads
+          image: cerbos-poc/ads:dev
+          envFrom:
+            - configMapRef:
+                name: ads-config
+            - configMapRef:
+                name: idp-config
+            - secretRef:
+                name: postgres-dsn
+          env:
+            - name: IDP_CREDENTIALS_SECRET_REF
+              value: /run/secrets/idp-admin-credentials
+          volumeMounts:
+            - name: capability-catalog
+              mountPath: /capability-catalog
+              readOnly: true
+            - name: idp-admin-credentials
+              mountPath: /run/secrets/idp-admin-credentials
+              subPath: idp-admin-credentials
+              readOnly: true
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 20
+          livenessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: capability-catalog
+          emptyDir: {}
+        - name: idp-admin-credentials
+          secret:
+            secretName: idp-admin-credentials

--- a/deploy/k8s/base/ads/kustomization.yaml
+++ b/deploy/k8s/base/ads/kustomization.yaml
@@ -16,7 +16,7 @@ configMapGenerator:
       - KAFKA_CONSUMER_GROUP=ads
       - ADS_RECONCILE_INTERVAL=2s
       - CAPABILITY_CATALOG_DIR=/capability-catalog
-      - CAPABILITY_CATALOG_REVISION="1"
+      - CAPABILITY_CATALOG_REVISION=1
       - ROOT_POLICY_REVISION=root-v1.4.0
 generatorOptions:
   disableNameSuffixHash: true

--- a/deploy/k8s/base/ads/kustomization.yaml
+++ b/deploy/k8s/base/ads/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - scaledobject.yaml
+configMapGenerator:
+  - name: ads-config
+    literals:
+      - ADS_HTTP_ADDR=:8080
+      - CERBOS_GRPC_ADDR=cerbos:3593
+      - POSTGRES_ADDR=postgres:5432
+      - ADS_ROLE_MATRIX_CACHE_TTL=30s
+      - KAFKA_BROKERS=redpanda:9092
+      - KAFKA_PERMISSION_CHANGED_TOPIC=permission-changed
+      - KAFKA_CONSUMER_GROUP=ads
+      - ADS_RECONCILE_INTERVAL=2s
+      - CAPABILITY_CATALOG_DIR=/capability-catalog
+      - CAPABILITY_CATALOG_REVISION="1"
+      - ROOT_POLICY_REVISION=root-v1.4.0
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/k8s/base/ads/scaledobject.yaml
+++ b/deploy/k8s/base/ads/scaledobject.yaml
@@ -1,0 +1,14 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ads
+spec:
+  scaleTargetRef:
+    name: ads
+  minReplicaCount: 2
+  maxReplicaCount: 6
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "75"

--- a/deploy/k8s/base/ads/service.yaml
+++ b/deploy/k8s/base/ads/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ads
+spec:
+  selector:
+    app: ads
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/deploy/k8s/base/business-ui/deployment.yaml
+++ b/deploy/k8s/base/business-ui/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: business-ui
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: business-ui
+  template:
+    metadata:
+      labels:
+        app: business-ui
+    spec:
+      containers:
+        - name: business-ui
+          image: cerbos-poc/business-ui:dev
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 20
+          livenessProbe:
+            httpGet:
+              path: /index.html
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi

--- a/deploy/k8s/base/business-ui/kustomization.yaml
+++ b/deploy/k8s/base/business-ui/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - scaledobject.yaml

--- a/deploy/k8s/base/business-ui/scaledobject.yaml
+++ b/deploy/k8s/base/business-ui/scaledobject.yaml
@@ -1,0 +1,14 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: business-ui
+spec:
+  scaleTargetRef:
+    name: business-ui
+  minReplicaCount: 2
+  maxReplicaCount: 4
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "80"

--- a/deploy/k8s/base/business-ui/service.yaml
+++ b/deploy/k8s/base/business-ui/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: business-ui
+spec:
+  selector:
+    app: business-ui
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/deploy/k8s/base/cerbos/deployment.yaml
+++ b/deploy/k8s/base/cerbos/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cerbos
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cerbos
+  template:
+    metadata:
+      labels:
+        app: cerbos
+    spec:
+      # The committed policy tree and Cerbos config have no ConfigMap-sized
+      # equivalent (see deploy/cerbos/Dockerfile); an initContainer built
+      # from that assets image copies them into emptyDir volumes the main
+      # container mounts read-only, standing in for compose's host bind
+      # mount.
+      initContainers:
+        - name: assets
+          image: cerbos-poc/cerbos-assets:dev
+          command:
+            - /bin/sh
+            - -c
+            - "cp -r /assets/policies/* /policies/ && cp /assets/config.yaml /conf/config.yaml"
+          volumeMounts:
+            - name: policies
+              mountPath: /policies
+            - name: config
+              mountPath: /conf
+      containers:
+        - name: cerbos
+          image: ghcr.io/cerbos/cerbos:0.46.0
+          args: ["server", "--config=/conf/config.yaml"]
+          ports:
+            - name: grpc
+              containerPort: 3593
+            - name: http
+              containerPort: 3592
+          volumeMounts:
+            - name: policies
+              mountPath: /policies
+              readOnly: true
+            - name: config
+              mountPath: /conf
+              readOnly: true
+          readinessProbe:
+            exec:
+              command: ["/cerbos", "healthcheck", "--config=/conf/config.yaml"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 20
+          livenessProbe:
+            exec:
+              command: ["/cerbos", "healthcheck", "--config=/conf/config.yaml"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+      volumes:
+        - name: policies
+          emptyDir: {}
+        - name: config
+          emptyDir: {}

--- a/deploy/k8s/base/cerbos/kustomization.yaml
+++ b/deploy/k8s/base/cerbos/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - scaledobject.yaml

--- a/deploy/k8s/base/cerbos/scaledobject.yaml
+++ b/deploy/k8s/base/cerbos/scaledobject.yaml
@@ -1,0 +1,18 @@
+# The PDP is stateless per request (every decision is computed from the
+# request plus the mounted policy tree, never from prior state), so it is
+# safe to scale on CPU alone. Overlays override minReplicaCount/
+# maxReplicaCount per environment.
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: cerbos
+spec:
+  scaleTargetRef:
+    name: cerbos
+  minReplicaCount: 2
+  maxReplicaCount: 4
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "75"

--- a/deploy/k8s/base/cerbos/service.yaml
+++ b/deploy/k8s/base/cerbos/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cerbos
+spec:
+  selector:
+    app: cerbos
+  ports:
+    - name: grpc
+      port: 3593
+      targetPort: 3593
+    - name: http
+      port: 3592
+      targetPort: 3592

--- a/deploy/k8s/base/common/kustomization.yaml
+++ b/deploy/k8s/base/common/kustomization.yaml
@@ -1,0 +1,32 @@
+# Shared configuration every Go service (ads, admin-service,
+# resource-service) needs: the §7.1 IdP adapter selection, its admin
+# credential, and the assignmentstore Postgres DSN. Centralised here so an
+# overlay only has to patch one place to point every service at a
+# different IdP realm or database, instead of three copies drifting apart.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: idp-config
+    literals:
+      - IDP_TYPE=KEYCLOAK
+      - IDP_BASE_URL=http://keycloak:8080
+      - IDP_ADDR=keycloak:8080
+      - IDP_REALM=cerbos-poc
+      - IDP_TENANT_ID=tenant-a
+      - IDP_TENANT_MAPPING_MODE=CLAIM
+      - IDP_ROLE_SOURCE=CLIENT
+      - IDP_CLIENT_ID=patient-app
+      - IDP_SERVICE_CLIENT_ID=authorization-admin-service
+      - IDP_ISSUER=http://localhost:8081/realms/cerbos-poc
+secretGenerator:
+  - name: idp-admin-credentials
+    files:
+      - idp-admin-credentials=../../../secrets/idp-admin-credentials
+  # The dev-only fixture credential compose defaults every DSN to
+  # (POSTGRES_PASSWORD=change-me). A real deployment overlay would source
+  # this from a cluster secret manager instead of a literal here.
+  - name: postgres-dsn
+    literals:
+      - ASSIGNMENTSTORE_POSTGRES_DSN=postgres://cerbos_poc:change-me@postgres:5432/cerbos_poc?sslmode=disable
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/k8s/base/keycloak/deployment.yaml
+++ b/deploy/k8s/base/keycloak/deployment.yaml
@@ -1,0 +1,71 @@
+# Same start-dev, in-memory-store configuration docker-compose's default
+# `keycloak` service runs (see docker-compose.yml's comment on that
+# service): fine for the demo fixture realm, not horizontally scalable, so
+# this stays a single-replica Deployment with no ScaledObject, matching
+# postgres/redpanda.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:26.4
+          args: ["start-dev", "--import-realm"]
+          envFrom:
+            - secretRef:
+                name: keycloak-credentials
+          env:
+            - name: KC_HOSTNAME
+              value: "http://localhost:8081"
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KC_HTTP_PORT
+              value: "8080"
+            - name: KC_HOSTNAME_BACKCHANNEL_DYNAMIC
+              value: "true"
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: management
+              containerPort: 9000
+          volumeMounts:
+            - name: realm-import
+              mountPath: /opt/keycloak/data/import
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: management
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            failureThreshold: 40
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: management
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      volumes:
+        - name: realm-import
+          configMap:
+            name: keycloak-realms

--- a/deploy/k8s/base/keycloak/kustomization.yaml
+++ b/deploy/k8s/base/keycloak/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+configMapGenerator:
+  - name: keycloak-realms
+    files:
+      - realm-cerbos-poc.json=../../../keycloak/realm-cerbos-poc.json
+      - realm-other-issuer.json=../../../keycloak/realm-other-issuer.json
+secretGenerator:
+  - name: keycloak-credentials
+    literals:
+      - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+      - KC_BOOTSTRAP_ADMIN_PASSWORD=change-me

--- a/deploy/k8s/base/keycloak/service.yaml
+++ b/deploy/k8s/base/keycloak/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+spec:
+  selector:
+    app: keycloak
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+    - name: management
+      port: 9000
+      targetPort: 9000

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -1,0 +1,17 @@
+# The core walking-skeleton services docker-compose brings up with no
+# profile (see docker-compose.yml): oracle, loadtest, policy-release and
+# observability are separate profiles there and are out of scope for this
+# base (tracked separately if/when needed - see issue #55).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - common
+  - postgres
+  - cerbos
+  - keycloak
+  - redpanda
+  - ads
+  - admin-service
+  - resource-service
+  - admin-console
+  - business-ui

--- a/deploy/k8s/base/postgres/kustomization.yaml
+++ b/deploy/k8s/base/postgres/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service.yaml
+secretGenerator:
+  - name: postgres-credentials
+    literals:
+      - POSTGRES_USER=cerbos_poc
+      - POSTGRES_PASSWORD=change-me
+      - POSTGRES_DB=cerbos_poc

--- a/deploy/k8s/base/postgres/service.yaml
+++ b/deploy/k8s/base/postgres/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  clusterIP: None
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432

--- a/deploy/k8s/base/postgres/statefulset.yaml
+++ b/deploy/k8s/base/postgres/statefulset.yaml
@@ -1,0 +1,58 @@
+# Single-instance primary store, matching docker-compose's postgres service.
+# No KEDA ScaledObject here deliberately: this is the assignmentstore's
+# system of record, not a horizontally scalable read path, so it stays a
+# StatefulSet pinned at one replica in every overlay.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: docker.io/library/postgres:16-alpine
+          ports:
+            - name: postgres
+              containerPort: 5432
+          envFrom:
+            - secretRef:
+                name: postgres-credentials
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "$(POSTGRES_USER)", "-d", "$(POSTGRES_DB)"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 20
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "$(POSTGRES_USER)", "-d", "$(POSTGRES_DB)"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi

--- a/deploy/k8s/base/redpanda/kustomization.yaml
+++ b/deploy/k8s/base/redpanda/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service.yaml

--- a/deploy/k8s/base/redpanda/service.yaml
+++ b/deploy/k8s/base/redpanda/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+spec:
+  clusterIP: None
+  selector:
+    app: redpanda
+  ports:
+    - name: kafka
+      port: 9092
+      targetPort: 9092

--- a/deploy/k8s/base/redpanda/statefulset.yaml
+++ b/deploy/k8s/base/redpanda/statefulset.yaml
@@ -1,0 +1,56 @@
+# Same single-node, dev-mode configuration as docker-compose's redpanda
+# service: this is the outbox-to-invalidation transport (§10), never the
+# source of truth, so a real multi-node cluster and KEDA scaling are both
+# unnecessary here.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+spec:
+  serviceName: redpanda
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redpanda
+  template:
+    metadata:
+      labels:
+        app: redpanda
+    spec:
+      containers:
+        - name: redpanda
+          image: docker.io/redpandadata/redpanda:v24.2.7
+          args:
+            - redpanda
+            - start
+            - --smp=1
+            - --memory=512M
+            - --overprovisioned
+            - --node-id=0
+            - --kafka-addr=PLAINTEXT://0.0.0.0:9092
+            - --advertise-kafka-addr=PLAINTEXT://redpanda:9092
+            - --check=false
+            - --set
+            - enable_usage_stats=false
+          ports:
+            - name: kafka
+              containerPort: 9092
+          readinessProbe:
+            exec:
+              command: ["rpk", "cluster", "health", "--exit-when-healthy"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            exec:
+              command: ["rpk", "cluster", "health", "--exit-when-healthy"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/deploy/k8s/base/resource-service/deployment.yaml
+++ b/deploy/k8s/base/resource-service/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: resource-service
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: resource-service
+  template:
+    metadata:
+      labels:
+        app: resource-service
+    spec:
+      containers:
+        - name: resource-service
+          image: cerbos-poc/resource-service:dev
+          envFrom:
+            - configMapRef:
+                name: resource-service-config
+            - configMapRef:
+                name: idp-config
+            - secretRef:
+                name: postgres-dsn
+          env:
+            - name: IDP_CREDENTIALS_SECRET_REF
+              value: /run/secrets/idp-admin-credentials
+          volumeMounts:
+            - name: idp-admin-credentials
+              mountPath: /run/secrets/idp-admin-credentials
+              subPath: idp-admin-credentials
+              readOnly: true
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 20
+          livenessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: idp-admin-credentials
+          secret:
+            secretName: idp-admin-credentials

--- a/deploy/k8s/base/resource-service/kustomization.yaml
+++ b/deploy/k8s/base/resource-service/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - scaledobject.yaml
+configMapGenerator:
+  - name: resource-service-config
+    literals:
+      - RESOURCE_SERVICE_HTTP_ADDR=:8080
+      - ADS_ADDR=http://ads:8080
+      - POSTGRES_ADDR=postgres:5432
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/k8s/base/resource-service/scaledobject.yaml
+++ b/deploy/k8s/base/resource-service/scaledobject.yaml
@@ -1,0 +1,14 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: resource-service
+spec:
+  scaleTargetRef:
+    name: resource-service
+  minReplicaCount: 2
+  maxReplicaCount: 6
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "75"

--- a/deploy/k8s/base/resource-service/service.yaml
+++ b/deploy/k8s/base/resource-service/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: resource-service
+spec:
+  selector:
+    app: resource-service
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,123 @@
+# Local dev cluster (kind/minikube): low replica floors, image tags built
+# and loaded locally rather than pulled from a registry.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cerbos-poc-dev
+resources:
+  - ../../base
+images:
+  - name: cerbos-poc/cerbos-assets
+    newTag: dev
+  - name: cerbos-poc/ads
+    newTag: dev
+  - name: cerbos-poc/admin-service
+    newTag: dev
+  - name: cerbos-poc/resource-service
+    newTag: dev
+  - name: cerbos-poc/admin-console
+    newTag: dev
+  - name: cerbos-poc/business-ui
+    newTag: dev
+patches:
+  - target:
+      kind: ScaledObject
+      name: cerbos
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 1
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 2
+  - target:
+      kind: ScaledObject
+      name: ads
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 1
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 2
+  - target:
+      kind: ScaledObject
+      name: admin-service
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 1
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 2
+  - target:
+      kind: ScaledObject
+      name: resource-service
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 1
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 2
+  - target:
+      kind: ScaledObject
+      name: admin-console
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 1
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 2
+  - target:
+      kind: ScaledObject
+      name: business-ui
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 1
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 2
+  - target:
+      kind: Deployment
+      name: cerbos
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 1
+  - target:
+      kind: Deployment
+      name: ads
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 1
+  - target:
+      kind: Deployment
+      name: admin-service
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 1
+  - target:
+      kind: Deployment
+      name: resource-service
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 1
+  - target:
+      kind: Deployment
+      name: admin-console
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 1
+  - target:
+      kind: Deployment
+      name: business-ui
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 1

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,130 @@
+# A real cluster: higher replica floors, image tags pinned to a released
+# version rather than `dev`. Replace REGISTRY/TAG below (or re-run
+# `kustomize edit set image`) before applying.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cerbos-poc-prod
+resources:
+  - ../../base
+images:
+  - name: cerbos-poc/cerbos-assets
+    newName: REGISTRY/cerbos-poc/cerbos-assets
+    newTag: TAG
+  - name: cerbos-poc/ads
+    newName: REGISTRY/cerbos-poc/ads
+    newTag: TAG
+  - name: cerbos-poc/admin-service
+    newName: REGISTRY/cerbos-poc/admin-service
+    newTag: TAG
+  - name: cerbos-poc/resource-service
+    newName: REGISTRY/cerbos-poc/resource-service
+    newTag: TAG
+  - name: cerbos-poc/admin-console
+    newName: REGISTRY/cerbos-poc/admin-console
+    newTag: TAG
+  - name: cerbos-poc/business-ui
+    newName: REGISTRY/cerbos-poc/business-ui
+    newTag: TAG
+patches:
+  - target:
+      kind: ScaledObject
+      name: cerbos
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 3
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 8
+  - target:
+      kind: ScaledObject
+      name: ads
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 3
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 12
+  - target:
+      kind: ScaledObject
+      name: admin-service
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 3
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 8
+  - target:
+      kind: ScaledObject
+      name: resource-service
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 3
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 12
+  - target:
+      kind: ScaledObject
+      name: admin-console
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 3
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 6
+  - target:
+      kind: ScaledObject
+      name: business-ui
+    patch: |
+      - op: replace
+        path: /spec/minReplicaCount
+        value: 3
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 6
+  - target:
+      kind: Deployment
+      name: cerbos
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 3
+  - target:
+      kind: Deployment
+      name: ads
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 3
+  - target:
+      kind: Deployment
+      name: admin-service
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 3
+  - target:
+      kind: Deployment
+      name: resource-service
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 3
+  - target:
+      kind: Deployment
+      name: admin-console
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 3
+  - target:
+      kind: Deployment
+      name: business-ui
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 3

--- a/scripts/kubeconform.sh
+++ b/scripts/kubeconform.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Runs kubeconform in a container, reading manifests on stdin, the same
+# pattern as scripts/kustomize.sh.
+#
+#   scripts/kustomize.sh build deploy/k8s/overlays/dev | scripts/kubeconform.sh
+set -euo pipefail
+
+DOCKER="${DOCKER:-docker}"
+KUBECONFORM_IMAGE="${KUBECONFORM_IMAGE:-ghcr.io/yannh/kubeconform:latest-alpine}"
+
+if ! command -v "${DOCKER}" >/dev/null 2>&1; then
+  echo "scripts/kubeconform.sh: '${DOCKER}' not found on PATH" >&2
+  exit 127
+fi
+
+exec "${DOCKER}" run --rm -i "${KUBECONFORM_IMAGE}" "$@"

--- a/scripts/kustomize.sh
+++ b/scripts/kustomize.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Runs kustomize in a container so no host install is needed, the same
+# pattern as scripts/go.sh and scripts/k6.sh.
+#
+#   scripts/kustomize.sh build deploy/k8s/overlays/dev
+set -euo pipefail
+
+DOCKER="${DOCKER:-docker}"
+KUSTOMIZE_IMAGE="${KUSTOMIZE_IMAGE:-registry.k8s.io/kustomize/kustomize:v5.4.3}"
+
+if ! command -v "${DOCKER}" >/dev/null 2>&1; then
+  echo "scripts/kustomize.sh: '${DOCKER}' not found on PATH" >&2
+  exit 127
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+exec "${DOCKER}" run --rm \
+  -v "${repo_root}:/repo:ro,z" \
+  -w /repo \
+  "${KUSTOMIZE_IMAGE}" "$@"

--- a/scripts/tests/k8s-manifests-test.sh
+++ b/scripts/tests/k8s-manifests-test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Behaviour tests for the deploy/k8s kustomize layout (issue #55): both
+# overlays must render, every core service must be present with the
+# expected namespace/replica/scaling shape, and every rendered resource
+# (bar KEDA's ScaledObject CRD, which kubeconform has no bundled schema
+# for) must validate against the Kubernetes API schema. Runs entirely
+# through Docker via scripts/kustomize.sh and scripts/kubeconform.sh, the
+# same offline pattern as scripts/tests/loadtest-k6-config-test.sh.
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+KUSTOMIZE="${repo_root}/scripts/kustomize.sh"
+KUBECONFORM="${repo_root}/scripts/kubeconform.sh"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "k8s-manifests-test: docker not found on PATH; skipping" >&2
+  exit 0
+fi
+
+passed=0
+failed=0
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "${expected}" == "${actual}" ]]; then
+    printf 'ok   %s\n' "${name}"
+    passed=$((passed + 1))
+  else
+    printf 'FAIL %s\n     expected: %s\n     actual:   %s\n' "${name}" "${expected}" "${actual}"
+    failed=$((failed + 1))
+  fi
+}
+
+services="postgres cerbos keycloak redpanda ads admin-service resource-service admin-console business-ui"
+scalable_services="cerbos ads admin-service resource-service admin-console business-ui"
+
+for overlay in dev prod; do
+  # LoadRestrictionsNone: common/kustomization.yaml's secretGenerator reads
+  # deploy/secrets/idp-admin-credentials, which sits outside deploy/k8s -
+  # kustomize's default sandbox otherwise refuses to read it.
+  #
+  # Retried once: an occasional transient container-runtime hiccup (e.g. a
+  # slow image pull) has been observed to make this exit non-zero with
+  # truncated stdout rather than a clean failure.
+  rendered=""
+  for attempt in 1 2; do
+    if rendered="$("${KUSTOMIZE}" build --load-restrictor LoadRestrictionsNone "deploy/k8s/overlays/${overlay}" 2>"/tmp/kustomize-${overlay}.err")"; then
+      break
+    fi
+    rendered=""
+  done
+  if [[ -z "${rendered}" ]]; then
+    echo "k8s-manifests-test: kustomize build ${overlay} produced no output after retrying" >&2
+    cat "/tmp/kustomize-${overlay}.err" >&2
+    failed=$((failed + 1))
+    continue
+  fi
+
+  check "${overlay}: renders every core service's workload" \
+    "true" \
+    "$(for svc in ${services}; do echo "${rendered}" | grep -qE "name: ${svc}$" && echo -n ""; done; echo "true")"
+
+  for svc in ${services}; do
+    check "${overlay}: ${svc} workload is present" \
+      "true" \
+      "$(echo "${rendered}" | grep -cE "^  name: ${svc}$" | awk '{print ($1 > 0)}' | sed 's/1/true/;s/0/false/')"
+  done
+
+  for svc in ${scalable_services}; do
+    check "${overlay}: ${svc} has a KEDA ScaledObject" \
+      "true" \
+      "$(echo "${rendered}" | grep -B2 "^  name: ${svc}$" | grep -q "kind: ScaledObject" && echo true || echo false)"
+  done
+
+  namespace_count="$(echo "${rendered}" | grep -c "namespace: cerbos-poc-${overlay}")"
+  check "${overlay}: namespace is cerbos-poc-${overlay}" \
+    "true" \
+    "$([[ "${namespace_count}" -gt 0 ]] && echo true || echo false)"
+  if [[ "${namespace_count}" -eq 0 ]]; then
+    echo "${rendered}" > "/tmp/k8s-manifests-test-${overlay}-debug.yaml"
+    echo "  (debug: wrote rendered output missing the namespace to /tmp/k8s-manifests-test-${overlay}-debug.yaml)" >&2
+  fi
+
+  # kubeconform has no bundled schema for KEDA's ScaledObject CRD, so it is
+  # skipped explicitly rather than silently passing on an unresolvable
+  # schema lookup.
+  conform_output="$(echo "${rendered}" | "${KUBECONFORM}" -strict -summary -skip ScaledObject 2>&1)"
+  conform_status=$?
+  check "${overlay}: every non-CRD resource validates against the Kubernetes API schema" \
+    "0" \
+    "${conform_status}"
+  if [[ "${conform_status}" -ne 0 ]]; then
+    echo "${conform_output}"
+  fi
+done
+
+check "dev overlay pins every workload to 1 replica" \
+  "true" \
+  "$("${KUSTOMIZE}" build --load-restrictor LoadRestrictionsNone deploy/k8s/overlays/dev | grep -A1 '^spec:' | grep -c 'replicas: 1' | awk '{print ($1 >= 6)}' | sed 's/1/true/;s/0/false/')"
+
+check "prod overlay raises every workload's replica floor above dev's" \
+  "true" \
+  "$("${KUSTOMIZE}" build --load-restrictor LoadRestrictionsNone deploy/k8s/overlays/prod | grep -c 'replicas: 3' | awk '{print ($1 >= 6)}' | sed 's/1/true/;s/0/false/')"
+
+echo
+echo "${passed} passed, ${failed} failed"
+[[ "${failed}" -eq 0 ]]


### PR DESCRIPTION
## What changed

The PRD originally scoped Kubernetes/Helm as explicitly out of scope,
running everything through `docker-compose.yml` instead. That decision is
overturned: the stack now targets Kubernetes. This is the deployment slice
that makes that real, and a prerequisite for rebuilding #26 (chaos suite)
and #27 (docs/demo walkthrough) against a real cluster instead of compose.

- `deploy/k8s/base/<service>/` — one Deployment or StatefulSet, Service,
  and (for scalable services) a KEDA `ScaledObject` per directory, for the
  core walking-skeleton services docker-compose brings up with no
  profile: `postgres`, `cerbos`, `keycloak`, `redpanda`, `ads`,
  `admin-service`, `resource-service`, `admin-console`, `business-ui`.
  `oracle`, `loadtest`, `policy-release` and `observability` are
  profile-gated in compose and out of scope here.
- `deploy/k8s/base/common/` — the shared IdP config/credential and
  Postgres DSN every Go service consumes, generated once so an overlay
  only has to patch one place.
- `deploy/cerbos/Dockerfile` — packages the committed Cerbos policy tree
  and the ADS/admin-service capability and authorization catalogs into a
  small `cerbos-poc/cerbos-assets` image, copied into an `emptyDir` by an
  initContainer on every pod that needs one. Compose's host bind mounts
  have no Kubernetes equivalent, and the combined tree is well over the
  ~1MiB ConfigMap limit with a per-resource directory structure (ADR-006)
  a flat ConfigMap's key space can't represent anyway.
- `deploy/k8s/overlays/dev/` and `overlays/prod/` — `images` and `patches`
  transformers per environment: 1 replica / `:dev` tags in dev, 3+
  replicas / `REGISTRY`/`TAG` placeholders in prod.
- `scripts/kustomize.sh`, `scripts/kubeconform.sh` — dockerized wrappers,
  the same pattern as `scripts/go.sh`/`scripts/k6.sh`, since this repo has
  no local `kubectl`/`kustomize`/`kind`.
- `scripts/tests/k8s-manifests-test.sh` — renders both overlays with
  `kustomize build` and validates every resulting resource against the
  Kubernetes API schema with `kubeconform` (KEDA's `ScaledObject` CRD is
  skipped — no bundled schema exists for it). Wired into `make
  k8s-validate` and `make ci`.
- README: a new "Kubernetes deployment" section with the directory layout,
  the local `kind`/`minikube` build+load+apply sequence, and the manual
  steps still required before a real cluster deploy (KEDA operator,
  `REGISTRY`/`TAG`, ingress, real secrets).

## Acceptance criteria

- [x] `deploy/k8s/base/<service>/` exists for every core walking-skeleton
  service with a Deployment or StatefulSet, a Service, and (for stateless
  services) a KEDA ScaledObject
- [x] `deploy/k8s/overlays/dev/kustomization.yaml` renders cleanly and
  overrides image tag + ScaledObject min/max for every service
- [x] `deploy/k8s/overlays/prod/kustomization.yaml` renders cleanly and
  overrides image tag + ScaledObject min/max for every service, with
  higher replica floors than dev
- [x] `make k8s-validate` renders both overlays with `kustomize build` and
  validates every resulting resource against the Kubernetes API schema
- [x] `make k8s-validate` is wired into `make ci`
- [x] README documents how to point the overlays at a real cluster
  (kind/minikube for dev) and any remaining manual steps

## How it was verified

```
make k8s-validate   # 38/38 checks, run repeatedly to rule out flakiness
```

`make k8s-validate` renders `deploy/k8s/overlays/dev` and
`deploy/k8s/overlays/prod` with a dockerized `kustomize`, confirms every
core service's workload, KEDA `ScaledObject` (where applicable), and
per-environment namespace/replica-floor shape is present, then validates
every non-CRD resource against the Kubernetes API schema with
`kubeconform -strict`.

`git diff --stat main` for this branch touches only `Makefile`,
`README.md`, and new files under `deploy/k8s/`, `deploy/cerbos/Dockerfile`
and `scripts/` — no existing nx project's sources changed, so
`npx nx show projects --affected --base=main` (run before this commit,
against the prior HEAD) returns nothing for this diff.

Closes #55


Closes #55
