### PR TITLE
Fix CI: nx-affected, compose contract and IdP diagnostics timeout

### DIFF
--- a/apps/admin-service/internal/platformstatus/platformstatus.go
+++ b/apps/admin-service/internal/platformstatus/platformstatus.go
@@ -9,12 +9,21 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/adsclient"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/authority"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
 	"github.com/tishan-harischandra/cerbos-poc/libs/policyrelease"
 )
+
+// idPHealthCheckTimeout bounds the live connectivity check IdPDiagnostics
+// makes against the ADS's identity directory proxy. Without a deadline of
+// its own, an IdP outage - the exact condition this check exists to
+// report - would hang the request for as long as the outbound connection
+// takes to fail at the TCP level, which can far exceed any caller's
+// timeout instead of reporting "degraded" promptly.
+const idPHealthCheckTimeout = 3 * time.Second
 
 // PolicyStore is the slice of policyrelease.Store this handler reads.
 type PolicyStore interface {
@@ -126,8 +135,11 @@ func (h *Handler) IdPDiagnostics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(r.Context(), idPHealthCheckTimeout)
+	defer cancel()
+
 	connectivity := "ok"
-	if err := h.ADS.DirectoryHealth(r.Context(), identity.RawToken); err != nil {
+	if err := h.ADS.DirectoryHealth(ctx, identity.RawToken); err != nil {
 		connectivity = "degraded"
 	}
 

--- a/apps/admin-service/internal/platformstatus/platformstatus_test.go
+++ b/apps/admin-service/internal/platformstatus/platformstatus_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/adsclient"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/platformstatus"
@@ -200,6 +201,48 @@ func TestIdPDiagnostics_ReportsTheSelectedProviderAndOKConnectivity(t *testing.T
 	}
 	if body.Provider != "KEYCLOAK" || body.Connectivity != "ok" {
 		t.Fatalf("body = %+v, want provider KEYCLOAK, connectivity ok", body)
+	}
+}
+
+type hangingADS struct{}
+
+func (hangingADS) Convergence(ctx context.Context, _ string) (adsclient.ConvergenceResponse, error) {
+	<-ctx.Done()
+	return adsclient.ConvergenceResponse{}, ctx.Err()
+}
+
+func (hangingADS) DirectoryHealth(ctx context.Context, _ string) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// A downstream outage - the exact condition this endpoint exists to report -
+// must never hang the request indefinitely. The check has to fail on its own
+// short deadline and report "degraded" rather than block on however long the
+// caller happens to wait (issue #26's node-drain and IdP-outage scenarios
+// depend on this responding well within their own client timeouts).
+func TestIdPDiagnostics_FailsFastWhenTheADSNeverResponds(t *testing.T) {
+	handler := &platformstatus.Handler{ADS: hangingADS{}, IdPType: "KEYCLOAK"}
+
+	started := time.Now()
+	rec := httptest.NewRecorder()
+	handler.IdPDiagnostics(rec, get("/admin/idp/diagnostics", adminOf("tenant-a")))
+	elapsed := time.Since(started)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("IdPDiagnostics took %s, want it to fail closed well under 5s", elapsed)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+	var body struct {
+		Connectivity string `json:"connectivity"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if body.Connectivity != "degraded" {
+		t.Fatalf("connectivity = %q, want degraded", body.Connectivity)
 	}
 }
 

--- a/scripts/tests/compose-contract.py
+++ b/scripts/tests/compose-contract.py
@@ -137,7 +137,14 @@ def main() -> int:
     if failures:
         return 1
 
+    # One-shot init containers run to completion and are never health polled;
+    # dependents gate on `condition: service_completed_successfully` instead,
+    # so a healthcheck on them would be dead configuration, not a contract.
+    ONE_SHOT_INIT_SERVICES = {"policy-release-store-init"}
+
     for name, service in services.items():
+        if name in ONE_SHOT_INIT_SERVICES:
+            continue
         check(f"service '{name}' declares a healthcheck", "healthcheck" in service)
 
     check(

--- a/tests/architecture/dialect.go
+++ b/tests/architecture/dialect.go
@@ -14,6 +14,17 @@ import (
 var dialectAdapterDirs = []string{
 	"libs/assignmentstore/postgresstore",
 	"libs/assignmentstore/oraclestore",
+	// Leader election uses a PostgreSQL advisory lock directly: it is not
+	// part of the assignmentstore port's dual-dialect contract, and an
+	// advisory lock has no portable equivalent to abstract behind a port.
+	"apps/policy-controller/internal/leader",
+	// The load-test seeding harness writes straight into Keycloak's own
+	// database, whose schema Keycloak owns and which this prototype only
+	// ever runs on PostgreSQL (see keycloak-db in docker-compose.yml). It
+	// is out of the assignmentstore port's dual-dialect scope for the same
+	// reason Keycloak's schema itself is: nothing here claims Oracle
+	// portability for Keycloak's own tables.
+	"libs/keycloakbulkload",
 }
 
 // dialectMarkers are constructs that only one engine understands. Each is


### PR DESCRIPTION
## Root causes fixed

1. **nx-affected / architecture:test** - `TestNoDialectSpecificSQLOutsideTheAdapters` flagged pgx imports in `apps/policy-controller/internal/leader` (Postgres advisory-lock leader election) and `libs/keycloakbulkload` (writes into Keycloak's own Postgres schema). Neither is part of the `assignmentstore` dual-dialect port's contract, so both are now recognised as legitimate single-dialect exceptions.

2. **compose job / compose-contract.py** - the blanket "every service declares a healthcheck" check had no exception for one-shot init containers. `policy-release-store-init` runs to completion; its dependent already gates on `condition: service_completed_successfully`, not a healthcheck.

3. **IdP diagnostics endpoint** - `IdPDiagnostics` called the ADS's identity directory proxy on the incoming request's own context, with no deadline of its own. During an IdP outage (the exact condition this endpoint exists to report), the outbound call could hang until the connection failed at the TCP level - far longer than any caller's timeout - instead of promptly reporting `"degraded"`. Diagnosed from the chaos suite's `07-idp-admin-outage` scenario. Now bounded by a 3s context timeout, with a regression test asserting the handler returns well under 5s even when the ADS never responds.

## Local verification

- `python3 scripts/tests/compose-contract.py` - passes
- `nx run architecture:test` - passes
- `nx run admin-service:test` - passes (new `TestIdPDiagnostics_FailsFastWhenTheADSNeverResponds` passes)
- `nx affected --target=lint/test/build` - passes

## Known remaining CI gap (not in this PR)

The chaos scenario suite (`make chaos`, only runs on push to `main`) has 6 failing scenarios: `04-kafka-outage`, `05-policy-rollout-failure`, `07-idp-admin-outage` (partially addressed here), `08-node-drain`, `09-keda-scale-to-zero`, `10-keda-scale-to-max`. Static analysis suggests at least two more root causes:
- `08-node-drain` cascades into `09`/`10`: `kubectl port-forward svc/X` targets a single pod at invocation time and does not re-target if that pod is evicted/rescheduled (e.g. by node drain), permanently breaking the tunnel for the rest of the run.
- `04`/`05` may be a stale-connection-after-pod-restart issue in admin-service's own Postgres pool (untouched by traffic during the prior scenario, so a dead connection from before a Postgres pod restart isn't detected until it's used, then hangs past the scenario's 5s curl timeout).

These require a live kind cluster to confirm and fix; deferred per user direction to a follow-up session.