### PR TITLE
Fix tamper_with flipping a base64 padding-only bit in the JWT signature

### DIFF
--- a/scripts/tests/lib-token.sh
+++ b/scripts/tests/lib-token.sh
@@ -50,15 +50,25 @@ claim_of() {
 # tamper_with <token>
 # Returns the same token with one signature byte changed, which is the cheapest
 # possible forgery and must be refused.
+#
+# The changed character must not be the signature's last one: base64url's
+# final character can carry as few as two significant bits (the rest is
+# encoding padding, always zero), so a signature whose length isn't a
+# multiple of 3 bytes - true for the 256-byte RSA signatures this realm
+# mints - has a last character where flipping between certain values (A and
+# B, notably) can leave every significant bit, and so the decoded signature
+# itself, unchanged: an apparently "tampered" token that still verifies.
+# The first character is always fully significant, so flipping it always
+# changes the decoded bytes.
 tamper_with() {
   local token="$1" header payload signature
   header="$(cut -d. -f1 <<<"${token}")"
   payload="$(cut -d. -f2 <<<"${token}")"
   signature="$(cut -d. -f3 <<<"${token}")"
-  local last="${signature: -1}"
+  local first="${signature:0:1}"
   local replacement="A"
-  [[ "${last}" == "A" ]] && replacement="B"
-  printf '%s.%s.%s%s' "${header}" "${payload}" "${signature%?}" "${replacement}"
+  [[ "${first}" == "A" ]] && replacement="B"
+  printf '%s.%s.%s%s' "${header}" "${payload}" "${replacement}" "${signature:1}"
 }
 
 # wait_for_keycloak waits until the realm's discovery document is served.


### PR DESCRIPTION
Unrelated to #63/#64/#65's chaos suite fixes, but surfaced by the same push (run 31306552783): the `docker compose walking skeleton` job's `identity-e2e.sh` failed with `FAIL a tampered signature is refused (HTTP 200, want 401)` - a real, security-relevant test flake, not chaos-suite infra.

## Root cause

`tamper_with` flipped the JWT signature's *last* base64url character between `A` and `B`. A 256-byte RSA signature's length isn't a multiple of 3 bytes, so its base64 encoding's final character carries only its top 2 bits as real data - the bottom 4 are encoding padding, always zero. `A` (000000) and `B` (000001) share the same top 2 bits, so flipping between them only ever touches that always-zero padding: whenever a token's real last significant bits happened to already be zero, the "tampered" signature decoded to bytes byte-for-byte identical to the original, still-valid one, and the ADS correctly accepted it.

## Verification

Reproduced locally against a live Keycloak/ADS stack (`make up`): the old logic failed the assertion on 2 of 10 real tokens; the fixed version (flips the signature's *first* character - always a fully significant 6-bit position) held for 20 of 20, and `make smoke` (the full identity + decision e2e suite) passes end to end.

No Nx projects affected (shell script only).