### PR TITLE
Fix policy-controller leader election reconnect and two chaos scenario bugs

### DIFF
--- a/apps/policy-controller/internal/leader/leader.go
+++ b/apps/policy-controller/internal/leader/leader.go
@@ -8,9 +8,20 @@ package leader
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 )
+
+// reconnectPingTimeout bounds the liveness ping ensureConn gives the
+// dedicated connection before deciding it is dead and redialing. A
+// PostgreSQL restart (the case that matters here: issue #26's chaos suite
+// restarts the database ahead of a policy-rollout scenario) leaves this
+// connection's socket half-open - it looks fine until something actually
+// uses it, and the raw pgx.Conn this Elector holds never notices or
+// reconnects on its own, so every TryAcquire after a restart failed the
+// same way and the controller silently stopped processing releases.
+const reconnectPingTimeout = 2 * time.Second
 
 // Elector holds one dedicated PostgreSQL connection and uses it to contend
 // for a session-scoped advisory lock. The lock is tied to the connection, not
@@ -18,6 +29,7 @@ import (
 // releases it automatically, so a crashed leader cannot hold the fleet
 // hostage.
 type Elector struct {
+	dsn     string
 	conn    *pgx.Conn
 	lockKey int64
 }
@@ -30,12 +42,36 @@ func New(ctx context.Context, dsn string, lockKey int64) (*Elector, error) {
 	if err != nil {
 		return nil, fmt.Errorf("leader: connecting: %w", err)
 	}
-	return &Elector{conn: conn, lockKey: lockKey}, nil
+	return &Elector{dsn: dsn, conn: conn, lockKey: lockKey}, nil
+}
+
+// ensureConn verifies the dedicated connection is still alive and
+// transparently redials it otherwise, so a PostgreSQL restart between two
+// TryAcquire calls does not wedge leader election forever.
+func (e *Elector) ensureConn(ctx context.Context) error {
+	if !e.conn.IsClosed() {
+		pingCtx, cancel := context.WithTimeout(ctx, reconnectPingTimeout)
+		alive := e.conn.Ping(pingCtx) == nil
+		cancel()
+		if alive {
+			return nil
+		}
+	}
+	_ = e.conn.Close(ctx)
+	conn, err := pgx.Connect(ctx, e.dsn)
+	if err != nil {
+		return fmt.Errorf("leader: reconnecting: %w", err)
+	}
+	e.conn = conn
+	return nil
 }
 
 // TryAcquire attempts to become leader without blocking. It returns false,
 // with no error, when another instance already holds the lock.
 func (e *Elector) TryAcquire(ctx context.Context) (bool, error) {
+	if err := e.ensureConn(ctx); err != nil {
+		return false, err
+	}
 	var acquired bool
 	if err := e.conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", e.lockKey).Scan(&acquired); err != nil {
 		return false, fmt.Errorf("leader: pg_try_advisory_lock: %w", err)

--- a/apps/policy-controller/internal/leader/leader_internal_test.go
+++ b/apps/policy-controller/internal/leader/leader_internal_test.go
@@ -1,0 +1,61 @@
+package leader
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// TestElector_ReconnectsAfterConnectionLoss guards against issue #26's chaos
+// suite finding: a PostgreSQL restart underneath a live Elector left its
+// dedicated connection half-open, so every later TryAcquire failed the same
+// way and the policy controller silently stopped processing releases.
+func TestElector_ReconnectsAfterConnectionLoss(t *testing.T) {
+	dsn := os.Getenv("ASSIGNMENTSTORE_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("ASSIGNMENTSTORE_POSTGRES_DSN is not set")
+	}
+	ctx := context.Background()
+
+	e, err := New(ctx, dsn, 384756123)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer e.Close(ctx)
+
+	acquired, err := e.TryAcquire(ctx)
+	if err != nil {
+		t.Fatalf("TryAcquire (before): %v", err)
+	}
+	if !acquired {
+		t.Fatal("TryAcquire (before) = false, want true on an uncontended lock")
+	}
+
+	killer, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting the killer: %v", err)
+	}
+	defer killer.Close(ctx)
+
+	// Simulate the connection dying underneath the Elector - a PostgreSQL
+	// restart being the case that matters - by terminating its backend
+	// from a second connection, without ever closing e.conn ourselves.
+	pid := e.conn.PgConn().PID()
+	if _, err := killer.Exec(ctx, "SELECT pg_terminate_backend($1)", pid); err != nil {
+		t.Fatalf("pg_terminate_backend: %v", err)
+	}
+	// Give PostgreSQL a moment to actually tear down the backend before
+	// asserting the Elector notices and recovers.
+	time.Sleep(200 * time.Millisecond)
+
+	acquiredAfter, err := e.TryAcquire(ctx)
+	if err != nil {
+		t.Fatalf("TryAcquire (after connection loss): %v", err)
+	}
+	if !acquiredAfter {
+		t.Fatal("TryAcquire (after connection loss) = false, want true: the Elector should reconnect and reacquire the now-unheld lock")
+	}
+}

--- a/scripts/chaos/scenarios/04-kafka-outage.sh
+++ b/scripts/chaos/scenarios/04-kafka-outage.sh
@@ -16,11 +16,23 @@ result=0
 token="$(token_for user-admin)"
 
 echo "==> Reading the current permission revision"
-revision_status="$(curl -sS -o /tmp/chaos-kafka-revision.json -w '%{http_code}' --max-time 5 \
-  -H "Authorization: Bearer ${token}" "${admin_url}/permission-revision")"
-current_revision="$(jq -r '.revision' /tmp/chaos-kafka-revision.json)"
+# The previous scenario (03-database-outage) only just restored PostgreSQL,
+# and admin-service's own connection pool needs a moment to notice its
+# pooled connections are stale and redial - so the first read here is
+# retried rather than failed outright on one slow response.
+revision_status=""
+current_revision=""
+for _ in $(seq 1 10); do
+  revision_status="$(curl -sS -o /tmp/chaos-kafka-revision.json -w '%{http_code}' --max-time 5 \
+    -H "Authorization: Bearer ${token}" "${admin_url}/permission-revision")"
+  current_revision="$(jq -r '.revision' /tmp/chaos-kafka-revision.json 2>/dev/null || true)"
+  if [[ "${revision_status}" == "200" ]] && [[ "${current_revision}" =~ ^[0-9]+$ ]]; then
+    break
+  fi
+  sleep 2
+done
 if [[ "${revision_status}" != "200" ]] || ! [[ "${current_revision}" =~ ^[0-9]+$ ]]; then
-  echo "FAIL a permission write commits while Kafka is paused (could not read the current permission revision: HTTP ${revision_status}: $(cat /tmp/chaos-kafka-revision.json))"
+  echo "FAIL a permission write commits while Kafka is paused (could not read the current permission revision: HTTP ${revision_status}: $(cat /tmp/chaos-kafka-revision.json 2>/dev/null))"
   exit 1
 fi
 

--- a/scripts/chaos/scenarios/05-policy-rollout-failure.sh
+++ b/scripts/chaos/scenarios/05-policy-rollout-failure.sh
@@ -63,7 +63,7 @@ done
 if [[ "${rejected}" -eq 1 ]]; then
   echo "ok   the failed release is recorded and not marked active"
 else
-  controller_status="$(kubectl_chaos exec deployment/policy-controller -- \
+  controller_status="$(kubectl_chaos exec deployment/policy-controller -c policy-controller -- \
     wget -qO- http://127.0.0.1:8082/readyz 2>&1 || true)"
   echo "FAIL the failed release is recorded and not marked active (never observed in history: ${history:-none}; policy-controller /readyz: ${controller_status:-none})"
   result=1


### PR DESCRIPTION
## Root cause

`04-kafka-outage` and `05-policy-rollout-failure` in issue #26's chaos suite fail on `main` (run 31302492231).

- **05-policy-rollout-failure (real bug)**: `leader.Elector` held one dedicated `pgx.Conn` for its whole lifetime with no liveness check. `03-database-outage` restarts PostgreSQL earlier in the suite, which leaves that connection half-open. Every subsequent `TryAcquire` then fails the same way, the controller silently stops contending for leadership, and the release pipeline never runs again - so the broken tag pushed in 05 is never even evaluated, let alone rejected. Fixed by pinging the connection with a bounded timeout before each `TryAcquire` and transparently redialing on failure, mirroring the `BeforeAcquire` liveness check `postgresstore.Open` already uses for the same class of problem. Added `TestElector_ReconnectsAfterConnectionLoss`, which kills the Elector's backend with `pg_terminate_backend` and asserts recovery (verified against a real Postgres container locally).
- **05 diagnostics bug**: the failure-path diagnostic `kubectl exec`'d into `deployment/policy-controller` without `-c`, defaulting to the `cerbos-managed` container, which has no `wget`. Now targets `-c policy-controller` explicitly.
- **04-kafka-outage**: its first read of the permission revision ran immediately after `03-database-outage` restored PostgreSQL, before admin-service's own connection pool had a chance to notice its pooled connections were stale and redial. Now retries that read for up to ~20s instead of failing outright on the first slow response.

## Verification

- `npx nx affected --target=lint,test,build` (policy-controller, architecture) - green.
- New `leader` package test suite run against a real PostgreSQL container (`docker compose up postgres` + `scripts/go.sh` with `GO_NETWORK`), including the new reconnect regression test - green.
- Full validation is the chaos scenario suite itself, which only runs on push to `main` (`.github/workflows/ci.yml`'s `chaos` job); will monitor that run after merge.