### PR TITLE
Stop .env choosing which backends a contract suite runs

### DIFF
--- a/scripts/tests/leaderlock-contract.sh
+++ b/scripts/tests/leaderlock-contract.sh
@@ -33,6 +33,18 @@ postgres_dsn="postgres://${POSTGRES_USER:-cerbos_poc}:${POSTGRES_PASSWORD:-chang
 oracle_dsn="oracle://${ORACLE_USER:-cerbos_poc}:${ORACLE_PASSWORD:-change-me}@${ORACLE_HOST:-oracle}:${ORACLE_PORT:-1521}/${ORACLE_SERVICE:-FREEPDB1}"
 redis_addr="${LEADER_ELECTION_REDIS_ADDR:-redis:6379}"
 
+# The mode decides which backends the suite is pointed at, and nothing else
+# may. Sourcing .env above is what gives the addresses their values, but it
+# also exports the very variables the tests read to decide whether to run, so
+# a mode that deliberately left one out still inherited it.
+#
+# That is not hypothetical: .env.example carries LEADER_ELECTION_REDIS_ADDR
+# for the redis profile, so `dual` - which starts PostgreSQL and Oracle and no
+# Redis - ran the Redis contract anyway and spent 100 seconds timing out
+# against nothing. Unsetting here makes the case below the only thing that can
+# turn a backend on.
+unset ASSIGNMENTSTORE_POSTGRES_DSN ASSIGNMENTSTORE_ORACLE_DSN LEADER_ELECTION_REDIS_ADDR
+
 case "${mode}" in
   postgres)
     export ASSIGNMENTSTORE_POSTGRES_DSN="${postgres_dsn}"

--- a/scripts/tests/store-contract.sh
+++ b/scripts/tests/store-contract.sh
@@ -26,6 +26,12 @@ export GO_NETWORK="${GO_NETWORK:-${COMPOSE_PROJECT_NAME:-cerbos-poc}_default}"
 postgres_dsn="postgres://${POSTGRES_USER:-cerbos_poc}:${POSTGRES_PASSWORD:-change-me}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-cerbos_poc}?sslmode=disable"
 oracle_dsn="oracle://${ORACLE_USER:-cerbos_poc}:${ORACLE_PASSWORD:-change-me}@${ORACLE_HOST:-oracle}:${ORACLE_PORT:-1521}/${ORACLE_SERVICE:-FREEPDB1}"
 
+# The mode is the only thing that may choose an engine. Sourcing .env above
+# gives the DSNs their parts, but a DSN that arrived from .env whole would
+# silently widen the run - the trap that made the leader election contract
+# spend 100 seconds in CI reaching for a Redis nobody had started.
+unset ASSIGNMENTSTORE_POSTGRES_DSN ASSIGNMENTSTORE_ORACLE_DSN
+
 case "${mode}" in
   postgres)
     export ASSIGNMENTSTORE_POSTGRES_DSN="${postgres_dsn}"


### PR DESCRIPTION
Fixes the `dual dialect portability` job, red on `main` since #67.

## Root cause

Both contract scripts source `.env` to give their DSNs their parts. `.env.example` also carries `LEADER_ELECTION_REDIS_ADDR=redis:6379` for the redis profile — added in #67 — and CI copies `.env.example` to `.env`. So sourcing it exported the very variable the Redis contract reads to decide whether to run.

The `dual` mode starts PostgreSQL and Oracle and no Redis, and deliberately does not point at Redis. It inherited the address anyway, ran the Redis contract, and spent 100 seconds timing out against a Redis nobody had started.

The script's own header says it "only decides which backends it is pointed at". Sourcing `.env` quietly took that decision away from it.

## Fix

Unset the selection variables after sourcing and before the `case`, so the mode is the only thing that can turn a backend on. Applied to `store-contract.sh` too, where the same trap is latent — `.env` happens not to define those DSNs today, but a `postgres` run would silently become a dual run the moment it did.

## Verification

With a fresh `cp .env.example .env`, exactly as CI does:

- Before: the Redis contract runs and every subtest times out at 20s.
- After: `ok github.com/.../libs/leaderlock/redislock 0.002s` — skipped, as the mode intends — and the PostgreSQL contract still passes in 13s, with Oracle correctly skipped.

`REQUIRE_ENGINES` still turns a skipped *selected* engine into a failure, so this cannot hide a backend that was supposed to run.
