### PR TITLE
Surface the real HTTP/controller error on two chaos scenario failures

### DIFF
--- a/scripts/chaos/scenarios/04-kafka-outage.sh
+++ b/scripts/chaos/scenarios/04-kafka-outage.sh
@@ -16,10 +16,11 @@ result=0
 token="$(token_for user-admin)"
 
 echo "==> Reading the current permission revision"
-current_revision="$(curl -sS --max-time 5 -H "Authorization: Bearer ${token}" \
-  "${admin_url}/permission-revision" | jq -r '.revision')"
-if ! [[ "${current_revision}" =~ ^[0-9]+$ ]]; then
-  echo "FAIL a permission write commits while Kafka is paused (could not read the current permission revision: got '${current_revision}')"
+revision_status="$(curl -sS -o /tmp/chaos-kafka-revision.json -w '%{http_code}' --max-time 5 \
+  -H "Authorization: Bearer ${token}" "${admin_url}/permission-revision")"
+current_revision="$(jq -r '.revision' /tmp/chaos-kafka-revision.json)"
+if [[ "${revision_status}" != "200" ]] || ! [[ "${current_revision}" =~ ^[0-9]+$ ]]; then
+  echo "FAIL a permission write commits while Kafka is paused (could not read the current permission revision: HTTP ${revision_status}: $(cat /tmp/chaos-kafka-revision.json))"
   exit 1
 fi
 

--- a/scripts/chaos/scenarios/05-policy-rollout-failure.sh
+++ b/scripts/chaos/scenarios/05-policy-rollout-failure.sh
@@ -63,7 +63,9 @@ done
 if [[ "${rejected}" -eq 1 ]]; then
   echo "ok   the failed release is recorded and not marked active"
 else
-  echo "FAIL the failed release is recorded and not marked active (never observed in history: ${history:-none})"
+  controller_status="$(kubectl_chaos exec deployment/policy-controller -- \
+    wget -qO- http://127.0.0.1:8082/readyz 2>&1 || true)"
+  echo "FAIL the failed release is recorded and not marked active (never observed in history: ${history:-none}; policy-controller /readyz: ${controller_status:-none})"
   result=1
 fi
 


### PR DESCRIPTION
Diagnostics-only follow-up to #60. 04-kafka-outage's permission-revision now returned an actual response (previously masked by the stale-port-forward timeout) but the guard added in #60 only logged the unparseable body ('null'), not the HTTP status, so we can't tell if it's a 401/403/500. 05-policy-rollout-failure's root cause is still unconfirmed via static review; dumping policy-controller's own /readyz on failure will show its lastError directly.