### PR TITLE
Spike: organization-scoped tokens without a browser (#75)

### DIFF
--- a/deploy/keycloak/realm-cerbos-poc.json
+++ b/deploy/keycloak/realm-cerbos-poc.json
@@ -5,6 +5,23 @@
   "registrationAllowed": false,
   "loginWithEmailAllowed": true,
   "accessTokenLifespan": 900,
+  "organizationsEnabled": true,
+  "organizations": [
+    {
+      "name": "North Hospital",
+      "alias": "north-hospital",
+      "enabled": true,
+      "domains": [{ "name": "north-hospital.example.test", "verified": false }],
+      "members": [{ "username": "user-doctor" }]
+    },
+    {
+      "name": "South Hospital",
+      "alias": "south-hospital",
+      "enabled": true,
+      "domains": [{ "name": "south-hospital.example.test", "verified": false }],
+      "members": []
+    }
+  ],
   "clients": [
     {
       "clientId": "patient-app",
@@ -31,6 +48,7 @@
         "post.logout.redirect.uris": "http://localhost:4200/*##http://localhost:4201/*"
       },
       "defaultClientScopes": ["basic", "web-origins", "profile", "roles", "email"],
+      "optionalClientScopes": ["organization"],
       "protocolMappers": [
         {
           "name": "audience",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,11 @@ services:
   # the ADS - a mismatch there rejects every token with a confusing message.
   keycloak:
     image: quay.io/keycloak/keycloak:26.4
-    command: ["start-dev", "--import-realm"]
+    # `organization` is a preview feature in 26.4: Keycloak Organizations
+    # (issue #75/#74) is disabled by default and every organization-scoped
+    # token request 400s without it. Enabling it here is required, not
+    # optional, once any realm fixture declares "organizationsEnabled".
+    command: ["start-dev", "--import-realm", "--features=organization"]
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-change-me}

--- a/docs/MEASURED_FINDINGS.md
+++ b/docs/MEASURED_FINDINGS.md
@@ -178,6 +178,37 @@ path.
 - **The policy suite is CPU-bound in one container.** Sixteen seconds on
   sixteen cores is not sixteen seconds on a two-core runner.
 
+## Organization-scoped tokens without a browser (issue #75)
+
+The realm/tenant/organization rework (#74) puts one load-bearing assumption on
+the critical path: that the 1,000-VU protocol-level load model can obtain an
+organization-scoped token by direct grant, with no browser and no custom
+Keycloak authenticator SPI in the path. This was spiked against a real
+Keycloak 26.4 (the `organization` feature is Preview and must be enabled with
+`--features=organization`; `deploy/keycloak/realm-cerbos-poc.json` now
+declares two organizations and one membership; `scripts/tests/org-scope-spike.sh`
+is the committed, repeatable form of this investigation).
+
+| Question | Answer |
+|---|---|
+| Does `grant_type=password` with `scope=organization:<alias>` populate an `organization` claim? | **Yes.** Confirmed on a direct grant against `patient-app`, no browser, no authenticator flow involved. |
+| What shape is the claim? | A JSON array of alias strings, e.g. `"organization": ["north-hospital"]` - not a map, not a bare scalar. Parse it as a list of one. |
+| What happens when the requested alias is not a membership? | Keycloak does **not** refuse the grant. It returns 200 with a token whose granted `scope` silently drops the `organization:<alias>` entry and whose `organization` claim is absent entirely. A caller that only checks the HTTP status will not notice. |
+| Does this apply to an administrator with no membership at all? | Same silent omission - holding the realm role `admin` does not let a direct grant acquire an organization scope by simply asking for it. |
+| Can organization membership be declared in the static realm-import JSON? | Only with `{"username": "<user>"}` member objects. `{"id": "<user>"}` deserializes but then fails import with a null-pointer deep in Keycloak's organization importer (`Cannot invoke "UserModel.getId()" because "user" is null`) - a real bug/limitation in 26.4's realm importer, not a fixture mistake. Any future seed/onboarding code that adds members programmatically must go through the Admin REST API (`POST .../organizations/{id}/members` with a bare user-id string body), not a hand-written import block. |
+
+**Finding: the load model in #74 survives unchanged.** Protocol-level virtual
+users can obtain a real organization-scoped token via direct grant exactly as
+the PRD's user story #41 assumes. No redesign is required before slice #87.
+
+**Finding: "requesting an org you don't belong to" is enforced by omission,
+not rejection.** The decision service's own refusal of an unscoped token
+(PRD decision: "a token carrying neither an active organization nor the
+tenant-wide marker is refused") is therefore load-bearing on its own -
+Keycloak's token endpoint will not do that refusing for it. Slice #78 and the
+decision-service tests must check for the *absence* of a usable organization
+claim, not for a non-200 status from Keycloak.
+
 ## What has not been measured
 
 Stated plainly, so nobody mistakes an absence for a pass:

--- a/scripts/tests/org-scope-spike.sh
+++ b/scripts/tests/org-scope-spike.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Spike (issue #75): can a non-browser client obtain an organization-scoped
+# token from Keycloak?
+#
+# This is the one investigation the rest of the realm/tenant/organization
+# rework (#74) depends on. The 1000-VU protocol-level load model (#41 in the
+# PRD's user stories) assumes a direct grant with `scope=organization:<alias>`
+# populates the same `organization` claim a browser login would get from the
+# in-flow selection screen. If Keycloak only populates that claim for browser
+# flows, the load model has to be redesigned before slice #87 is attempted.
+# This suite is the evidence either way; see
+# docs/MEASURED_FINDINGS.md#organization-scoped-tokens-without-a-browser-issue-75
+# for the written finding the acceptance criteria requires.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+# shellcheck source=scripts/tests/lib-token.sh
+source scripts/tests/lib-token.sh
+
+failures=0
+pass() { echo "ok   $1"; }
+fail() { echo "FAIL $1"; failures=$((failures + 1)); }
+
+command -v jq >/dev/null 2>&1 || { echo "org-scope-spike: jq is required" >&2; exit 1; }
+wait_for_keycloak || exit 1
+
+# token_with_scope <username> <scope>
+# Echoes the raw token response (not just the access token), so callers can
+# inspect the granted `scope` alongside the claims.
+token_with_scope() {
+  local username="$1" scope="$2"
+  curl -sS --max-time 10 \
+    -d "grant_type=password" \
+    -d "client_id=patient-app" \
+    -d "username=${username}" \
+    -d "password=${DEMO_PASSWORD}" \
+    -d "scope=${scope}" \
+    "${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/token"
+}
+
+echo "--- the realm fixture ---"
+
+# The realm fixture (deploy/keycloak/realm-cerbos-poc.json) declares
+# organizationsEnabled, two organizations - north-hospital and
+# south-hospital - and user-doctor as a member of north-hospital only, via
+# Keycloak's own realm import. Declarative membership import works with a
+# "username" reference in the member object; an "id" reference silently fails
+# import with a null-pointer deep in Keycloak's organization importer (tried
+# and rejected while building this spike). That is itself a finding worth
+# keeping: seed and onboarding code must add members through the Admin REST
+# API, not by hand-writing "members" blocks with user ids.
+admin_org_members() {
+  local alias="$1" admin_token org_id
+  admin_token="$(curl -sS --max-time 10 \
+    -d "grant_type=password" -d "client_id=admin-cli" \
+    -d "username=${KEYCLOAK_ADMIN:-admin}" -d "password=${KEYCLOAK_ADMIN_PASSWORD:-change-me}" \
+    "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" | jq -r '.access_token')"
+  org_id="$(curl -sS --max-time 10 -H "Authorization: Bearer ${admin_token}" \
+    "${KEYCLOAK_URL}/admin/realms/${REALM}/organizations?search=${alias}" | jq -r '.[0].id')"
+  curl -sS --max-time 10 -H "Authorization: Bearer ${admin_token}" \
+    "${KEYCLOAK_URL}/admin/realms/${REALM}/organizations/${org_id}/members" | jq -r '.[].username'
+}
+
+north_members="$(admin_org_members north-hospital)"
+if [[ "${north_members}" == "user-doctor" ]]; then
+  pass "north-hospital has exactly the one member the fixture declares"
+else
+  fail "north-hospital has exactly the one member the fixture declares (was '${north_members}')"
+fi
+
+south_members="$(admin_org_members south-hospital)"
+if [[ -z "${south_members}" ]]; then
+  pass "south-hospital has no members, so it is a clean negative fixture"
+else
+  fail "south-hospital has no members (was '${south_members}')"
+fi
+
+echo
+echo "--- a direct grant, no browser involved ---"
+
+response="$(token_with_scope user-doctor "openid organization:north-hospital")"
+token="$(jq -r '.access_token // empty' <<<"${response}")"
+if [[ -z "${token}" ]]; then
+  fail "a direct grant with an organization scope returns a token (got: ${response})"
+else
+  pass "a direct grant with an organization scope returns a token"
+
+  granted_scope="$(jq -r '.scope' <<<"${response}")"
+  if [[ "${granted_scope}" == *"organization:north-hospital"* ]]; then
+    pass "the granted scope names the organization"
+  else
+    fail "the granted scope names the organization (was '${granted_scope}')"
+  fi
+
+  # The claim's shape is the load model's contract: a JSON array of aliases,
+  # not a map and not a single scalar. Record the shape exactly, not just
+  # "truthy", so later slices parse it rather than guess (AC: exact shape).
+  organization_claim="$(claim_of "${token}" '.organization | tojson')"
+  if [[ "${organization_claim}" == '["north-hospital"]' ]]; then
+    pass "the organization claim is a JSON array containing exactly the requested alias"
+  else
+    fail "the organization claim is a JSON array containing exactly the requested alias (was '${organization_claim}')"
+  fi
+fi
+
+echo
+echo "--- an alias the user does not belong to ---"
+
+response="$(token_with_scope user-doctor "openid organization:south-hospital")"
+token="$(jq -r '.access_token // empty' <<<"${response}")"
+if [[ -z "${token}" ]]; then
+  fail "Keycloak still issues a token when the requested organization is not a membership (got: ${response})"
+else
+  pass "Keycloak still issues a token when the requested organization is not a membership"
+
+  # This is the load-bearing negative: Keycloak does not refuse the grant, it
+  # silently drops the scope. A test (and any future caller) that only checks
+  # the HTTP status would be fooled into thinking the request succeeded as
+  # asked.
+  granted_scope="$(jq -r '.scope' <<<"${response}")"
+  if [[ "${granted_scope}" != *"organization:south-hospital"* ]]; then
+    pass "the ungranted organization scope is silently dropped, not honoured"
+  else
+    fail "the ungranted organization scope is silently dropped, not honoured (scope was '${granted_scope}')"
+  fi
+
+  organization_claim="$(claim_of "${token}" '.organization // "absent"')"
+  if [[ "${organization_claim}" == "absent" ]]; then
+    pass "the resulting token carries no organization claim at all"
+  else
+    fail "the resulting token carries no organization claim at all (was '${organization_claim}')"
+  fi
+fi
+
+echo
+echo "--- an administrator with no organization membership at all ---"
+
+response="$(token_with_scope user-admin "openid organization:north-hospital")"
+token="$(jq -r '.access_token // empty' <<<"${response}")"
+if [[ -n "${token}" ]]; then
+  organization_claim="$(claim_of "${token}" '.organization // "absent"')"
+  if [[ "${organization_claim}" == "absent" ]]; then
+    pass "an administrator cannot acquire an organization scope by simply asking for it"
+  else
+    fail "an administrator cannot acquire an organization scope by simply asking for it (was '${organization_claim}')"
+  fi
+else
+  fail "the admin token request itself failed (got: ${response})"
+fi
+
+if (( failures > 0 )); then
+  echo
+  echo "${failures} organization-scope-spike failure(s)"
+  exit 1
+fi
+
+echo
+echo "organization-scope spike passed: direct grant populates the organization claim"


### PR DESCRIPTION
## What changed

- Enabled Keycloak's `organization` preview feature in the compose stack
  (`docker-compose.yml`: `--features=organization` on the `keycloak` service,
  with a comment explaining why it is required).
- Extended `deploy/keycloak/realm-cerbos-poc.json` with `organizationsEnabled`,
  two organizations (`north-hospital`, `south-hospital`), `user-doctor` as a
  declared member of `north-hospital` only, and `optionalClientScopes:
  ["organization"]` on `patient-app` so a direct grant can request the scope.
- Added `scripts/tests/org-scope-spike.sh`, a committed shell suite (in the
  existing `scripts/tests` / `lib-token.sh` style) that proves the spike's
  question empirically against a real running Keycloak.
- Recorded the finding in `docs/MEASURED_FINDINGS.md` under "Organization-scoped
  tokens without a browser (issue #75)".

## Acceptance criteria

- [x] Keycloak Organizations is enabled in the compose stack and the setting is documented - `docker-compose.yml` comment + findings doc.
- [x] A realm fixture exists with at least two organizations and a user who is a member of exactly one - `north-hospital` (member: `user-doctor`) / `south-hospital` (no members).
- [x] A shell test in the existing `scripts/tests` style obtains a token by direct grant with an organization scope and asserts on the organization claim - `scripts/tests/org-scope-spike.sh`.
- [x] The test asserts that requesting an organization the user does not belong to does not yield a token scoped to it - same script, "an alias the user does not belong to" section.
- [x] The exact shape of the organization claim is recorded - a JSON array of alias strings, e.g. `["north-hospital"]`; documented in `MEASURED_FINDINGS.md` and asserted verbatim in the test.
- [x] A written finding states whether the load model in #74 survives - **it survives unchanged**; see `MEASURED_FINDINGS.md`.
- [ ] Findings reviewed with a human before dependent slices start - **this criterion cannot be self-certified by an autonomous merge.** Flagging here: please read the new section of `docs/MEASURED_FINDINGS.md` before slices #78 or #87 are started.

## How it was verified

- `bash scripts/tests/org-scope-spike.sh` against a real Keycloak 26.4 container: all 8 assertions pass.
- `bash scripts/tests/identity-e2e.sh` re-run against the same realm fixture with the organizations addition: all pre-existing assertions still pass (no regression from `organizationsEnabled` or the new optional client scope).
- `python3 scripts/tests/compose-contract.py`: passes.
- Full `make up` stack build and boot verified locally (Keycloak, ADS, admin-service, business-ui, resource-service, cerbos, postgres, redpanda all healthy).

## Notable finding not in the acceptance criteria

Declarative realm-import membership only works with `{"username": "<user>"}`
member objects. `{"id": "<user>"}` deserializes but then null-pointers deep in
Keycloak's own organization importer. Recorded so future seed/onboarding code
(slice #87, #76) knows to use the Admin REST API for membership writes rather
than a hand-written import block.

Closes #75


Closes #75
