### PR TITLE
Retry 07-idp-admin-outage's ads requests through a transient post-scale blackhole

### DIFF
--- a/scripts/chaos/scenarios/07-idp-admin-outage.sh
+++ b/scripts/chaos/scenarios/07-idp-admin-outage.sh
@@ -31,13 +31,23 @@ pin_to_one_replica ads
 
 echo "==> Minting a token and warming the JWKS cache before the outage"
 token="$(token_for user-unassigned)"
-curl -sS -o /dev/null --max-time 5 \
-  -H 'Content-Type: application/json' -H "Authorization: Bearer ${token}" \
-  --data "${probe}" "${check_url}"
+# pin_to_one_replica's scale-down just above can leave the console's
+# upstream connection to ads pointed at the pod that no longer exists
+# until the cluster's networking converges on the survivor - a transient
+# blackhole, not a signal about this scenario's own assertion - so this
+# warm-up call is retried rather than trusted on its first attempt.
+admin_token="$(token_for user-admin)"
+warm_code=""
+for _ in $(seq 1 10); do
+  warm_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 \
+    -H 'Content-Type: application/json' -H "Authorization: Bearer ${token}" \
+    --data "${probe}" "${check_url}")"
+  [[ "${warm_code}" == "200" ]] && break
+  sleep 2
+done
 # admin-service verifies tokens against its own, separately cached JWKS
 # (see the console diagnostics check below), so it needs its own warm
 # request too - a decision through ads warms only ads's.
-admin_token="$(token_for user-admin)"
 curl -sS -o /dev/null --max-time 5 -H "Authorization: Bearer ${admin_token}" \
   "http://127.0.0.1:${ADMIN_CONSOLE_PORT}/api/admin/idp/diagnostics"
 
@@ -45,9 +55,18 @@ echo "==> Stopping the IdP (scaling deployment/keycloak to 0)"
 kubectl_chaos scale deployment/keycloak --replicas=0
 kubectl_chaos wait --for=delete pod -l app=keycloak --timeout=60s
 
-code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 \
-  -H 'Content-Type: application/json' -H "Authorization: Bearer ${token}" \
-  --data "${probe}" "${check_url}")"
+code=""
+for _ in $(seq 1 10); do
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 \
+    -H 'Content-Type: application/json' -H "Authorization: Bearer ${token}" \
+    --data "${probe}" "${check_url}")"
+  # Only a transport-level failure (curl never got a response at all) is
+  # retried here - the same transient blackhole the warm-up above accounts
+  # for. Any real HTTP response, including a non-200 one, is this
+  # assertion's actual answer and must not be retried away.
+  [[ "${code}" != "000" ]] && break
+  sleep 2
+done
 if [[ "${code}" == "200" ]]; then
   echo "ok   runtime authorization continues while the IdP admin API is unavailable"
 else


### PR DESCRIPTION
Follow-up to #63/#64. Run 31305801913 on `main` (after both merged) got both `04-kafka-outage` and `05-policy-rollout-failure` green, but a new failure appeared in `07-idp-admin-outage`: the JWKS warm-up curl through admin-console to ads timed out with HTTP 000 *before Keycloak was even touched*, and the scenario's own assertion curl afterward timed out the same way.

Both calls happen right after `pin_to_one_replica` scales `ads` from 2 replicas to 1 - the same class of transient blackhole `lib.sh`'s `restart_port_forward`/`pin_to_one_replica` comments already document for a scaled deployment's backing pod changing out from under an established route (kube-proxy/conntrack convergence lag in the `kind` cluster), here affecting the console's own upstream connection to ads's Service rather than a kubectl port-forward. Notably `03-database-outage` uses the same `pin_to_one_replica ads` helper and did not hit this in the same run, consistent with this being transient network convergence timing rather than a deterministic bug.

Both the warm-up call and the scenario's own assertion curl now retry for up to ~20s, but only on a transport-level failure (curl's HTTP 000) - any real HTTP response, including a non-200 one, is still treated as the assertion's actual answer with no retry.

No Nx projects affected (shell script only).