### PR TITLE
Bound the ADS revision reconciler's per-tenant PostgreSQL read

### DIFF
--- a/apps/ads/internal/invalidation/reconciler.go
+++ b/apps/ads/internal/invalidation/reconciler.go
@@ -15,6 +15,19 @@ import (
 // path never delivers it at all.
 const DefaultReconcileInterval = 2 * time.Second
 
+// DefaultPerTenantTimeout bounds a single tenant's Store.PermissionRevision
+// call within one reconciliation pass when ReconcilerConfig.PerTenantTimeout
+// is left zero.
+//
+// ReconcileOnce runs on one goroutine and checks every known tenant in
+// sequence with no timeout of its own, so a single slow or stuck call - a
+// PostgreSQL restart leaving the pool's idle connections stale is the case
+// that matters here (issue #26's chaos suite) - would otherwise stall every
+// tenant behind it and every future tick until that one call finally
+// returns, silently pausing convergence for the whole replica rather than
+// just missing one pass for one tenant.
+const DefaultPerTenantTimeout = 5 * time.Second
+
 // RevisionSource is the authoritative revision this reconciler compares the
 // cache against - PostgreSQL, via assignmentstore.Store, directly. It never
 // goes through the cache itself: comparing a cache against itself could
@@ -38,6 +51,9 @@ type ReconcilerConfig struct {
 	// Interval bounds how often a reconciliation pass runs. Zero means
 	// DefaultReconcileInterval.
 	Interval time.Duration
+	// PerTenantTimeout bounds a single tenant's Store.PermissionRevision
+	// call within one pass. Zero means DefaultPerTenantTimeout.
+	PerTenantTimeout time.Duration
 	// OnDrift, if set, is called whenever a pass finds and repairs a
 	// mismatch, naming the tenant and the two revisions that disagreed.
 	OnDrift func(tenantID string, cached, actual int64)
@@ -61,6 +77,9 @@ func NewReconciler(cfg ReconcilerConfig) *Reconciler {
 	if cfg.Interval <= 0 {
 		cfg.Interval = DefaultReconcileInterval
 	}
+	if cfg.PerTenantTimeout <= 0 {
+		cfg.PerTenantTimeout = DefaultPerTenantTimeout
+	}
 	return &Reconciler{cfg: cfg}
 }
 
@@ -70,7 +89,7 @@ func NewReconciler(cfg ReconcilerConfig) *Reconciler {
 // misses on its first read, not through this pass.
 func (r *Reconciler) ReconcileOnce(ctx context.Context) {
 	for _, tenantID := range r.cfg.Cache.KnownTenants() {
-		actual, found, err := r.cfg.Store.PermissionRevision(ctx, tenantID)
+		actual, found, err := r.checkTenant(ctx, tenantID)
 		if err != nil {
 			if r.cfg.OnError != nil {
 				r.cfg.OnError(err)
@@ -93,6 +112,14 @@ func (r *Reconciler) ReconcileOnce(ctx context.Context) {
 			r.cfg.OnDrift(tenantID, cachedRevision, actualRevision)
 		}
 	}
+}
+
+// checkTenant reads one tenant's actual revision, bounded by
+// PerTenantTimeout so this one call can never stall the whole pass.
+func (r *Reconciler) checkTenant(ctx context.Context, tenantID string) (assignmentstore.PermissionRevision, bool, error) {
+	tenantCtx, cancel := context.WithTimeout(ctx, r.cfg.PerTenantTimeout)
+	defer cancel()
+	return r.cfg.Store.PermissionRevision(tenantCtx, tenantID)
 }
 
 // Run calls ReconcileOnce immediately, then on every tick of Interval, until

--- a/apps/ads/internal/invalidation/reconciler_test.go
+++ b/apps/ads/internal/invalidation/reconciler_test.go
@@ -140,6 +140,51 @@ func (s *erroringOneTenantSource) PermissionRevision(_ context.Context, tenantID
 	return assignmentstore.PermissionRevision{TenantID: tenantID, Revision: revision}, found, nil
 }
 
+// hangingRevisionSource never returns until its context is cancelled - the
+// case that matters here is a PostgreSQL connection left half-open by a
+// restart (issue #26's chaos suite), which otherwise blocks pgxpool's
+// Acquire indefinitely since ReconcileOnce's own caller passes it no
+// deadline.
+type hangingRevisionSource struct{}
+
+func (hangingRevisionSource) PermissionRevision(ctx context.Context, _ string) (assignmentstore.PermissionRevision, bool, error) {
+	<-ctx.Done()
+	return assignmentstore.PermissionRevision{}, false, ctx.Err()
+}
+
+// A tenant whose Store call hangs must not stall the whole pass past
+// PerTenantTimeout - a bound this test sets short so it does not itself
+// hang - and must still report the hang through OnError rather than
+// silently doing nothing.
+func TestReconcileOnceBoundsAHangingTenantByPerTenantTimeout(t *testing.T) {
+	cache := &fakeReconcilerCache{known: []string{"tenant-a"}, cached: map[string]int64{"tenant-a": 5}}
+
+	var errs []error
+	reconciler := invalidation.NewReconciler(invalidation.ReconcilerConfig{
+		Cache: cache, Store: hangingRevisionSource{},
+		PerTenantTimeout: 20 * time.Millisecond,
+		OnError:          func(err error) { errs = append(errs, err) },
+	})
+
+	done := make(chan struct{})
+	go func() {
+		reconciler.ReconcileOnce(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("ReconcileOnce did not return within PerTenantTimeout of a hanging Store call")
+	}
+	if len(errs) != 1 {
+		t.Fatalf("got %d errors, want 1 for the timed-out tenant", len(errs))
+	}
+	if len(cache.invalidated) != 0 {
+		t.Errorf("invalidated = %v, want none: a timeout is not a confirmed drift", cache.invalidated)
+	}
+}
+
 // A tenant this replica has never served costs nothing: KnownTenants would
 // simply never name it, so Run must not require any external enumeration of
 // every tenant in the system.


### PR DESCRIPTION
## Root cause

Follow-up to #63. After that fix, `04-kafka-outage` still failed on `main` (run 31304315626): the initial revision read and the write both succeeded now, but the revision reconciler never converged within the scenario's 60s budget on one ADS replica (`cachedRevision:184, actualRevision:185, converged:false` repeated for the whole window).

`Reconciler.ReconcileOnce` calls `Store.PermissionRevision` once per known tenant, in sequence, with no timeout of its own, on a long-running goroutine whose `ctx` carries no deadline. `03-database-outage` restarts PostgreSQL earlier in the same suite run - exactly the condition `postgresstore`'s own `BeforeAcquire` comment already documents as capable of leaving a pooled connection half-open. One tenant's call blocking behind such a connection stalls that tenant, and every tenant after it, for every future tick, until the call finally returns.

## Fix

`checkTenant` now wraps each per-tenant `Store.PermissionRevision` call in a bounded context (`PerTenantTimeout`, default 5s, configurable via `ReconcilerConfig`). A stuck call now surfaces as one reported error and the reconciler retries on its next tick instead of stalling convergence indefinitely.

## Verification

- Added `TestReconcileOnceBoundsAHangingTenantByPerTenantTimeout` (a `Store` that never returns until its context is cancelled); `npx nx affected --target=lint,test,build` (ads, architecture) - green.
- Full validation is the chaos scenario suite, which only runs on push to `main`; will monitor after merge.