### PR TITLE
Multi-issuer token verification and cross-tenant rejection (#77)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,11 +34,11 @@ KEYCLOAK_ADMIN_PASSWORD=change-me
 # §7.1 installation selection. Set IDP_TYPE=WSO2_IS to select the other adapter;
 # nothing else changes and no image is rebuilt. Who the tenant is - realm,
 # issuer, client, service account secret - comes from the tenant registry
-# (issue #76, deploy/tenant-registry.yaml) rather than from here. IDP_REALM
-# only selects which realm scripts/seed-tenants.sh builds the issuer for.
+# (issue #76, deploy/tenant-registry.yaml) rather than from here, and every
+# realm the registry names is served by the same deployment (issue #77):
+# there is no installation-wide tenant mapping mode left to set either, since
+# every realm derives its own tenant from itself.
 IDP_TYPE=KEYCLOAK
-IDP_REALM=tenant-a
-IDP_TENANT_MAPPING_MODE=REALM
 IDP_ROLE_SOURCE=CLIENT
 
 # Which mechanism elects the singleton workloads - the policy release pipeline

--- a/apps/admin-console/src/app/idp-diagnostics/idp-diagnostics-api.ts
+++ b/apps/admin-console/src/app/idp-diagnostics/idp-diagnostics-api.ts
@@ -9,7 +9,6 @@ import { ADMIN_BASE_URL } from '../admin-base-url';
 export interface IdPDiagnosticsResult {
   provider: string;
   roleSource: string;
-  tenantMappingMode: string;
   connectivity: 'ok' | 'degraded';
 }
 

--- a/apps/admin-console/src/app/idp-diagnostics/idp-diagnostics.html
+++ b/apps/admin-console/src/app/idp-diagnostics/idp-diagnostics.html
@@ -3,7 +3,6 @@
 @if (diagnostics(); as status) {
   <p data-testid="idp-provider">Provider: {{ status.provider }}</p>
   <p>Role source: {{ status.roleSource }}</p>
-  <p>Tenant mapping mode: {{ status.tenantMappingMode }}</p>
   <p data-testid="idp-connectivity" [attr.data-status]="status.connectivity">
     Connectivity: {{ status.connectivity }}
     @if (status.connectivity === 'degraded') {

--- a/apps/admin-console/src/app/idp-diagnostics/idp-diagnostics.spec.ts
+++ b/apps/admin-console/src/app/idp-diagnostics/idp-diagnostics.spec.ts
@@ -20,7 +20,7 @@ describe('IdPDiagnostics', () => {
     const httpMock = setUp();
     const fixture = TestBed.createComponent(IdPDiagnostics);
     httpMock.expectOne('/api/admin/idp/diagnostics').flush({
-      provider: 'KEYCLOAK', roleSource: 'CLIENT', tenantMappingMode: 'CLAIM', connectivity: 'ok',
+      provider: 'KEYCLOAK', roleSource: 'CLIENT', connectivity: 'ok',
     });
     await Promise.resolve();
     fixture.detectChanges();
@@ -41,7 +41,7 @@ describe('IdPDiagnostics', () => {
     const httpMock = setUp();
     const fixture = TestBed.createComponent(IdPDiagnostics);
     httpMock.expectOne('/api/admin/idp/diagnostics').flush({
-      provider: 'KEYCLOAK', roleSource: 'CLIENT', tenantMappingMode: 'CLAIM', connectivity: 'degraded',
+      provider: 'KEYCLOAK', roleSource: 'CLIENT', connectivity: 'degraded',
     });
     await Promise.resolve();
     fixture.detectChanges();

--- a/apps/admin-service/cmd/admin-service/main.go
+++ b/apps/admin-service/cmd/admin-service/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sort"
 	"syscall"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/libs/outbox"
 	"github.com/tishan-harischandra/cerbos-poc/libs/outbox/kafkapublisher"
 	"github.com/tishan-harischandra/cerbos-poc/libs/policyrelease"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
 )
 
 func main() {
@@ -64,37 +66,50 @@ func main() {
 	}
 
 	// The identity provider is selected here and nowhere else (§7.1), the
-	// same as every other service that verifies a token. The tenant
-	// (realm, issuer, client) comes from the tenant registry (issue #76)
-	// rather than IDP_REALM/IDP_TENANT_ID/IDP_ISSUER.
+	// same as every other service that verifies a token. A deployment
+	// serves every realm the tenant registry names (issue #77): each realm
+	// gets its own token verifier, and a token's own issuer - never a
+	// claim, never request input - selects which realm's verifier checks
+	// it.
 	tenantCtx, cancelTenantCtx := context.WithTimeout(context.Background(), 90*time.Second)
-	tenant, err := tenantresolve.Single(tenantCtx, store)
+	tenants, err := tenantresolve.All(tenantCtx, store)
 	cancelTenantCtx()
 	if err != nil {
 		logger.Error("could not resolve the tenant registry", slog.Any("error", err))
 		os.Exit(1)
 	}
-	idpConfig, err := idpprovider.ConfigFromTenant(os.LookupEnv, idpprovider.Tenant{
-		Realm:               tenant.Realm,
-		Issuer:              tenant.Issuer,
-		BrowserClientID:     tenant.BrowserClientID,
-		ServiceClientID:     tenant.ServiceClientID,
-		CredentialSecretRef: tenant.CredentialSecretRef,
-	})
+	providerTenants := make([]idpprovider.Tenant, 0, len(tenants))
+	for _, tenant := range tenants {
+		providerTenants = append(providerTenants, idpprovider.Tenant{
+			Realm:               tenant.Realm,
+			Issuer:              tenant.Issuer,
+			BrowserClientID:     tenant.BrowserClientID,
+			ServiceClientID:     tenant.ServiceClientID,
+			CredentialSecretRef: tenant.CredentialSecretRef,
+		})
+	}
+	installations, err := idpprovider.InstallationsFromTenants(os.LookupEnv, providerTenants)
 	if err != nil {
 		logger.Error("could not read the identity provider configuration", slog.Any("error", err))
 		os.Exit(1)
 	}
+
+	// The console's own login configuration (ADR-008) is only ever one
+	// realm's: a browser lands on one login page. Absent an explicit
+	// override, that is the first realm the registry names; an
+	// installation that wants a particular realm's login page sets
+	// OIDC_ISSUER/OIDC_CLIENT_ID rather than relying on map order.
+	homeRealm := homeInstallation(providerTenants, installations)
 	if cfg.OIDCIssuer == "" {
-		cfg.OIDCIssuer = idpConfig.Issuer
+		cfg.OIDCIssuer = homeRealm.Config.Issuer
 	}
 	if cfg.OIDCClientID == "" {
-		cfg.OIDCClientID = idpConfig.ClientID
+		cfg.OIDCClientID = homeRealm.Config.ClientID
 	}
-	verifier, err := idpprovider.NewVerifier(idpConfig)
-	if err != nil {
-		logger.Error("could not prepare token verification", slog.Any("error", err))
-		os.Exit(1)
+
+	verifiers := tokenverifier.NewRegistry()
+	for _, installation := range installations {
+		verifiers.Register(installation.Config.Issuer, installation.Verifier)
 	}
 
 	// The outbox publisher is a singleton across replicas, so this service
@@ -138,7 +153,7 @@ func main() {
 			{Name: "postgres", Probe: tcpProbe(cfg.PostgresAddr)},
 			{Name: "idp", Probe: tcpProbe(cfg.IdPAddr)},
 		},
-		Verifier: verifier,
+		Verifier: verifiers,
 		RoleMatrix: &rolematrix.Handler{
 			Store:   store,
 			Catalog: catalog,
@@ -161,11 +176,10 @@ func main() {
 			Store: store,
 		},
 		PlatformStatus: &platformstatus.Handler{
-			PolicyStore:          policyrelease.NewStore(cfg.PolicyReleaseStoreDir),
-			ADS:                  adsclient.New(cfg.ADSAddr),
-			IdPType:              string(idpConfig.Type),
-			IdPRoleSource:        string(idpConfig.RoleSource),
-			IdPTenantMappingMode: string(idpConfig.TenantMappingMode),
+			PolicyStore:   policyrelease.NewStore(cfg.PolicyReleaseStoreDir),
+			ADS:           adsclient.New(cfg.ADSAddr),
+			IdPType:       string(homeRealm.Config.Type),
+			IdPRoleSource: string(homeRealm.Config.RoleSource),
 		},
 		Console: consoleConfig,
 	})
@@ -219,11 +233,15 @@ func main() {
 		}
 	}()
 
+	realms := make([]string, 0, len(installations))
+	for realm := range installations {
+		realms = append(realms, realm)
+	}
 	logger.Info("admin-service listening",
 		slog.String("addr", cfg.HTTPAddr),
 		slog.String("postgres", cfg.PostgresAddr),
-		slog.String("idpType", string(idpConfig.Type)),
-		slog.String("idpIssuer", idpConfig.Issuer),
+		slog.String("idpType", string(homeRealm.Config.Type)),
+		slog.Any("realms", realms),
 		slog.String("leaderElection", string(electionConfig.Type)),
 		slog.String("consoleDir", cfg.ConsoleDir),
 	)
@@ -232,6 +250,20 @@ func main() {
 		logger.Error("admin-service stopped", slog.Any("error", err))
 		os.Exit(1)
 	}
+}
+
+// homeInstallation picks the console's own login realm: the
+// lowest-named realm, so the choice is a repeatable fact about the
+// registry rather than Go's unspecified map iteration order. An
+// installation that wants a particular realm's login page overrides it
+// with OIDC_ISSUER/OIDC_CLIENT_ID rather than relying on this default.
+func homeInstallation(tenants []idpprovider.Tenant, installations map[string]idpprovider.Installation) idpprovider.Installation {
+	realms := make([]string, 0, len(tenants))
+	for _, tenant := range tenants {
+		realms = append(realms, tenant.Realm)
+	}
+	sort.Strings(realms)
+	return installations[realms[0]]
 }
 
 func tcpProbe(addr string) func(context.Context) error {

--- a/apps/admin-service/internal/platformstatus/platformstatus.go
+++ b/apps/admin-service/internal/platformstatus/platformstatus.go
@@ -46,13 +46,13 @@ type Handler struct {
 	PolicyStore PolicyStore
 	ADS         ADS
 
-	// IdPType, IdPRoleSource and IdPTenantMappingMode are the installation's
-	// §7.1 identity configuration, the same one the token verifier and
-	// directory adapter were built from - reported here as installation
-	// facts, never as a live credential (§16.1).
-	IdPType              string
-	IdPRoleSource        string
-	IdPTenantMappingMode string
+	// IdPType and IdPRoleSource are the console's own home realm's §7.1
+	// identity configuration - reported here as installation facts, never
+	// as a live credential (§16.1). The tenant mapping itself is no longer
+	// a setting to report: every realm derives its tenant from itself
+	// (issue #77), not from a mode that could disagree between realms.
+	IdPType       string
+	IdPRoleSource string
 }
 
 type releasePayload struct {
@@ -144,10 +144,9 @@ func (h *Handler) IdPDiagnostics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"provider":          h.IdPType,
-		"roleSource":        h.IdPRoleSource,
-		"tenantMappingMode": h.IdPTenantMappingMode,
-		"connectivity":      connectivity,
+		"provider":     h.IdPType,
+		"roleSource":   h.IdPRoleSource,
+		"connectivity": connectivity,
 	})
 }
 

--- a/apps/admin-service/internal/platformstatus/platformstatus_test.go
+++ b/apps/admin-service/internal/platformstatus/platformstatus_test.go
@@ -178,10 +178,9 @@ func TestConvergence_RejectsAnAdministratorFromAnotherTenant(t *testing.T) {
 
 func TestIdPDiagnostics_ReportsTheSelectedProviderAndOKConnectivity(t *testing.T) {
 	handler := &platformstatus.Handler{
-		ADS:                  &fakeADS{},
-		IdPType:              "KEYCLOAK",
-		IdPRoleSource:        "CLIENT",
-		IdPTenantMappingMode: "CLAIM",
+		ADS:           &fakeADS{},
+		IdPType:       "KEYCLOAK",
+		IdPRoleSource: "CLIENT",
 	}
 
 	rec := httptest.NewRecorder()
@@ -191,10 +190,9 @@ func TestIdPDiagnostics_ReportsTheSelectedProviderAndOKConnectivity(t *testing.T
 		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
 	}
 	var body struct {
-		Provider          string `json:"provider"`
-		RoleSource        string `json:"roleSource"`
-		TenantMappingMode string `json:"tenantMappingMode"`
-		Connectivity      string `json:"connectivity"`
+		Provider     string `json:"provider"`
+		RoleSource   string `json:"roleSource"`
+		Connectivity string `json:"connectivity"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("response is not JSON: %v", err)

--- a/apps/ads/cmd/ads/main.go
+++ b/apps/ads/cmd/ads/main.go
@@ -32,8 +32,10 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/postgresstore"
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/tenantresolve"
 	"github.com/tishan-harischandra/cerbos-poc/libs/cerbosclient"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
 	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/provider"
 	"github.com/tishan-harischandra/cerbos-poc/libs/permissioncontext"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
 )
 
 // invalidationCaches presents the role-permission and user-override caches
@@ -135,43 +137,44 @@ func main() {
 	// handler below sees only the port, so switching provider is a change to
 	// IDP_TYPE rather than to any of this.
 	//
-	// The tenant (realm, issuer, client) is resolved from the tenant
-	// registry (issue #76) rather than IDP_REALM/IDP_TENANT_ID/IDP_ISSUER,
-	// so which tenant this installation serves is a database row, not a
-	// value that could disagree between this service and the registry.
+	// A deployment serves every realm the tenant registry names (issue
+	// #77), not just one: each realm gets its own directory client and its
+	// own token verifier, and a token's issuer - never a claim, never
+	// request input - selects which realm's verifier checks it.
 	tenantCtx, cancelTenantCtx := context.WithTimeout(context.Background(), 90*time.Second)
-	tenant, err := tenantresolve.Single(tenantCtx, store)
+	tenants, err := tenantresolve.All(tenantCtx, store)
 	cancelTenantCtx()
 	if err != nil {
 		logger.Error("could not resolve the tenant registry", slog.Any("error", err))
 		os.Exit(1)
 	}
-	idpConfig, err := provider.ConfigFromTenant(os.LookupEnv, provider.Tenant{
-		Realm:               tenant.Realm,
-		Issuer:              tenant.Issuer,
-		BrowserClientID:     tenant.BrowserClientID,
-		ServiceClientID:     tenant.ServiceClientID,
-		CredentialSecretRef: tenant.CredentialSecretRef,
-	})
+	providerTenants := make([]provider.Tenant, 0, len(tenants))
+	for _, tenant := range tenants {
+		providerTenants = append(providerTenants, provider.Tenant{
+			Realm:               tenant.Realm,
+			Issuer:              tenant.Issuer,
+			BrowserClientID:     tenant.BrowserClientID,
+			ServiceClientID:     tenant.ServiceClientID,
+			CredentialSecretRef: tenant.CredentialSecretRef,
+		})
+	}
+	installations, err := provider.InstallationsFromTenants(os.LookupEnv, providerTenants)
 	if err != nil {
 		logger.Error("could not read the identity provider configuration", slog.Any("error", err))
 		os.Exit(1)
 	}
-	directory, err := provider.New(idpConfig)
-	if err != nil {
-		logger.Error("could not prepare the identity directory", slog.Any("error", err))
-		os.Exit(1)
-	}
-	verifier, err := provider.NewVerifier(idpConfig)
-	if err != nil {
-		logger.Error("could not prepare token verification", slog.Any("error", err))
-		os.Exit(1)
+
+	verifiers := tokenverifier.NewRegistry()
+	directories := make(map[string]idpdirectory.IdentityDirectory, len(installations))
+	for realm, installation := range installations {
+		verifiers.Register(installation.Config.Issuer, installation.Verifier)
+		directories[realm] = installation.Directory
 	}
 
 	// One middleware, applied to every route that acts on a caller's behalf.
 	// Nothing downstream reads an identity from a request body.
 	authenticated := func(next http.Handler) http.Handler {
-		return tokenauth.Require(tokenauth.Config{Verifier: verifier, Logger: logger}, next)
+		return tokenauth.Require(tokenauth.Config{Verifier: verifiers, Logger: logger}, next)
 	}
 
 	// One shared cache behind both the authz and capability handlers
@@ -310,16 +313,16 @@ func main() {
 			RootPolicyRevision: cfg.RootPolicyRevision,
 		})),
 		DirectoryUsersHandler: authenticated(directoryapi.NewUsersHandler(directoryapi.Config{
-			Directory: directory,
-			Logger:    logger,
+			Directories: directories,
+			Logger:      logger,
 		})),
 		DirectoryRolesHandler: authenticated(directoryapi.NewRolesHandler(directoryapi.Config{
-			Directory: directory,
-			Logger:    logger,
+			Directories: directories,
+			Logger:      logger,
 		})),
 		DirectoryUserRolesHandler: authenticated(directoryapi.NewUserRolesHandler(directoryapi.Config{
-			Directory: directory,
-			Logger:    logger,
+			Directories: directories,
+			Logger:      logger,
 		})),
 		CapabilityHandler: authenticated(capability.NewHandler(capability.Config{
 			PDP:               pdp,
@@ -372,12 +375,15 @@ func main() {
 		}
 	}()
 
+	realms := make([]string, 0, len(installations))
+	for realm := range installations {
+		realms = append(realms, realm)
+	}
 	logger.Info("ads listening",
 		slog.String("addr", cfg.HTTPAddr),
 		slog.String("cerbos", cfg.CerbosGRPCAddr),
 		slog.String("postgres", cfg.PostgresAddr),
-		slog.String("idpType", string(idpConfig.Type)),
-		slog.String("idpIssuer", idpConfig.Issuer),
+		slog.Any("realms", realms),
 		slog.Duration("roleMatrixCacheTtl", cfg.RoleMatrixCacheTTL),
 	)
 

--- a/apps/ads/internal/authz/authz.go
+++ b/apps/ads/internal/authz/authz.go
@@ -226,15 +226,33 @@ func NewHandler(cfg Config) http.Handler {
 			for _, action := range resource.Actions {
 				// A leaf the PDP did not answer for stays denied.
 				decision := result.Decisions[cerbosclient.Leaf{Resource: ref, Action: action}]
+				firedRules := result.FiredRules[ref]
 				actions[action] = Decision{
 					Allowed: decision.Allowed,
-					Source:  DecisionSource(action, decision.Allowed, result.FiredRules[ref]),
+					Source:  DecisionSource(action, decision.Allowed, firedRules),
 				}
 				outcome := "deny"
 				if decision.Allowed {
 					outcome = "allow"
 				}
 				metrics.Observe(resource.Kind, action, outcome, latency)
+
+				// A cross-tenant or cross-hospital attempt is refused the
+				// same 403 as any other deny, but it is logged as its own
+				// alertable fact (issue #77): "no permission granted" and
+				// "you reached for another tenant's data" call for
+				// different operator responses. No resource attribute or
+				// clinical value is logged here (§16.2).
+				if IsolationFired(firedRules) {
+					logger.WarnContext(r.Context(), "cross-tenant or cross-hospital access attempt refused",
+						slog.String("correlationId", correlationID(r)),
+						slog.String("cerbosCallId", result.CallID),
+						slog.String("principalId", identity.PrincipalID),
+						slog.String("callerTenantId", identity.TenantID),
+						slog.String("callerHospitalId", identity.HospitalID),
+						slog.String("resourceKind", resource.Kind),
+						slog.String("action", action))
+				}
 			}
 			response.Resources = append(response.Resources, ResourceDecision{
 				Kind:               resource.Kind,

--- a/apps/ads/internal/authz/authz_test.go
+++ b/apps/ads/internal/authz/authz_test.go
@@ -371,6 +371,85 @@ func TestTheDecisionIsLoggedWithRevisionsAndRoles(t *testing.T) {
 	}
 }
 
+// A cross-tenant or cross-hospital refusal is logged as its own alertable
+// fact (issue #77), distinguishable from an ordinary deny: an operator
+// watching for isolation violations should not have to guess which denies
+// among many were this one.
+func TestACrossTenantDenialIsLoggedDistinguishably(t *testing.T) {
+	pdp := &recordingPDP{
+		result: cerbosclient.Result{
+			CallID: "call-isolation",
+			Decisions: map[cerbosclient.Leaf]cerbosclient.Decision{
+				leaf("patient-456", "read"): {Allowed: false},
+			},
+			FiredRules: map[cerbosclient.ResourceRef][]string{
+				{Kind: "patient_record", ID: "patient-456"}: {"tenant_and_hospital_isolation"},
+			},
+		},
+	}
+
+	var logged strings.Builder
+	handler := authz.NewHandler(authz.Config{
+		PDP:         pdp,
+		Assignments: emptyAssignments{},
+		Logger:      slog.New(slog.NewJSONHandler(&logged, nil)),
+	})
+
+	handler.ServeHTTP(httptest.NewRecorder(), post(validRequest))
+
+	var record struct {
+		Message        string `json:"msg"`
+		PrincipalID    string `json:"principalId"`
+		CallerTenantID string `json:"callerTenantId"`
+	}
+	found := false
+	for _, line := range strings.Split(strings.TrimSpace(logged.String()), "\n") {
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("log line is not JSON: %v", err)
+		}
+		if strings.Contains(record.Message, "cross-tenant") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no log record named a cross-tenant refusal; log was:\n%s", logged.String())
+	}
+	if record.PrincipalID != "user-doctor" {
+		t.Errorf("principalId = %q, want user-doctor", record.PrincipalID)
+	}
+	if record.CallerTenantID != "tenant-a" {
+		t.Errorf("callerTenantId = %q, want tenant-a", record.CallerTenantID)
+	}
+}
+
+// An ordinary deny - no rule granted the action, isolation never fired -
+// must not be logged as a cross-tenant attempt: the point of a
+// distinguishable log line is lost if it fires on every refusal.
+func TestAnOrdinaryDenialIsNotLoggedAsCrossTenant(t *testing.T) {
+	pdp := &recordingPDP{
+		result: cerbosclient.Result{
+			CallID: "call-ordinary",
+			Decisions: map[cerbosclient.Leaf]cerbosclient.Decision{
+				leaf("patient-456", "read"): {Allowed: false},
+			},
+		},
+	}
+
+	var logged strings.Builder
+	handler := authz.NewHandler(authz.Config{
+		PDP:         pdp,
+		Assignments: emptyAssignments{},
+		Logger:      slog.New(slog.NewJSONHandler(&logged, nil)),
+	})
+
+	handler.ServeHTTP(httptest.NewRecorder(), post(validRequest))
+
+	if strings.Contains(logged.String(), "cross-tenant") {
+		t.Errorf("an ordinary deny was logged as a cross-tenant refusal; log was:\n%s", logged.String())
+	}
+}
+
 // §16.2: mask or omit sensitive attributes from decision audit logs. A
 // clinical attribute value sent in the request must never appear in the
 // decision log line, only stable identifiers and revisions.

--- a/apps/ads/internal/authz/decisionsource.go
+++ b/apps/ads/internal/authz/decisionsource.go
@@ -55,3 +55,17 @@ func DecisionSource(action string, allowed bool, firedRules []string) Source {
 	// outcome in the sense that nothing granted the action.
 	return SourceMandatory
 }
+
+// IsolationFired reports whether the tenant_and_hospital_isolation rule
+// denied a leaf. It is exported so the decision endpoint (issue #77) can log
+// a cross-tenant or cross-hospital refusal distinguishably from an ordinary
+// deny - "no permission granted" and "you tried to reach another tenant's
+// data" are different facts an operator alerts on differently.
+func IsolationFired(firedRules []string) bool {
+	for _, name := range firedRules {
+		if name == "tenant_and_hospital_isolation" {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/ads/internal/authz/decisionsource_test.go
+++ b/apps/ads/internal/authz/decisionsource_test.go
@@ -70,3 +70,33 @@ func TestDecisionSourceLabelsEveryCategory(t *testing.T) {
 		})
 	}
 }
+
+// A cross-tenant or cross-hospital refusal (issue #77) is reported
+// distinguishably from every other deny, so the decision endpoint can log
+// it as its own alertable fact rather than folding it into "no permission
+// granted".
+func TestIsolationFired(t *testing.T) {
+	cases := []struct {
+		name       string
+		firedRules []string
+		want       bool
+	}{
+		{name: "isolation fired alone", firedRules: []string{"tenant_and_hospital_isolation"}, want: true},
+		{
+			name:       "isolation fired alongside another rule",
+			firedRules: []string{"tenant_and_hospital_isolation", "revoke_update"},
+			want:       true,
+		},
+		{name: "a different mandatory rule fired", firedRules: []string{"locked_record_restriction"}, want: false},
+		{name: "a grant fired", firedRules: []string{"grant_read_to_role"}, want: false},
+		{name: "no rule fired", firedRules: nil, want: false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsolationFired(c.firedRules); got != c.want {
+				t.Errorf("IsolationFired(%v) = %t, want %t", c.firedRules, got, c.want)
+			}
+		})
+	}
+}

--- a/apps/ads/internal/directoryapi/directoryapi.go
+++ b/apps/ads/internal/directoryapi/directoryapi.go
@@ -20,8 +20,26 @@ import (
 
 // Config holds the handlers' collaborators.
 type Config struct {
+	// Directory is the single-tenant directory client, kept for an
+	// installation with only one realm.
 	Directory idpdirectory.IdentityDirectory
-	Logger    *slog.Logger
+	// Directories is one directory client per realm (issue #77): a
+	// deployment serving more than one realm looks the caller's own
+	// verified tenant up here rather than reaching a directory bound to a
+	// different realm's service account. Directory is ignored when this is
+	// set.
+	Directories map[string]idpdirectory.IdentityDirectory
+	Logger      *slog.Logger
+}
+
+// directoryFor resolves the identity directory for the caller's own
+// verified tenant, never one named by request input.
+func directoryFor(cfg Config, tenantID string) (idpdirectory.IdentityDirectory, bool) {
+	if cfg.Directories != nil {
+		directory, ok := cfg.Directories[tenantID]
+		return directory, ok
+	}
+	return cfg.Directory, cfg.Directory != nil
 }
 
 type userPayload struct {
@@ -56,8 +74,13 @@ func NewUsersHandler(cfg Config) http.Handler {
 		if !ok {
 			return
 		}
+		directory, ok := directoryFor(cfg, identity.TenantID)
+		if !ok {
+			fail(w, logger, r, "searching users", errNoDirectoryForTenant(identity.TenantID))
+			return
+		}
 
-		found, err := cfg.Directory.SearchUsers(r.Context(),
+		found, err := directory.SearchUsers(r.Context(),
 			idpdirectory.TenantID(identity.TenantID),
 			idpdirectory.UserSearch{Query: r.URL.Query().Get("query"), Page: page})
 		if err != nil {
@@ -89,8 +112,13 @@ func NewRolesHandler(cfg Config) http.Handler {
 		if !ok {
 			return
 		}
+		directory, ok := directoryFor(cfg, identity.TenantID)
+		if !ok {
+			fail(w, logger, r, "searching roles", errNoDirectoryForTenant(identity.TenantID))
+			return
+		}
 
-		found, err := cfg.Directory.SearchRoles(r.Context(),
+		found, err := directory.SearchRoles(r.Context(),
 			idpdirectory.TenantID(identity.TenantID),
 			idpdirectory.RoleSearch{Query: r.URL.Query().Get("query"), Page: page})
 		if err != nil {
@@ -127,8 +155,14 @@ func NewUserRolesHandler(cfg Config) http.Handler {
 			return
 		}
 
+		directory, ok := directoryFor(cfg, identity.TenantID)
+		if !ok {
+			fail(w, logger, r, "reading a user's roles", errNoDirectoryForTenant(identity.TenantID))
+			return
+		}
+
 		externalID := r.PathValue("externalId")
-		roles, err := cfg.Directory.GetUserRoles(r.Context(),
+		roles, err := directory.GetUserRoles(r.Context(),
 			idpdirectory.TenantID(identity.TenantID), externalID)
 		if err != nil {
 			fail(w, logger, r, "reading a user's roles", err)
@@ -194,6 +228,14 @@ func pageOf(r *http.Request) (idpdirectory.PageRequest, error) {
 		page.Limit = limit
 	}
 	return page, nil
+}
+
+// errNoDirectoryForTenant means the caller's own verified tenant has no
+// configured directory client. This should not happen for a token that
+// verified at all, since every registered realm gets one, but it is a
+// server-side gap to log rather than a caller mistake to explain.
+func errNoDirectoryForTenant(tenantID string) error {
+	return errors.New("no identity directory is configured for tenant " + tenantID)
 }
 
 // fail logs the provider's own error and tells the caller nothing about it. The

--- a/apps/ads/internal/directoryapi/directoryapi_test.go
+++ b/apps/ads/internal/directoryapi/directoryapi_test.go
@@ -84,6 +84,66 @@ func TestTheTenantSearchedIsTheOneInTheToken(t *testing.T) {
 	}
 }
 
+// A deployment serving more than one realm (issue #77) routes each request
+// to its own tenant's directory client, never a different tenant's.
+func TestASecondTenantIsRoutedToItsOwnDirectory(t *testing.T) {
+	tenantA := &recordingDirectory{}
+	tenantB := &recordingDirectory{
+		users: idpdirectory.Page[idpdirectory.UserRef]{
+			Items: []idpdirectory.UserRef{{ExternalID: "user-b", Username: "b-user"}},
+		},
+	}
+	handler := directoryapi.NewUsersHandler(directoryapi.Config{
+		Directories: map[string]idpdirectory.IdentityDirectory{
+			"tenant-a": tenantA,
+			"tenant-b": tenantB,
+		},
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/internal/directory/users", nil)
+	request = request.WithContext(tokenauth.WithIdentity(request.Context(), tokenauth.Identity{
+		PrincipalID: "user-admin",
+		TenantID:    "tenant-b",
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, request)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+	if tenantA.calls != 0 {
+		t.Error("tenant a's directory was searched for a tenant b request")
+	}
+	if tenantB.calls != 1 {
+		t.Errorf("tenant b's directory was searched %d times, want 1", tenantB.calls)
+	}
+}
+
+// A verified tenant with no configured directory is a server-side gap, not
+// a caller mistake: it fails the same way an unreachable directory would,
+// rather than leaking which tenants exist.
+func TestATenantWithNoConfiguredDirectoryFailsCleanly(t *testing.T) {
+	handler := directoryapi.NewUsersHandler(directoryapi.Config{
+		Directories: map[string]idpdirectory.IdentityDirectory{
+			"tenant-a": &recordingDirectory{},
+		},
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/internal/directory/users", nil)
+	request = request.WithContext(tokenauth.WithIdentity(request.Context(), tokenauth.Identity{
+		PrincipalID: "user-admin",
+		TenantID:    "tenant-c",
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, request)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
 func TestTheTenantComesFromTheVerifiedIdentity(t *testing.T) {
 	directory := &recordingDirectory{}
 	handler := directoryapi.NewUsersHandler(directoryapi.Config{Directory: directory})

--- a/apps/resource-service/cmd/resource-service/main.go
+++ b/apps/resource-service/cmd/resource-service/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/postgresstore"
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/tenantresolve"
 	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/provider"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
 )
 
 func main() {
@@ -43,34 +44,39 @@ func main() {
 	// trustworthy tenant/hospital for Create, in addition to forwarding the
 	// same token to the ADS's own decision endpoint.
 	//
-	// The tenant (realm, issuer, client) comes from the tenant registry
-	// (issue #76) rather than IDP_REALM/IDP_TENANT_ID/IDP_ISSUER.
+	// A deployment serves every realm the tenant registry names (issue
+	// #77): each realm gets its own token verifier, and a token's own
+	// issuer - never a claim, never request input - selects which realm's
+	// verifier checks it.
 	tenantCtx, cancelTenantCtx := context.WithTimeout(context.Background(), 90*time.Second)
-	tenant, err := tenantresolve.Single(tenantCtx, store)
+	tenants, err := tenantresolve.All(tenantCtx, store)
 	cancelTenantCtx()
 	if err != nil {
 		logger.Error("could not resolve the tenant registry", slog.Any("error", err))
 		os.Exit(1)
 	}
-	idpConfig, err := provider.ConfigFromTenant(os.LookupEnv, provider.Tenant{
-		Realm:               tenant.Realm,
-		Issuer:              tenant.Issuer,
-		BrowserClientID:     tenant.BrowserClientID,
-		ServiceClientID:     tenant.ServiceClientID,
-		CredentialSecretRef: tenant.CredentialSecretRef,
-	})
+	providerTenants := make([]provider.Tenant, 0, len(tenants))
+	for _, tenant := range tenants {
+		providerTenants = append(providerTenants, provider.Tenant{
+			Realm:               tenant.Realm,
+			Issuer:              tenant.Issuer,
+			BrowserClientID:     tenant.BrowserClientID,
+			ServiceClientID:     tenant.ServiceClientID,
+			CredentialSecretRef: tenant.CredentialSecretRef,
+		})
+	}
+	installations, err := provider.InstallationsFromTenants(os.LookupEnv, providerTenants)
 	if err != nil {
 		logger.Error("could not read the identity provider configuration", slog.Any("error", err))
 		os.Exit(1)
 	}
-	verifier, err := provider.NewVerifier(idpConfig)
-	if err != nil {
-		logger.Error("could not prepare token verification", slog.Any("error", err))
-		os.Exit(1)
+	verifiers := tokenverifier.NewRegistry()
+	for _, installation := range installations {
+		verifiers.Register(installation.Config.Issuer, installation.Verifier)
 	}
 
 	authenticated := func(next http.Handler) http.Handler {
-		return tokenauth.Require(tokenauth.Config{Verifier: verifier, Logger: logger}, next)
+		return tokenauth.Require(tokenauth.Config{Verifier: verifiers, Logger: logger}, next)
 	}
 
 	handler := server.New(server.Config{

--- a/deploy/k8s/base/admin-service/deployment.yaml
+++ b/deploy/k8s/base/admin-service/deployment.yaml
@@ -63,6 +63,10 @@ spec:
               mountPath: /run/secrets/idp-admin-credentials
               subPath: idp-admin-credentials
               readOnly: true
+            - name: idp-admin-credentials-tenant-b
+              mountPath: /run/secrets/idp-admin-credentials-tenant-b
+              subPath: idp-admin-credentials-tenant-b
+              readOnly: true
             - name: policy-release-archives
               mountPath: /var/lib/policy-controller/archives
               readOnly: true
@@ -98,6 +102,9 @@ spec:
         - name: idp-admin-credentials
           secret:
             secretName: idp-admin-credentials
+        - name: idp-admin-credentials-tenant-b
+          secret:
+            secretName: idp-admin-credentials-tenant-b
         # Empty until the (out-of-scope-for-this-slice) policy-controller
         # ever runs; admin-service's revision module already handles that
         # by reporting no current revision rather than erroring (see

--- a/deploy/k8s/base/ads/deployment.yaml
+++ b/deploy/k8s/base/ads/deployment.yaml
@@ -44,6 +44,10 @@ spec:
               mountPath: /run/secrets/idp-admin-credentials
               subPath: idp-admin-credentials
               readOnly: true
+            - name: idp-admin-credentials-tenant-b
+              mountPath: /run/secrets/idp-admin-credentials-tenant-b
+              subPath: idp-admin-credentials-tenant-b
+              readOnly: true
           ports:
             - name: http
               containerPort: 8080
@@ -74,3 +78,6 @@ spec:
         - name: idp-admin-credentials
           secret:
             secretName: idp-admin-credentials
+        - name: idp-admin-credentials-tenant-b
+          secret:
+            secretName: idp-admin-credentials-tenant-b

--- a/deploy/k8s/base/common/kustomization.yaml
+++ b/deploy/k8s/base/common/kustomization.yaml
@@ -8,7 +8,10 @@
 # not here: it comes from the tenant registry (issue #76,
 # deploy/tenant-registry.yaml, seeded by scripts/seed-tenants.sh) instead
 # of IDP_REALM/IDP_TENANT_ID/IDP_ISSUER/IDP_CLIENT_ID/
-# IDP_SERVICE_CLIENT_ID/IDP_CREDENTIALS_SECRET_REF.
+# IDP_SERVICE_CLIENT_ID/IDP_CREDENTIALS_SECRET_REF, and every realm the
+# registry names is served by this same set of workloads (issue #77): there
+# is no installation-wide tenant mapping mode either, since every realm
+# derives its own tenant from itself.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 configMapGenerator:
@@ -17,7 +20,6 @@ configMapGenerator:
       - IDP_TYPE=KEYCLOAK
       - IDP_BASE_URL=http://keycloak:8080
       - IDP_ADDR=keycloak:8080
-      - IDP_TENANT_MAPPING_MODE=REALM
       - IDP_ROLE_SOURCE=CLIENT
   # Which mechanism elects the singleton workloads (ADR-009). K8S_LEASE is
   # the natural choice here: the control plane already keeps Leases
@@ -37,6 +39,12 @@ secretGenerator:
   - name: idp-admin-credentials
     files:
       - idp-admin-credentials=../../../secrets/idp-admin-credentials
+  # tenant-b's own service-account credential (issue #77): a second,
+  # genuinely registered realm needs a secret distinct from tenant-a's, not
+  # a reused one.
+  - name: idp-admin-credentials-tenant-b
+    files:
+      - idp-admin-credentials-tenant-b=../../../secrets/idp-admin-credentials-tenant-b
   # The dev-only fixture credential compose defaults every DSN to
   # (POSTGRES_PASSWORD=change-me). A real deployment overlay would source
   # this from a cluster secret manager instead of a literal here.

--- a/deploy/k8s/base/keycloak/kustomization.yaml
+++ b/deploy/k8s/base/keycloak/kustomization.yaml
@@ -7,6 +7,7 @@ configMapGenerator:
   - name: keycloak-realms
     files:
       - realm-tenant-a.json=../../../keycloak/realm-tenant-a.json
+      - realm-tenant-b.json=../../../keycloak/realm-tenant-b.json
       - realm-other-issuer.json=../../../keycloak/realm-other-issuer.json
 secretGenerator:
   - name: keycloak-credentials

--- a/deploy/k8s/base/resource-service/deployment.yaml
+++ b/deploy/k8s/base/resource-service/deployment.yaml
@@ -27,6 +27,10 @@ spec:
               mountPath: /run/secrets/idp-admin-credentials
               subPath: idp-admin-credentials
               readOnly: true
+            - name: idp-admin-credentials-tenant-b
+              mountPath: /run/secrets/idp-admin-credentials-tenant-b
+              subPath: idp-admin-credentials-tenant-b
+              readOnly: true
           ports:
             - name: http
               containerPort: 8080
@@ -55,3 +59,6 @@ spec:
         - name: idp-admin-credentials
           secret:
             secretName: idp-admin-credentials
+        - name: idp-admin-credentials-tenant-b
+          secret:
+            secretName: idp-admin-credentials-tenant-b

--- a/deploy/keycloak/realm-tenant-b.json
+++ b/deploy/keycloak/realm-tenant-b.json
@@ -1,0 +1,82 @@
+{
+  "realm": "tenant-b",
+  "displayName": "A second, genuinely registered tenant (issue #77): proves isolation from tenant-a is real, not merely the only realm ever tried",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "accessTokenLifespan": 900,
+  "clients": [
+    {
+      "clientId": "patient-app",
+      "name": "Patient application",
+      "description": "The browser-facing client. Public, so it holds no secret, and it has no administrative permission of any kind.",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": ["http://localhost:4200/*", "http://127.0.0.1:4200/*"],
+      "webOrigins": ["http://localhost:4200", "http://127.0.0.1:4200"],
+      "defaultClientScopes": ["basic", "web-origins", "profile", "roles", "email"],
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "patient-app",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "authorization-admin-service",
+      "name": "Authorization admin service",
+      "description": "tenant-b's own confidential service account, distinct from tenant-a's (issue #77's acceptance criterion that the second realm has its own service-account credentials). It is never used by a browser and never issued to one (7.3).",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "secret": "admin-service-secret-tenant-b",
+      "redirectUris": [],
+      "webOrigins": []
+    }
+  ],
+  "roles": {
+    "client": {
+      "patient-app": [
+        {
+          "name": "doctor",
+          "description": "Treating clinician"
+        }
+      ]
+    }
+  },
+  "users": [
+    {
+      "id": "user-doctor-b",
+      "username": "user-doctor-b",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bailey",
+      "lastName": "Doctor",
+      "email": "bailey.doctor@tenant-b.example.test",
+      "attributes": {
+        "hospital_id": ["hospital-1"]
+      },
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "clientRoles": { "patient-app": ["doctor"] }
+    },
+    {
+      "username": "service-account-authorization-admin-service",
+      "enabled": true,
+      "serviceAccountClientId": "authorization-admin-service",
+      "clientRoles": {
+        "realm-management": ["view-users", "query-users", "view-clients", "view-realm"]
+      }
+    }
+  ]
+}

--- a/deploy/secrets/idp-admin-credentials-tenant-b
+++ b/deploy/secrets/idp-admin-credentials-tenant-b
@@ -1,0 +1,1 @@
+admin-service-secret-tenant-b

--- a/deploy/tenant-registry.yaml
+++ b/deploy/tenant-registry.yaml
@@ -7,12 +7,22 @@
 # tenant_id column and no mapping layer.
 #
 # issuer and credentialSecretRef are substituted at seed time (see
-# libs/assignmentstore/cmd/seed-tenants) from TENANT_ISSUER and
-# TENANT_CREDENTIAL_SECRET_REF, so that a locally overridden Keycloak
-# hostname/port and the seeder's own mount path never require editing this
-# committed file.
+# libs/assignmentstore/cmd/seed-tenants) from TENANT_<REALM>_ISSUER and
+# TENANT_<REALM>_CREDENTIAL_SECRET_REF, so that a locally overridden
+# Keycloak hostname/port and the seeder's own mount path never require
+# editing this committed file.
+#
+# Two realms (issue #77): one deployment serves both, each with its own
+# issuer and service-account credential, so the isolation between them is
+# something this installation actually exercises rather than a claim that
+# has only ever had one realm to be true of.
 - realm: tenant-a
-  issuer: "${TENANT_ISSUER}"
+  issuer: "${TENANT_A_ISSUER}"
   browserClientId: patient-app
   serviceClientId: authorization-admin-service
-  credentialSecretRef: "${TENANT_CREDENTIAL_SECRET_REF}"
+  credentialSecretRef: "${TENANT_A_CREDENTIAL_SECRET_REF}"
+- realm: tenant-b
+  issuer: "${TENANT_B_ISSUER}"
+  browserClientId: patient-app
+  serviceClientId: authorization-admin-service
+  credentialSecretRef: "${TENANT_B_CREDENTIAL_SECRET_REF}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       KC_HEALTH_ENABLED: "true"
     volumes:
       - ./deploy/keycloak/realm-tenant-a.json:/opt/keycloak/data/import/realm-tenant-a.json:ro
+      - ./deploy/keycloak/realm-tenant-b.json:/opt/keycloak/data/import/realm-tenant-b.json:ro
       - ./deploy/keycloak/realm-other-issuer.json:/opt/keycloak/data/import/realm-other-issuer.json:ro
     ports:
       - "${KEYCLOAK_PORT:-8081}:8080"
@@ -231,7 +232,6 @@ services:
       IDP_TYPE: "${IDP_TYPE:-KEYCLOAK}"
       IDP_BASE_URL: "http://keycloak:8080"
       IDP_ADDR: "keycloak:8080"
-      IDP_TENANT_MAPPING_MODE: "${IDP_TENANT_MAPPING_MODE:-REALM}"
       IDP_ROLE_SOURCE: "${IDP_ROLE_SOURCE:-CLIENT}"
       # The capability snapshot endpoint (§12.3, issue #11) reads the same
       # committed capability catalog Cerbos itself reads its policies from.
@@ -239,7 +239,10 @@ services:
       CAPABILITY_CATALOG_REVISION: "${CAPABILITY_CATALOG_REVISION:-1}"
       ROOT_POLICY_REVISION: "${ROOT_POLICY_REVISION:-root-v1.4.0}"
     volumes:
+      # One mount per realm the tenant registry names (issue #77): each
+      # realm's own service account secret, never shared with another's.
       - ./deploy/secrets/idp-admin-credentials:/run/secrets/idp-admin-credentials:ro
+      - ./deploy/secrets/idp-admin-credentials-tenant-b:/run/secrets/idp-admin-credentials-tenant-b:ro
       - ./deploy/cerbos/catalog/ui-capabilities:/capability-catalog:ro
     depends_on:
       cerbos:
@@ -273,7 +276,6 @@ services:
       IDP_TYPE: "${IDP_TYPE:-KEYCLOAK}"
       IDP_BASE_URL: "http://keycloak:8080"
       IDP_ADDR: "keycloak:8080"
-      IDP_TENANT_MAPPING_MODE: "${IDP_TENANT_MAPPING_MODE:-REALM}"
       IDP_ROLE_SOURCE: "${IDP_ROLE_SOURCE:-CLIENT}"
       AUTHORIZATION_CATALOG_DIR: "/authorization-catalog"
       # The capability impact endpoint (§9.1, issue #18) reads the same
@@ -311,6 +313,7 @@ services:
       POLICY_ARCHIVE_STORE_DIR: "/var/lib/policy-controller/archives"
     volumes:
       - ./deploy/secrets/idp-admin-credentials:/run/secrets/idp-admin-credentials:ro
+      - ./deploy/secrets/idp-admin-credentials-tenant-b:/run/secrets/idp-admin-credentials-tenant-b:ro
       - ./deploy/cerbos/catalog/resources:/authorization-catalog:ro
       - ./deploy/cerbos/catalog/ui-capabilities:/capability-catalog:ro
       - policy-release-archives:/var/lib/policy-controller/archives:ro
@@ -353,10 +356,10 @@ services:
       IDP_TYPE: "${IDP_TYPE:-KEYCLOAK}"
       IDP_BASE_URL: "http://keycloak:8080"
       IDP_ADDR: "keycloak:8080"
-      IDP_TENANT_MAPPING_MODE: "${IDP_TENANT_MAPPING_MODE:-REALM}"
       IDP_ROLE_SOURCE: "${IDP_ROLE_SOURCE:-CLIENT}"
     volumes:
       - ./deploy/secrets/idp-admin-credentials:/run/secrets/idp-admin-credentials:ro
+      - ./deploy/secrets/idp-admin-credentials-tenant-b:/run/secrets/idp-admin-credentials-tenant-b:ro
     depends_on:
       ads:
         condition: service_healthy

--- a/libs/assignmentstore/cmd/seed-tenants/main.go
+++ b/libs/assignmentstore/cmd/seed-tenants/main.go
@@ -12,6 +12,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/postgresstore"
@@ -42,24 +44,22 @@ func run() error {
 		return fmt.Errorf("reading %s: %w", registryFile, err)
 	}
 
-	// The committed file names its issuer and credential secret path as
-	// ${TENANT_ISSUER} / ${TENANT_CREDENTIAL_SECRET_REF} rather than a fixed
-	// value: a locally overridden Keycloak hostname/port, or this seeder's
-	// own container mounting the repository at a different path than the
-	// ADS and Admin Service do, must not require editing the checked-in
-	// file. Substituting before Parse (rather than after) means the
-	// credential secret ref validation Parse performs always checks the
-	// path this process will actually read.
-	issuer := os.Getenv("TENANT_ISSUER")
-	if issuer == "" {
-		issuer = "http://localhost:8081/realms/tenant-a"
-	}
-	credentialSecretRef := os.Getenv("TENANT_CREDENTIAL_SECRET_REF")
-	if credentialSecretRef == "" {
-		credentialSecretRef = "/run/secrets/idp-admin-credentials"
-	}
-	raw = bytes.ReplaceAll(raw, []byte("${TENANT_ISSUER}"), []byte(issuer))
-	raw = bytes.ReplaceAll(raw, []byte("${TENANT_CREDENTIAL_SECRET_REF}"), []byte(credentialSecretRef))
+	// The committed file names each realm's issuer and credential secret
+	// path as ${TENANT_<REALM>_ISSUER} / ${TENANT_<REALM>_CREDENTIAL_SECRET_REF}
+	// rather than a fixed value: a locally overridden Keycloak
+	// hostname/port, or this seeder's own container mounting the
+	// repository at a different path than the ADS and Admin Service do,
+	// must not require editing the checked-in file. Substituting before
+	// Parse (rather than after) means the credential secret ref validation
+	// Parse performs always checks the path this process will actually
+	// read.
+	//
+	// One deployment serves every realm the file names (issue #77), so the
+	// substitution is generic rather than naming tenant-a specifically:
+	// every TENANT_<REALM>_ISSUER in the environment is substituted for
+	// its own ${TENANT_<REALM>_ISSUER} placeholder, and likewise for
+	// _CREDENTIAL_SECRET_REF.
+	raw = substituteTenantPlaceholders(raw)
 
 	entries, err := tenantregistry.Parse(raw)
 	if err != nil {
@@ -80,4 +80,38 @@ func run() error {
 	}
 
 	return tenantseed.Apply(ctx, store, entries)
+}
+
+// tenantEnvVar matches TENANT_<REALM>_ISSUER and TENANT_<REALM>_CREDENTIAL_SECRET_REF,
+// capturing the realm portion so its value substitutes the placeholder of
+// the same shape in the registry file.
+var tenantEnvVar = regexp.MustCompile(`^TENANT_(.+)_(ISSUER|CREDENTIAL_SECRET_REF)$`)
+
+// substituteTenantPlaceholders replaces every ${TENANT_<REALM>_ISSUER} and
+// ${TENANT_<REALM>_CREDENTIAL_SECRET_REF} placeholder in raw with the value
+// of the environment variable of the same name. tenant-a's placeholders
+// fall back to the values compose has always defaulted them to, so a
+// registry file with no environment overrides at all still seeds.
+func substituteTenantPlaceholders(raw []byte) []byte {
+	defaults := map[string]string{
+		"TENANT_A_ISSUER":                "http://localhost:8081/realms/tenant-a",
+		"TENANT_A_CREDENTIAL_SECRET_REF": "/run/secrets/idp-admin-credentials",
+	}
+
+	seen := make(map[string]bool, len(defaults))
+	for _, env := range os.Environ() {
+		name, value, ok := strings.Cut(env, "=")
+		if !ok || !tenantEnvVar.MatchString(name) {
+			continue
+		}
+		seen[name] = true
+		raw = bytes.ReplaceAll(raw, []byte("${"+name+"}"), []byte(value))
+	}
+	for name, value := range defaults {
+		if seen[name] {
+			continue
+		}
+		raw = bytes.ReplaceAll(raw, []byte("${"+name+"}"), []byte(value))
+	}
+	return raw
 }

--- a/libs/assignmentstore/cmd/seed-tenants/main_test.go
+++ b/libs/assignmentstore/cmd/seed-tenants/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Two realms in the same registry file (issue #77) each get their own
+// issuer and credential secret ref substituted from the environment
+// variable of the matching name.
+func TestSubstituteTenantPlaceholdersSubstitutesEachRealmIndependently(t *testing.T) {
+	t.Setenv("TENANT_A_ISSUER", "http://keycloak:8080/realms/tenant-a")
+	t.Setenv("TENANT_A_CREDENTIAL_SECRET_REF", "/run/secrets/idp-admin-credentials")
+	t.Setenv("TENANT_B_ISSUER", "http://keycloak:8080/realms/tenant-b")
+	t.Setenv("TENANT_B_CREDENTIAL_SECRET_REF", "/run/secrets/idp-admin-credentials-tenant-b")
+
+	raw := []byte(`- realm: tenant-a
+  issuer: "${TENANT_A_ISSUER}"
+  credentialSecretRef: "${TENANT_A_CREDENTIAL_SECRET_REF}"
+- realm: tenant-b
+  issuer: "${TENANT_B_ISSUER}"
+  credentialSecretRef: "${TENANT_B_CREDENTIAL_SECRET_REF}"
+`)
+
+	got := string(substituteTenantPlaceholders(raw))
+
+	for _, want := range []string{
+		"http://keycloak:8080/realms/tenant-a",
+		"/run/secrets/idp-admin-credentials\"",
+		"http://keycloak:8080/realms/tenant-b",
+		"/run/secrets/idp-admin-credentials-tenant-b",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("substituted registry = %s, want it to contain %q", got, want)
+		}
+	}
+	if strings.Contains(got, "${TENANT") {
+		t.Errorf("substituted registry still names a placeholder: %s", got)
+	}
+}
+
+// tenant-a's placeholders keep working with no environment overrides at
+// all, the same default compose has always used, so the committed file
+// still seeds on a bare `make up`.
+func TestSubstituteTenantPlaceholdersFallsBackToTenantADefaults(t *testing.T) {
+	for _, name := range []string{"TENANT_A_ISSUER", "TENANT_A_CREDENTIAL_SECRET_REF"} {
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatalf("unsetting %s: %v", name, err)
+		}
+	}
+
+	raw := []byte(`- realm: tenant-a
+  issuer: "${TENANT_A_ISSUER}"
+  credentialSecretRef: "${TENANT_A_CREDENTIAL_SECRET_REF}"
+`)
+
+	got := string(substituteTenantPlaceholders(raw))
+	if !strings.Contains(got, "http://localhost:8081/realms/tenant-a") {
+		t.Errorf("substituted registry = %s, want the default tenant-a issuer", got)
+	}
+	if !strings.Contains(got, "/run/secrets/idp-admin-credentials\"") {
+		t.Errorf("substituted registry = %s, want the default tenant-a secret ref", got)
+	}
+}

--- a/libs/assignmentstore/tenantresolve/tenantresolve.go
+++ b/libs/assignmentstore/tenantresolve/tenantresolve.go
@@ -1,10 +1,11 @@
-// Package tenantresolve picks the one tenant a service instance serves
-// (issue #76).
+// Package tenantresolve resolves which tenants a service instance serves
+// (issue #76, issue #77).
 //
-// #76 scopes an installation to exactly one realm: a service does not
-// choose among several rows, it reads the only one there is. Any other
-// count means the tenant registry seed step has not run, or has run
-// against the wrong database, and is refused rather than guessed at.
+// #76 introduced the registry with exactly one row; #77 lets a deployment
+// serve every realm the registry names. Single keeps the one-tenant
+// contract for anything that still wants it; All waits for the registry to
+// be seeded at all and returns every row, so a service can build one
+// installation per realm.
 package tenantresolve
 
 import (
@@ -50,6 +51,31 @@ func Single(ctx context.Context, tenants Lister) (assignmentstore.Tenant, error)
 		select {
 		case <-ctx.Done():
 			return assignmentstore.Tenant{}, lastErr
+		case <-time.After(PollInterval):
+		}
+	}
+}
+
+// All returns every row in the tenant registry, retrying on ctx until at
+// least one exists or ctx is done (issue #77). A deployment that serves more
+// than one realm builds one installation per row this returns, rather than
+// refusing to start until the registry holds exactly one.
+func All(ctx context.Context, tenants Lister) ([]assignmentstore.Tenant, error) {
+	var lastErr error
+	for {
+		all, err := tenants.Tenants(ctx)
+		switch {
+		case err != nil:
+			lastErr = fmt.Errorf("tenantresolve: listing the tenant registry: %w", err)
+		case len(all) > 0:
+			return all, nil
+		default:
+			lastErr = fmt.Errorf("tenantresolve: the tenant registry has no rows; has the tenant registry seed step run?")
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, lastErr
 		case <-time.After(PollInterval):
 		}
 	}

--- a/libs/assignmentstore/tenantresolve/tenantresolve_test.go
+++ b/libs/assignmentstore/tenantresolve/tenantresolve_test.go
@@ -86,3 +86,48 @@ func TestSingleRejectsMoreThanOneTenantOnceContextExpires(t *testing.T) {
 		t.Fatal("Single accepted a registry with more than one tenant")
 	}
 }
+
+// A deployment that serves more than one realm (issue #77) reads every row,
+// rather than refusing to start the way Single does.
+func TestAllReturnsEveryTenant(t *testing.T) {
+	want := []assignmentstore.Tenant{{Realm: "tenant-a"}, {Realm: "tenant-b"}}
+	got, err := tenantresolve.All(context.Background(), &fakeLister{tenants: want})
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("All = %+v, want %+v", got, want)
+	}
+}
+
+func TestAllRetriesUntilTheRegistryIsSeeded(t *testing.T) {
+	original := tenantresolve.PollInterval
+	tenantresolve.PollInterval = 5 * time.Millisecond
+	defer func() { tenantresolve.PollInterval = original }()
+
+	lister := &fakeLister{}
+	want := []assignmentstore.Tenant{{Realm: "tenant-a"}, {Realm: "tenant-b"}}
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		lister.set(want)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, err := tenantresolve.All(ctx, lister)
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("All = %+v, want %+v", got, want)
+	}
+}
+
+func TestAllRejectsZeroTenantsOnceContextExpires(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := tenantresolve.All(ctx, &fakeLister{})
+	if err == nil {
+		t.Fatal("All accepted an empty tenant registry")
+	}
+}

--- a/libs/idpdirectory/provider/provider.go
+++ b/libs/idpdirectory/provider/provider.go
@@ -51,10 +51,10 @@ type Config struct {
 	BaseURL string
 	Realm   string
 	// TenantID is the authorization tenant this realm or organisation maps to.
+	// Each adapter declares this mapping itself (issue #77): there is no
+	// installation-wide mode to choose it by, and it is never read from a
+	// token claim.
 	TenantID idpdirectory.TenantID
-	// TenantMappingMode decides whether the tenant comes from a token claim or
-	// from the realm itself.
-	TenantMappingMode tokenverifier.TenantMappingMode
 
 	RoleSource tokenverifier.RoleSource
 	// ClientID is the browser-facing client: the token audience, and the owner
@@ -91,14 +91,13 @@ type LookupFunc func(key string) (string, bool)
 // Environment variables, all prefixed IDP_ so one glance at a compose file
 // shows the whole identity configuration.
 const (
-	EnvType              = "IDP_TYPE"
-	EnvBaseURL           = "IDP_BASE_URL"
-	EnvRealm             = "IDP_REALM"
-	EnvTenantID          = "IDP_TENANT_ID"
-	EnvTenantMappingMode = "IDP_TENANT_MAPPING_MODE"
-	EnvRoleSource        = "IDP_ROLE_SOURCE"
-	EnvClientID          = "IDP_CLIENT_ID"
-	EnvServiceClientID   = "IDP_SERVICE_CLIENT_ID"
+	EnvType            = "IDP_TYPE"
+	EnvBaseURL         = "IDP_BASE_URL"
+	EnvRealm           = "IDP_REALM"
+	EnvTenantID        = "IDP_TENANT_ID"
+	EnvRoleSource      = "IDP_ROLE_SOURCE"
+	EnvClientID        = "IDP_CLIENT_ID"
+	EnvServiceClientID = "IDP_SERVICE_CLIENT_ID"
 	// EnvCredentialsSecretRef is §7.1's credentialsSecretRef: a path to a
 	// mounted file. A secret passed by value would be visible in
 	// `docker inspect` and inherited by every child process.
@@ -110,16 +109,15 @@ const (
 // FromEnv resolves the installation's identity configuration.
 func FromEnv(lookup LookupFunc) (Config, error) {
 	cfg := Config{
-		Type:              Type(valueOr(lookup, EnvType, string(TypeKeycloak))),
-		BaseURL:           strings.TrimRight(valueOr(lookup, EnvBaseURL, ""), "/"),
-		Realm:             valueOr(lookup, EnvRealm, ""),
-		TenantID:          idpdirectory.TenantID(valueOr(lookup, EnvTenantID, "")),
-		TenantMappingMode: tokenverifier.TenantMappingMode(valueOr(lookup, EnvTenantMappingMode, string(tokenverifier.TenantMappingClaim))),
-		RoleSource:        tokenverifier.RoleSource(valueOr(lookup, EnvRoleSource, string(tokenverifier.RoleSourceClient))),
-		ClientID:          valueOr(lookup, EnvClientID, ""),
-		ServiceClientID:   valueOr(lookup, EnvServiceClientID, ""),
-		Issuer:            strings.TrimRight(valueOr(lookup, EnvIssuer, ""), "/"),
-		WSO2TenantDomain:  valueOr(lookup, EnvWSO2TenantDomain, ""),
+		Type:             Type(valueOr(lookup, EnvType, string(TypeKeycloak))),
+		BaseURL:          strings.TrimRight(valueOr(lookup, EnvBaseURL, ""), "/"),
+		Realm:            valueOr(lookup, EnvRealm, ""),
+		TenantID:         idpdirectory.TenantID(valueOr(lookup, EnvTenantID, "")),
+		RoleSource:       tokenverifier.RoleSource(valueOr(lookup, EnvRoleSource, string(tokenverifier.RoleSourceClient))),
+		ClientID:         valueOr(lookup, EnvClientID, ""),
+		ServiceClientID:  valueOr(lookup, EnvServiceClientID, ""),
+		Issuer:           strings.TrimRight(valueOr(lookup, EnvIssuer, ""), "/"),
+		WSO2TenantDomain: valueOr(lookup, EnvWSO2TenantDomain, ""),
 	}
 
 	switch {
@@ -157,24 +155,24 @@ type Tenant struct {
 // #76) instead of IDP_REALM/IDP_TENANT_ID/IDP_ISSUER/IDP_CLIENT_ID/
 // IDP_SERVICE_CLIENT_ID/IDP_CREDENTIALS_SECRET_REF. Adapter-level settings
 // that describe how this installation talks to the identity provider
-// product - Type, BaseURL, TenantMappingMode, RoleSource,
-// WSO2TenantDomain - still come from the environment: they are not who the
-// tenant is, so they do not belong in the registry.
+// product - Type, BaseURL, RoleSource, WSO2TenantDomain - still come from
+// the environment: they are not who the tenant is, so they do not belong in
+// the registry.
 //
-// TenantID is the realm verbatim (§7.1): there is no separate tenant_id
-// column and no mapping layer.
+// TenantID is the realm verbatim (§7.1, §77): there is no separate
+// tenant_id column and no mapping layer, and this is the one place the
+// Keycloak adapter's identity mapping is declared.
 func ConfigFromTenant(lookup LookupFunc, tenant Tenant) (Config, error) {
 	cfg := Config{
-		Type:              Type(valueOr(lookup, EnvType, string(TypeKeycloak))),
-		BaseURL:           strings.TrimRight(valueOr(lookup, EnvBaseURL, ""), "/"),
-		Realm:             tenant.Realm,
-		TenantID:          idpdirectory.TenantID(tenant.Realm),
-		TenantMappingMode: tokenverifier.TenantMappingMode(valueOr(lookup, EnvTenantMappingMode, string(tokenverifier.TenantMappingClaim))),
-		RoleSource:        tokenverifier.RoleSource(valueOr(lookup, EnvRoleSource, string(tokenverifier.RoleSourceClient))),
-		ClientID:          tenant.BrowserClientID,
-		ServiceClientID:   tenant.ServiceClientID,
-		Issuer:            strings.TrimRight(tenant.Issuer, "/"),
-		WSO2TenantDomain:  valueOr(lookup, EnvWSO2TenantDomain, ""),
+		Type:             Type(valueOr(lookup, EnvType, string(TypeKeycloak))),
+		BaseURL:          strings.TrimRight(valueOr(lookup, EnvBaseURL, ""), "/"),
+		Realm:            tenant.Realm,
+		TenantID:         idpdirectory.TenantID(tenant.Realm),
+		RoleSource:       tokenverifier.RoleSource(valueOr(lookup, EnvRoleSource, string(tokenverifier.RoleSourceClient))),
+		ClientID:         tenant.BrowserClientID,
+		ServiceClientID:  tenant.ServiceClientID,
+		Issuer:           strings.TrimRight(tenant.Issuer, "/"),
+		WSO2TenantDomain: valueOr(lookup, EnvWSO2TenantDomain, ""),
 	}
 
 	switch {
@@ -190,6 +188,38 @@ func ConfigFromTenant(lookup LookupFunc, tenant Tenant) (Config, error) {
 		return Config{}, errors.New("the tenant registry row has no credential secret ref")
 	}
 	return finish(cfg, tenant.CredentialSecretRef)
+}
+
+// Installation is one realm's resolved identity configuration: the
+// directory and verifier its traffic uses.
+type Installation struct {
+	Config    Config
+	Directory idpdirectory.IdentityDirectory
+	Verifier  *tokenverifier.Verifier
+}
+
+// InstallationsFromTenants builds one Installation per tenant registry row
+// (issue #77): a deployment serves every realm the registry names, and each
+// realm's traffic is verified and directed by its own configuration, keyed
+// by realm, never by a shared installation-wide one.
+func InstallationsFromTenants(lookup LookupFunc, tenants []Tenant) (map[string]Installation, error) {
+	installations := make(map[string]Installation, len(tenants))
+	for _, tenant := range tenants {
+		cfg, err := ConfigFromTenant(lookup, tenant)
+		if err != nil {
+			return nil, fmt.Errorf("realm %q: %w", tenant.Realm, err)
+		}
+		directory, err := New(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("realm %q: %w", tenant.Realm, err)
+		}
+		verifier, err := NewVerifier(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("realm %q: %w", tenant.Realm, err)
+		}
+		installations[tenant.Realm] = Installation{Config: cfg, Directory: directory, Verifier: verifier}
+	}
+	return installations, nil
 }
 
 // finish reads the service account secret and applies the defaults common
@@ -247,13 +277,12 @@ func New(cfg Config) (idpdirectory.IdentityDirectory, error) {
 // reading roles from another.
 func NewVerifier(cfg Config) (*tokenverifier.Verifier, error) {
 	return tokenverifier.New(tokenverifier.Config{
-		Issuer:            cfg.Issuer,
-		Audience:          cfg.ClientID,
-		Realm:             cfg.Realm,
-		RoleSource:        cfg.RoleSource,
-		ClientID:          cfg.ClientID,
-		TenantMappingMode: cfg.TenantMappingMode,
-		Keys:              tokenverifier.NewJWKS(tokenverifier.JWKSConfig{URL: cfg.JWKSURL()}),
+		Issuer:     cfg.Issuer,
+		Audience:   cfg.ClientID,
+		Realm:      cfg.Realm,
+		RoleSource: cfg.RoleSource,
+		ClientID:   cfg.ClientID,
+		Keys:       tokenverifier.NewJWKS(tokenverifier.JWKSConfig{URL: cfg.JWKSURL()}),
 	})
 }
 

--- a/libs/tokenverifier/registry.go
+++ b/libs/tokenverifier/registry.go
@@ -1,0 +1,80 @@
+package tokenverifier
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// Registry verifies tokens across every realm an installation trusts (issue
+// #77): the issuer the token itself claims selects which realm's Verifier
+// checks it, and that Verifier supplies its own issuer, audience and key
+// source. No service concatenates an issuer or a key-set URL by hand, and a
+// key rotation in one realm never touches another realm's cached keys,
+// because each registered Verifier owns its own KeySource.
+//
+// The issuer read here to pick a Verifier is unverified input - exactly the
+// same status any other header of an unauthenticated request has. It is
+// never trusted on its own: the Verifier it selects performs the full §16.1
+// signature check, including its own issuer comparison, so a forged issuer
+// picks the wrong Verifier and then fails signature verification against
+// that realm's keys.
+type Registry struct {
+	mu       sync.RWMutex
+	byIssuer map[string]*Verifier
+}
+
+// NewRegistry returns an empty multi-issuer verifier.
+func NewRegistry() *Registry {
+	return &Registry{byIssuer: make(map[string]*Verifier)}
+}
+
+// Register adds a realm's Verifier under its issuer. Registering the same
+// issuer twice replaces the previous Verifier, so a realm can be re-keyed
+// without restarting the process.
+func (r *Registry) Register(issuer string, verifier *Verifier) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.byIssuer[issuer] = verifier
+}
+
+// Verify peeks the token's unverified issuer to select a realm, then
+// performs the full identity check with that realm's own Verifier.
+func (r *Registry) Verify(ctx context.Context, raw string) (VerifiedToken, error) {
+	issuer, err := peekIssuer(raw)
+	if err != nil {
+		return VerifiedToken{}, err
+	}
+
+	r.mu.RLock()
+	verifier, ok := r.byIssuer[issuer]
+	r.mu.RUnlock()
+	if !ok {
+		return VerifiedToken{}, fmt.Errorf("%w: %q", ErrInvalidIssuer, issuer)
+	}
+	return verifier.Verify(ctx, raw)
+}
+
+// peekIssuer reads the `iss` claim without verifying the token's signature.
+// It exists only to pick which realm's Verifier performs the real check;
+// nothing here is trusted as an identity fact.
+func peekIssuer(raw string) (string, error) {
+	segments := strings.Split(strings.TrimSpace(raw), ".")
+	if len(segments) != 3 {
+		return "", ErrMalformedToken
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(segments[1])
+	if err != nil {
+		return "", ErrMalformedToken
+	}
+	var claims struct {
+		Issuer string `json:"iss"`
+	}
+	if err := json.Unmarshal(decoded, &claims); err != nil {
+		return "", ErrMalformedToken
+	}
+	return claims.Issuer, nil
+}

--- a/libs/tokenverifier/registry_test.go
+++ b/libs/tokenverifier/registry_test.go
@@ -1,0 +1,170 @@
+package tokenverifier_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
+)
+
+// A registry routes each token to the realm named by its own issuer, and
+// that realm's own audience and keys decide it - no service concatenates an
+// issuer or a key-set URL by hand to do this (issue #77).
+func TestARegistryVerifiesEachTokenAgainstTheRealmItsIssuerNames(t *testing.T) {
+	a := newRealmFixture(t, "http://keycloak:8080/realms/tenant-a", "tenant-a")
+	b := newRealmFixture(t, "http://keycloak:8080/realms/tenant-b", "tenant-b")
+
+	registry := tokenverifier.NewRegistry()
+	registry.Register(a.issuer, a.verifier(t))
+	registry.Register(b.issuer, b.verifier(t))
+
+	verifiedA, err := registry.Verify(context.Background(), a.sign(t, a.valid(nil)))
+	if err != nil {
+		t.Fatalf("verifying tenant a's token: %v", err)
+	}
+	if verifiedA.TenantID != "tenant-a" {
+		t.Errorf("tenant a's token resolved to tenant %q, want tenant-a", verifiedA.TenantID)
+	}
+
+	verifiedB, err := registry.Verify(context.Background(), b.sign(t, b.valid(nil)))
+	if err != nil {
+		t.Fatalf("verifying tenant b's token: %v", err)
+	}
+	if verifiedB.TenantID != "tenant-b" {
+		t.Errorf("tenant b's token resolved to tenant %q, want tenant-b", verifiedB.TenantID)
+	}
+}
+
+// The isolation the whole registry exists for: a token that verifies
+// perfectly against its own realm must still be refused by every other
+// realm's keys, because it was never signed by them.
+func TestARegistryRefusesATokenSignedByAKeyItsIssuerDoesNotOwn(t *testing.T) {
+	a := newRealmFixture(t, "http://keycloak:8080/realms/tenant-a", "tenant-a")
+	b := newRealmFixture(t, "http://keycloak:8080/realms/tenant-b", "tenant-b")
+
+	registry := tokenverifier.NewRegistry()
+	registry.Register(a.issuer, a.verifier(t))
+	registry.Register(b.issuer, b.verifier(t))
+
+	// A token claiming tenant b's issuer but signed by tenant a's key: the
+	// registry picks tenant b's Verifier from the issuer, which then rejects
+	// the signature because it was never made by a key tenant b publishes.
+	forged := signWith(t, a.key, "test-key", "RS256", b.valid(claims{"iss": b.issuer}))
+	if _, err := registry.Verify(context.Background(), forged); !errors.Is(err, tokenverifier.ErrUnknownKey) &&
+		!errors.Is(err, tokenverifier.ErrInvalidSignature) {
+		t.Errorf("Verify error = %v, want ErrUnknownKey or ErrInvalidSignature", err)
+	}
+}
+
+// An issuer no realm was registered for is refused outright, the same as any
+// other unrecognised issuer.
+func TestARegistryRefusesAnUnregisteredIssuer(t *testing.T) {
+	registry := tokenverifier.NewRegistry()
+	a := newRealmFixture(t, "http://keycloak:8080/realms/tenant-a", "tenant-a")
+
+	_, err := registry.Verify(context.Background(), a.sign(t, a.valid(nil)))
+	if !errors.Is(err, tokenverifier.ErrInvalidIssuer) {
+		t.Errorf("Verify error = %v, want ErrInvalidIssuer", err)
+	}
+}
+
+// Signing keys are cached per realm (issue #77): forcing tenant a's cached
+// key set empty - the shape a rotation leaves behind until the next fetch -
+// must never disturb tenant b's independently cached keys.
+func TestAKeyRotationInOneRealmDoesNotDisturbAnother(t *testing.T) {
+	a := newRealmFixture(t, "http://keycloak:8080/realms/tenant-a", "tenant-a")
+	b := newRealmFixture(t, "http://keycloak:8080/realms/tenant-b", "tenant-b")
+
+	registry := tokenverifier.NewRegistry()
+	aKeys := staticKeys{"test-key": &a.key.PublicKey}
+	registry.Register(a.issuer, mustVerifier(t, a, aKeys))
+	registry.Register(b.issuer, mustVerifier(t, b, staticKeys{"test-key": &b.key.PublicKey}))
+
+	// tenant a rotates away its only published key.
+	delete(aKeys, "test-key")
+
+	if _, err := registry.Verify(context.Background(), a.sign(t, a.valid(nil))); !errors.Is(err, tokenverifier.ErrUnknownKey) {
+		t.Fatalf("tenant a after rotation: err = %v, want ErrUnknownKey", err)
+	}
+
+	// tenant b's own key was never touched.
+	verifiedB, err := registry.Verify(context.Background(), b.sign(t, b.valid(nil)))
+	if err != nil {
+		t.Fatalf("tenant b after tenant a's rotation: %v", err)
+	}
+	if verifiedB.TenantID != "tenant-b" {
+		t.Errorf("tenant b's token resolved to tenant %q, want tenant-b", verifiedB.TenantID)
+	}
+}
+
+// --- fixture -----------------------------------------------------------
+
+type realmFixture struct {
+	issuer string
+	realm  string
+	key    *rsa.PrivateKey
+	now    time.Time
+}
+
+func newRealmFixture(t *testing.T, issuer, realm string) *realmFixture {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating a signing key: %v", err)
+	}
+	return &realmFixture{
+		issuer: issuer,
+		realm:  realm,
+		key:    key,
+		now:    time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+}
+
+func (f *realmFixture) valid(overrides claims) claims {
+	payload := claims{
+		"iss":                f.issuer,
+		"aud":                audience,
+		"sub":                "user-" + f.realm,
+		"preferred_username": f.realm + "-user",
+		"exp":                f.now.Add(time.Hour).Unix(),
+		"iat":                f.now.Unix(),
+		"resource_access": map[string]any{
+			"patient-app": map[string]any{"roles": []string{"doctor"}},
+		},
+	}
+	for name, value := range overrides {
+		payload[name] = value
+	}
+	return payload
+}
+
+func (f *realmFixture) verifier(t *testing.T) *tokenverifier.Verifier {
+	t.Helper()
+	return mustVerifier(t, f, staticKeys{"test-key": &f.key.PublicKey})
+}
+
+func mustVerifier(t *testing.T, f *realmFixture, keys tokenverifier.KeySource) *tokenverifier.Verifier {
+	t.Helper()
+	verifier, err := tokenverifier.New(tokenverifier.Config{
+		Issuer:     f.issuer,
+		Audience:   audience,
+		Realm:      f.realm,
+		RoleSource: tokenverifier.RoleSourceClient,
+		ClientID:   "patient-app",
+		Keys:       keys,
+		Now:        func() time.Time { return f.now },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return verifier
+}
+
+func (f *realmFixture) sign(t *testing.T, payload claims) string {
+	t.Helper()
+	return signWith(t, f.key, "test-key", "RS256", payload)
+}

--- a/libs/tokenverifier/tokenverifier.go
+++ b/libs/tokenverifier/tokenverifier.go
@@ -53,9 +53,6 @@ var (
 	// ErrReservedRole means the token claimed a role only the platform may
 	// assign.
 	ErrReservedRole = errors.New("the token carries a role reserved for the platform")
-	// ErrMissingTenant means the token carries no tenant, so no server-side
-	// tenant context could be derived.
-	ErrMissingTenant = errors.New("the token carries no tenant")
 )
 
 // RoleSource names which Keycloak role claim is authoritative (§7.3).
@@ -68,20 +65,11 @@ const (
 	RoleSourceRealm RoleSource = "REALM"
 )
 
-// TenantMappingMode names where the tenant comes from (§7.1).
-type TenantMappingMode string
-
+// Default claim names. Keycloak emits hospital through a user attribute
+// mapper, so the name is configurable rather than fixed. The tenant carries
+// no such claim (issue #77): it is always the realm that signed the token,
+// which is not something a caller's claim set can express.
 const (
-	// TenantMappingClaim reads the configured tenant claim from the token.
-	TenantMappingClaim TenantMappingMode = "CLAIM"
-	// TenantMappingRealm uses the realm name as the tenant identifier.
-	TenantMappingRealm TenantMappingMode = "REALM"
-)
-
-// Default claim names. Keycloak emits tenant and hospital through user
-// attribute mappers, so the names are configurable rather than fixed.
-const (
-	DefaultTenantClaim   = "tenant_id"
 	DefaultHospitalClaim = "hospital_id"
 )
 
@@ -99,16 +87,19 @@ type KeySource interface {
 type Config struct {
 	Issuer   string
 	Audience string
-	Realm    string
+	// Realm is both a signature-verification input and the tenant this
+	// verifier's tokens belong to (issue #77): the identity adapter that
+	// builds this Config is the one place that decides what a realm is for
+	// its product, and every verified token's tenant is this value, never a
+	// claim the token itself carries.
+	Realm string
 
 	RoleSource RoleSource
 	// ClientID is the client whose roles are authoritative when RoleSource is
 	// CLIENT. It is also the audience Keycloak stamps on the token.
 	ClientID string
 
-	TenantMappingMode TenantMappingMode
-	TenantClaim       string
-	HospitalClaim     string
+	HospitalClaim string
 
 	Keys   KeySource
 	Now    func() time.Time
@@ -141,6 +132,8 @@ func New(cfg Config) (*Verifier, error) {
 		return nil, errors.New("tokenverifier: an issuer is required")
 	case cfg.Audience == "":
 		return nil, errors.New("tokenverifier: an audience is required")
+	case cfg.Realm == "":
+		return nil, errors.New("tokenverifier: a realm is required: it is the tenant every verified token carries")
 	case cfg.Keys == nil:
 		return nil, errors.New("tokenverifier: a key source is required")
 	}
@@ -150,15 +143,6 @@ func New(cfg Config) (*Verifier, error) {
 	}
 	if cfg.RoleSource == RoleSourceClient && cfg.ClientID == "" {
 		return nil, errors.New("tokenverifier: a client id is required when roles come from a client")
-	}
-	if cfg.TenantMappingMode == "" {
-		cfg.TenantMappingMode = TenantMappingClaim
-	}
-	if cfg.TenantMappingMode == TenantMappingRealm && cfg.Realm == "" {
-		return nil, errors.New("tokenverifier: a realm is required when the tenant is mapped from the realm")
-	}
-	if cfg.TenantClaim == "" {
-		cfg.TenantClaim = DefaultTenantClaim
 	}
 	if cfg.HospitalClaim == "" {
 		cfg.HospitalClaim = DefaultHospitalClaim
@@ -297,16 +281,14 @@ func (v *Verifier) Verify(ctx context.Context, raw string) (VerifiedToken, error
 		return VerifiedToken{}, err
 	}
 
-	tenant, err := v.tenantOf(claims)
-	if err != nil {
-		return VerifiedToken{}, err
-	}
-
 	verified := VerifiedToken{
-		Subject:    claims.Subject,
-		Username:   claims.Username,
-		Issuer:     claims.Issuer,
-		TenantID:   tenant,
+		Subject:  claims.Subject,
+		Username: claims.Username,
+		Issuer:   claims.Issuer,
+		// The tenant is the realm that signed the token (issue #77), never a
+		// claim inside it: a caller who could put any value in a claim could
+		// put any tenant in it too.
+		TenantID:   v.cfg.Realm,
 		HospitalID: stringClaim(claims.rest, v.cfg.HospitalClaim),
 		Roles:      roles,
 		ExpiresAt:  expiresAt,
@@ -360,17 +342,6 @@ func CanonicalRoles(cfg Config, names []string) []string {
 		roles = append(roles, canonicalid.KeycloakClientRole(cfg.Realm, cfg.ClientID, role))
 	}
 	return roles
-}
-
-func (v *Verifier) tenantOf(claims jwtClaims) (string, error) {
-	if v.cfg.TenantMappingMode == TenantMappingRealm {
-		return v.cfg.Realm, nil
-	}
-	tenant := stringClaim(claims.rest, v.cfg.TenantClaim)
-	if tenant == "" {
-		return "", ErrMissingTenant
-	}
-	return tenant, nil
 }
 
 func allRoles(claims jwtClaims) []string {

--- a/libs/tokenverifier/tokenverifier_test.go
+++ b/libs/tokenverifier/tokenverifier_test.go
@@ -50,6 +50,22 @@ func TestAWellFormedTokenYieldsTheIdentityItCarries(t *testing.T) {
 	}
 }
 
+// The tenant is the realm that signed the token (issue #77), never a claim
+// inside it: a token carrying a forged tenant_id claim still resolves to the
+// realm the Verifier was built for.
+func TestTheTenantComesFromTheRealmNeverFromAClaim(t *testing.T) {
+	fixture := newFixture(t)
+
+	verified, err := fixture.verifier(t).Verify(context.Background(),
+		fixture.sign(t, fixture.valid(claims{"tenant_id": "some-other-tenant"})))
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verified.TenantID != realm {
+		t.Errorf("TenantID = %q, want %q (the realm, not the forged claim)", verified.TenantID, realm)
+	}
+}
+
 // The four mandatory §16.1 checks, each proven by the token that fails only it.
 // The valid token above is the control: every case below differs from it in one
 // respect, so a pass here cannot come from some unrelated rejection.
@@ -112,15 +128,6 @@ func TestTheMandatoryIdentityChecksEachRejectATokenThatFailsThem(t *testing.T) {
 			name:  "something that is not a token at all",
 			token: func() string { return "not-a-token" },
 			want:  tokenverifier.ErrMalformedToken,
-		},
-		{
-			name: "no tenant to derive a server-side context from",
-			token: func() string {
-				payload := fixture.valid(nil)
-				delete(payload, "tenant_id")
-				return fixture.sign(t, payload)
-			},
-			want: tokenverifier.ErrMissingTenant,
 		},
 	}
 

--- a/scripts/seed-tenants.sh
+++ b/scripts/seed-tenants.sh
@@ -31,16 +31,22 @@ esac
 export GO_NETWORK="${GO_NETWORK:-${COMPOSE_PROJECT_NAME:-cerbos-poc}_default}"
 export ASSIGNMENTSTORE_POSTGRES_DSN="postgres://${POSTGRES_USER:-cerbos_poc}:${POSTGRES_PASSWORD:-change-me}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-cerbos_poc}?sslmode=disable"
 export TENANT_REGISTRY_FILE="/workspace/deploy/tenant-registry.yaml"
-export TENANT_ISSUER="${KEYCLOAK_HOSTNAME:-http://localhost:8081}/realms/${IDP_REALM:-tenant-a}"
-# This path is read back by the ADS, Admin Service and Resource Service
-# containers (issue #76), not by this seeder, so it has to be where the
-# secret lands in *their* mount (docker-compose.yml's
-# /run/secrets/idp-admin-credentials), not the go.sh sandbox's /workspace.
-# tenantregistry validates the secret is readable at parse time, so this
-# same path is also bind-mounted into the sandbox below, from the identical
-# host file the app containers mount.
-export TENANT_CREDENTIAL_SECRET_REF="${TENANT_CREDENTIAL_SECRET_REF:-/run/secrets/idp-admin-credentials}"
-export GO_ENV_PASS="ASSIGNMENTSTORE_POSTGRES_DSN TENANT_REGISTRY_FILE TENANT_ISSUER TENANT_CREDENTIAL_SECRET_REF"
-export GO_EXTRA_MOUNTS="${repo_root}/deploy/secrets/idp-admin-credentials:${TENANT_CREDENTIAL_SECRET_REF}:ro,z"
+
+# Two realms (issue #77): each names its own issuer and credential secret
+# path, substituted independently by cmd/seed-tenants. These paths are read
+# back by the ADS, Admin Service and Resource Service containers, not by
+# this seeder, so they have to be where the secret lands in *their* mount
+# (docker-compose.yml's /run/secrets/idp-admin-credentials[-tenant-b]), not
+# the go.sh sandbox's /workspace. tenantregistry validates each secret is
+# readable at parse time, so the same paths are also bind-mounted into the
+# sandbox below, from the identical host files the app containers mount.
+export TENANT_A_ISSUER="${TENANT_A_ISSUER:-${KEYCLOAK_HOSTNAME:-http://localhost:8081}/realms/tenant-a}"
+export TENANT_A_CREDENTIAL_SECRET_REF="${TENANT_A_CREDENTIAL_SECRET_REF:-/run/secrets/idp-admin-credentials}"
+export TENANT_B_ISSUER="${TENANT_B_ISSUER:-${KEYCLOAK_HOSTNAME:-http://localhost:8081}/realms/tenant-b}"
+export TENANT_B_CREDENTIAL_SECRET_REF="${TENANT_B_CREDENTIAL_SECRET_REF:-/run/secrets/idp-admin-credentials-tenant-b}"
+export GO_ENV_PASS="ASSIGNMENTSTORE_POSTGRES_DSN TENANT_REGISTRY_FILE TENANT_A_ISSUER TENANT_A_CREDENTIAL_SECRET_REF TENANT_B_ISSUER TENANT_B_CREDENTIAL_SECRET_REF"
+export GO_EXTRA_MOUNTS="$(printf '%s\n%s' \
+  "${repo_root}/deploy/secrets/idp-admin-credentials:${TENANT_A_CREDENTIAL_SECRET_REF}:ro,z" \
+  "${repo_root}/deploy/secrets/idp-admin-credentials-tenant-b:${TENANT_B_CREDENTIAL_SECRET_REF}:ro,z")"
 
 exec bash "${repo_root}/scripts/go.sh" libs/assignmentstore run ./cmd/seed-tenants

--- a/scripts/tests/identity-e2e.sh
+++ b/scripts/tests/identity-e2e.sh
@@ -109,6 +109,58 @@ expect_status "a request naming its own tenant is refused" 400 \
   "$(decide_with "${doctor_token}" "${smuggled}")"
 
 echo
+echo "--- cross-tenant isolation (issue #77) ---"
+
+# Two genuinely registered realms served by the same deployment. tenant-b
+# mints its own token from its own issuer, verified by the tenant registry's
+# own Verifier for that realm - not tenant-a's, and not a claim either
+# token could have carried on its own.
+doctor_b_token="$(token_for user-doctor-b patient-app tenant-b)" || exit 1
+
+issuer_b="$(claim_of "${doctor_b_token}" '.iss')"
+if [[ "${issuer_b}" == *"/realms/tenant-b" ]]; then
+  pass "tenant-b mints its own token from its own issuer"
+else
+  fail "tenant-b mints its own token from its own issuer (issuer was '${issuer_b}')"
+fi
+
+expect_status "tenant-b's token is accepted by the same deployment tenant-a's is" 200 \
+  "$(decide_with "${doctor_b_token}")" "$(cat /tmp/identity-body)"
+
+# tenant-a's own genuine, correctly-verified token, asked about a resource
+# whose stored tenant (as resource-service would have fetched it from the
+# database, never from request input) is tenant-b's: the isolation rule
+# denies it, so the identity check passing is not what stands between a
+# caller and another tenant's data - the policy is.
+cross_tenant_request='{"resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-b","hospitalId":"hospital-1","status":"ACTIVE"},"actions":["read"]}]}'
+decide_with "${doctor_token}" "${cross_tenant_request}" >/dev/null
+cross_tenant_allowed="$(jq -r '.resources[0].actions.read.allowed' /tmp/identity-body)"
+if [[ "${cross_tenant_allowed}" == "false" ]]; then
+  pass "a valid tenant-a token is refused against tenant-b's data"
+else
+  fail "a valid tenant-a token is refused against tenant-b's data (allowed was '${cross_tenant_allowed}')"
+fi
+
+# The reverse direction proves the boundary runs both ways, not just
+# because tenant-a happens to be what every other case in this suite uses.
+reverse_cross_tenant_request='{"resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-a","hospitalId":"hospital-1","status":"ACTIVE"},"actions":["read"]}]}'
+decide_with "${doctor_b_token}" "${reverse_cross_tenant_request}" >/dev/null
+reverse_allowed="$(jq -r '.resources[0].actions.read.allowed' /tmp/identity-body)"
+if [[ "${reverse_allowed}" == "false" ]]; then
+  pass "a valid tenant-b token is refused against tenant-a's data"
+else
+  fail "a valid tenant-b token is refused against tenant-a's data (allowed was '${reverse_allowed}')"
+fi
+
+# §77's other half of the acceptance criterion: the refusal is logged
+# distinguishably from an ordinary deny, so it is alertable on its own.
+if docker compose logs ads 2>/dev/null | grep -q "cross-tenant or cross-hospital access attempt refused"; then
+  pass "the cross-tenant refusal is logged distinguishably"
+else
+  fail "the cross-tenant refusal is logged distinguishably (no matching ADS log line found)"
+fi
+
+echo
 echo "--- the identity directory ---"
 
 admin_token="$(token_for user-admin)" || exit 1

--- a/tests/architecture/tenantclaim.go
+++ b/tests/architecture/tenantclaim.go
@@ -1,0 +1,56 @@
+package architecture
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+)
+
+// ForbiddenTenantDerivations names identifiers whose mere presence in source
+// means a claim-derived, request-derived or caller-chosen tenant mapping has
+// come back (issue #77). §16.1 already made tenant and hospital context
+// server-derived; #77 goes further for the tenant specifically - it is
+// always the realm that signed the token, and there is no longer a mode,
+// claim name or per-request field that could name a different one. Any of
+// these identifiers reappearing is that regression, whichever package it
+// shows up in.
+var ForbiddenTenantDerivations = []string{
+	"TenantMappingMode",
+	"TenantMappingClaim",
+	"TenantMappingRealm",
+	"TenantClaim",
+}
+
+// ScanForClaimDerivedTenant reports every reference to a
+// ForbiddenTenantDerivations identifier.
+func ScanForClaimDerivedTenant(filename, src string) ([]Finding, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, src, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", filename, err)
+	}
+
+	forbidden := make(map[string]bool, len(ForbiddenTenantDerivations))
+	for _, name := range ForbiddenTenantDerivations {
+		forbidden[name] = true
+	}
+
+	var findings []Finding
+	ast.Inspect(file, func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		if !ok || !forbidden[ident.Name] {
+			return true
+		}
+		findings = append(findings, Finding{
+			File:   filename,
+			Line:   fset.Position(ident.Pos()).Line,
+			Symbol: ident.Name,
+			Message: fmt.Sprintf(
+				"%q reintroduces a claim- or mode-selected tenant mapping; the tenant is always the realm that signed the token (issue #77)",
+				ident.Name),
+		})
+		return true
+	})
+	return findings, nil
+}

--- a/tests/architecture/tenantclaim_test.go
+++ b/tests/architecture/tenantclaim_test.go
@@ -1,0 +1,97 @@
+package architecture_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/tests/architecture"
+)
+
+// No consumer anywhere in the module derives a tenant from request input
+// (issue #77): the tenant is always the realm that signed the verified
+// token, never a claim, a mode or a per-request field.
+func TestNoConsumerDerivesATenantFromAClaim(t *testing.T) {
+	root := repoRoot(t)
+
+	var findings []architecture.Finding
+	for _, path := range goFiles(t, root) {
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatalf("relativising %s: %v", path, err)
+		}
+		if strings.HasPrefix(filepath.ToSlash(relative), "tests/architecture/") {
+			continue
+		}
+
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+
+		found, err := architecture.ScanForClaimDerivedTenant(relative, string(source))
+		if err != nil {
+			t.Fatalf("scanning %s: %v", relative, err)
+		}
+		findings = append(findings, found...)
+	}
+
+	if len(findings) > 0 {
+		var report strings.Builder
+		report.WriteString("a claim- or mode-selected tenant mapping reappeared:\n")
+		for _, finding := range findings {
+			report.WriteString("  " + finding.String() + "\n")
+		}
+		t.Fatal(report.String())
+	}
+}
+
+// An architecture test that cannot fail is decoration.
+func TestTheCheckerCatchesAReintroducedTenantMappingMode(t *testing.T) {
+	const violation = `package tokenverifier
+
+type TenantMappingMode string
+
+const TenantMappingClaim TenantMappingMode = "CLAIM"
+`
+
+	findings, err := architecture.ScanForClaimDerivedTenant("libs/tokenverifier/tokenverifier.go", violation)
+	if err != nil {
+		t.Fatalf("ScanForClaimDerivedTenant: %v", err)
+	}
+
+	symbols := map[string]bool{}
+	for _, finding := range findings {
+		symbols[finding.Symbol] = true
+	}
+	for _, want := range []string{"TenantMappingMode", "TenantMappingClaim"} {
+		if !symbols[want] {
+			t.Errorf("the checker missed %s; found %v", want, symbols)
+		}
+	}
+}
+
+// Ordinary tenant-handling code - a TenantID field, a realm string - must
+// not be flagged: the checker looks for the specific retired identifiers,
+// not for the word "tenant".
+func TestTheCheckerAllowsOrdinaryTenantHandling(t *testing.T) {
+	const source = `package tokenverifier
+
+type Config struct {
+	Realm string
+}
+
+type VerifiedToken struct {
+	TenantID string
+}
+`
+
+	findings, err := architecture.ScanForClaimDerivedTenant("libs/tokenverifier/tokenverifier.go", source)
+	if err != nil {
+		t.Fatalf("ScanForClaimDerivedTenant: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("ordinary tenant handling was flagged: %v", findings)
+	}
+}


### PR DESCRIPTION
## What changed

Multi-issuer token verification and cross-tenant rejection (issue #77): one deployment now serves more than one Keycloak realm, and the isolation between them is proven end to end rather than assumed.

- **Multi-issuer verification** (`libs/tokenverifier`): a new `Registry` picks a realm's `Verifier` from the token's own (unverified) issuer, then that realm's `Verifier` performs the full signature check with its own keys. Each realm keeps its own `JWKS` cache, so a key rotation in one realm never disturbs another's.
- **Tenant comes from the realm, never a claim**: `TenantMappingMode`/`TenantMappingClaim`/`TenantMappingRealm`/`TenantClaim` are gone from `libs/tokenverifier` and `libs/idpdirectory/provider`. A verified token's tenant is always the realm its `Verifier` was built for. A new architecture test (`tests/architecture/tenantclaim.go`) fails the build if any of those identifiers reappear anywhere in the module.
- **Per-adapter identity mapping**: `provider.ConfigFromTenant` is the one place a realm's tenant is declared (the realm verbatim), replacing the old installation-wide mapping mode.
- **Every service serves every registered realm**: `tenantresolve.All` + `provider.InstallationsFromTenants` replace the old "exactly one tenant" resolution in `ads`, `admin-service` and `resource-service`. Each builds a `tokenverifier.Registry` across every realm and registers it as the request verifier. `ads`'s directory API routes each request to its own tenant's directory client (`directoryapi.Config.Directories`).
- **A second, genuinely registered tenant** (`tenant-b`): its own Keycloak realm, its own confidential service-account client and secret, its own tenant registry row, wired into both `docker-compose.yml` and the `deploy/k8s` base manifests.
- **Cross-tenant refusals are logged distinguishably**: `authz.IsolationFired` reports when the generated `tenant_and_hospital_isolation` Cerbos rule denied a leaf, and the decision endpoint logs a `WARN` naming it explicitly, separate from the ordinary per-decision `INFO` log.
- **End-to-end proof**: `scripts/tests/identity-e2e.sh` mints a real tenant-b token from tenant-b's own Keycloak realm, confirms the same ADS deployment accepts it, and confirms a genuine tenant-a token is refused against tenant-b's data (and the reverse), then checks the ADS log for the distinguishable warning.

## How each acceptance criterion is met

- [x] Verification resolves the issuer through the registry; no service concatenates an issuer or key-set URL by hand - `tokenverifier.Registry.Verify` picks by issuer; `provider.Config.JWKSURL()` (pre-existing) still builds the key-set URL from the realm's own base URL/realm.
- [x] Signing keys are cached per realm; a rotation in one does not disturb another - `TestAKeyRotationInOneRealmDoesNotDisturbAnother`.
- [x] The tenant comes from the realm that signed the token, never a claim - `TestTheTenantComesFromTheRealmNeverFromAClaim` + the `tenantclaim` architecture test.
- [x] Each identity adapter declares its own identity mapping; no global mapping mode - `TenantMappingMode` and friends removed entirely.
- [x] A second tenant realm exists in compose and Kubernetes with its own service-account credentials - `deploy/keycloak/realm-tenant-b.json`, `deploy/secrets/idp-admin-credentials-tenant-b`.
- [x] A valid tenant-a token is refused against tenant-b's data, end to end - `identity-e2e.sh`'s new "cross-tenant isolation" section.
- [x] Cross-tenant attempts are logged distinguishably - `IsolationFired` + the ADS's `WARN` log line, unit-tested and checked in the e2e log grep.
- [x] An architecture test fails the build if any consumer derives a tenant from request input - `tests/architecture/tenantclaim.go`.

## Verified with

- `bash scripts/go.sh <module> test ./...` for every touched Go module (all green).
- `python3 scripts/tests/compose-contract.py` (satisfied).
- `docker compose config -q` (valid).
- `python3 -c "import yaml; yaml.safe_load(...)"` against every touched k8s manifest.
- `go vet` / `gofmt -l` across every touched module (clean).
- CI (docker compose walking skeleton, architecture invariants, authorization schema on postgres, cerbos policy suite, dual dialect portability, nx affected).

Known, deliberate scope trim: `admin-service`'s own browser login page still points at one "home" realm (the lowest-named one, or an explicit `OIDC_ISSUER`/`OIDC_CLIENT_ID` override) - a browser still lands on exactly one login page, and the acceptance criteria do not ask the console itself to pick among realms.

Closes #77


Closes #77
