### PR TITLE
Fix stale chaos port-forwards and 04-kafka-outage crash

### DIFF
--- a/scripts/chaos/lib.sh
+++ b/scripts/chaos/lib.sh
@@ -73,6 +73,16 @@ wait_for_rollout() {
 # ${CHAOS_PORT_FORWARD_PIDS_FILE} so stop_port_forwards can clean them up.
 CHAOS_PORT_FORWARD_PIDS_FILE="${repo_root}/.chaos-port-forward-pids"
 
+# start_one_port_forward <target> <local_port> <remote_port>
+# Backgrounds a single kubectl port-forward tunnel and records its PID in
+# CHAOS_PORT_FORWARD_PIDS_FILE so stop_port_forwards cleans it up too.
+start_one_port_forward() {
+  local target="$1" local_port="$2" remote_port="$3"
+  kubectl_chaos port-forward "${target}" "${local_port}:${remote_port}" \
+    >>"${repo_root}/.chaos-port-forward.log" 2>&1 &
+  echo "$!" >> "${CHAOS_PORT_FORWARD_PIDS_FILE}"
+}
+
 start_port_forwards() {
   : > "${CHAOS_PORT_FORWARD_PIDS_FILE}"
   local spec
@@ -83,12 +93,25 @@ start_port_forwards() {
     "svc/gitea:${CHAOS_GITEA_PORT}:3000"; do
     local target="${spec%%:*}" rest="${spec#*:}"
     local local_port="${rest%%:*}" remote_port="${rest#*:}"
-    kubectl_chaos port-forward "${target}" "${local_port}:${remote_port}" \
-      >>"${repo_root}/.chaos-port-forward.log" 2>&1 &
-    echo "$!" >> "${CHAOS_PORT_FORWARD_PIDS_FILE}"
+    start_one_port_forward "${target}" "${local_port}" "${remote_port}"
   done
   # Give kubectl a moment to establish the tunnels before the first caller
   # tries to use one.
+  sleep 3
+}
+
+# restart_port_forward <target> <local_port> <remote_port>
+# kubectl port-forward against a Service resolves to one specific pod at
+# the moment the tunnel opens and never follows a pod replacement. Any
+# scenario that deletes or replaces the pod behind one of
+# start_port_forwards' tunnels (scaling a deployment to 0 and back, for
+# example) leaves that tunnel forwarding to a pod that no longer exists,
+# breaking every later scenario that reuses it. Call this right after such
+# a scenario restores the deployment.
+restart_port_forward() {
+  local target="$1" local_port="$2" remote_port="$3"
+  pkill -f "port-forward ${target} ${local_port}:${remote_port}" 2>/dev/null || true
+  start_one_port_forward "${target}" "${local_port}" "${remote_port}"
   sleep 3
 }
 

--- a/scripts/chaos/scenarios/04-kafka-outage.sh
+++ b/scripts/chaos/scenarios/04-kafka-outage.sh
@@ -18,6 +18,10 @@ token="$(token_for user-admin)"
 echo "==> Reading the current permission revision"
 current_revision="$(curl -sS --max-time 5 -H "Authorization: Bearer ${token}" \
   "${admin_url}/permission-revision" | jq -r '.revision')"
+if ! [[ "${current_revision}" =~ ^[0-9]+$ ]]; then
+  echo "FAIL a permission write commits while Kafka is paused (could not read the current permission revision: got '${current_revision}')"
+  exit 1
+fi
 
 echo "==> Pausing Kafka (scaling statefulset/redpanda to 0)"
 kubectl_chaos scale statefulset/redpanda --replicas=0

--- a/scripts/chaos/scenarios/06-gitea-outage.sh
+++ b/scripts/chaos/scenarios/06-gitea-outage.sh
@@ -30,5 +30,8 @@ fi
 echo "==> Restoring Gitea"
 kubectl_chaos scale deployment/gitea --replicas=1
 wait_for_rollout deployment/gitea 180s
+# See 07-idp-admin-outage.sh's identical call: the scale-to-zero above
+# deleted the pod the long-lived Gitea port-forward was bound to.
+restart_port_forward svc/gitea "${CHAOS_GITEA_PORT}" 3000
 
 exit "${result}"

--- a/scripts/chaos/scenarios/07-idp-admin-outage.sh
+++ b/scripts/chaos/scenarios/07-idp-admin-outage.sh
@@ -67,5 +67,10 @@ fi
 echo "==> Restoring the IdP"
 kubectl_chaos scale deployment/keycloak --replicas=1
 wait_for_rollout deployment/keycloak 180s
+# The scale-to-zero above deleted the pod the long-lived Keycloak
+# port-forward from lib.sh's start_port_forwards was bound to; without
+# this, every later scenario's token_for call fails against a tunnel that
+# forwards to a pod that no longer exists (see restart_port_forward).
+restart_port_forward svc/keycloak "${KEYCLOAK_PORT}" 8080
 
 exit "${result}"


### PR DESCRIPTION
## Summary
- Fixes 3 of the 5 make chaos failures reported by the user: 08-node-drain, 09-keda-scale-to-zero, 10-keda-scale-to-max all failed with an unrelated "can't reach Keycloak" error because kubectl port-forward against svc/keycloak is bound to one pod at tunnel-open time and never follows the pod replacement that 07-idp-admin-outage.sh causes (scale to 0, back to 1). Added lib.sh:restart_port_forward and call it from 07 (Keycloak) and 06 (Gitea, same latent bug).
- Hardens 04-kafka-outage.sh: a failed permission-revision read left current_revision empty, crashing jq -cn --argjson with an opaque error instead of a clear scenario failure.

## Not fixed here
05-policy-rollout-failure's root cause was not conclusively identified via static review; recommend re-running make chaos with these fixes in place and capturing policy-controller logs if it still fails.

Local verification: shellcheck/bash -n only (kind cluster chaos run needs to be re-executed by the user; not runnable from this environment).