### PR TITLE
Bump actions/checkout to v5 across every CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: nx affected
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -52,7 +52,7 @@ jobs:
     name: cerbos policy suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Fails fast if the committed catalog (policies, schemas, tests, DB
       # seed) has drifted from libs/cataloggen/manifest.yaml, without waiting
@@ -88,7 +88,7 @@ jobs:
     name: authorization schema on postgres
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Start PostgreSQL
         run: |
@@ -122,7 +122,7 @@ jobs:
     outputs:
       database: ${{ steps.filter.outputs.database }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -159,7 +159,7 @@ jobs:
     if: needs.changes.outputs.database == 'true' || github.event_name == 'push'
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Start both engines
         run: |
@@ -194,7 +194,7 @@ jobs:
     name: docker compose walking skeleton
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install the compose contract test dependencies
         run: pip install --quiet pyyaml
@@ -234,7 +234,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run the chaos suite against a real kind cluster
         run: make chaos


### PR DESCRIPTION
actions/checkout@v4 is deprecated in favor of v5 (Node 24 runtime); updates every job in ci.yml.