### PR TITLE
Hospital derived from the verified organization claim (#78)

### DIFF
--- a/apps/admin-service/internal/tokenauth/tokenauth.go
+++ b/apps/admin-service/internal/tokenauth/tokenauth.go
@@ -84,6 +84,14 @@ func Require(cfg Config, next http.Handler) http.Handler {
 				writeError(w, http.StatusForbidden, "the token carries a role reserved for the platform")
 				return
 			}
+			// An unscoped token (issue #78) is a distinct, logged reason:
+			// it is not a forgery attempt, but it is not an ordinary
+			// expired-or-malformed rejection either.
+			if errors.Is(err, tokenverifier.ErrUnscopedToken) || errors.Is(err, tokenverifier.ErrAmbiguousOrganization) {
+				logger.WarnContext(r.Context(), "rejected an unscoped token", slog.Any("error", err))
+				writeError(w, http.StatusUnauthorized, "the token names no usable hospital scope")
+				return
+			}
 			logger.WarnContext(r.Context(), "rejected a bearer token", slog.Any("error", err))
 			writeError(w, http.StatusUnauthorized, "the bearer token was refused")
 			return

--- a/apps/ads/internal/tokenauth/tokenauth.go
+++ b/apps/ads/internal/tokenauth/tokenauth.go
@@ -83,6 +83,16 @@ func Require(cfg Config, next http.Handler) http.Handler {
 				writeError(w, http.StatusForbidden, "the token carries a role reserved for the platform")
 				return
 			}
+			// An unscoped token (issue #78) is a distinct, logged reason
+			// too: it is not a forgery attempt, but it is not an ordinary
+			// expired-or-malformed rejection either, and an operator
+			// watching for organization-selection gaps should not have to
+			// pattern-match the generic message to find it.
+			if errors.Is(err, tokenverifier.ErrUnscopedToken) || errors.Is(err, tokenverifier.ErrAmbiguousOrganization) {
+				logger.WarnContext(r.Context(), "rejected an unscoped token", slog.Any("error", err))
+				writeError(w, http.StatusUnauthorized, "the token names no usable hospital scope")
+				return
+			}
 			// Which check failed goes to the log, not to the caller: telling
 			// an unauthenticated caller whether the signature or the audience
 			// was wrong is telling them how to get closer.

--- a/apps/ads/internal/tokenauth/tokenauth_test.go
+++ b/apps/ads/internal/tokenauth/tokenauth_test.go
@@ -3,6 +3,7 @@ package tokenauth_test
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -106,6 +107,33 @@ func TestATokenClaimingTheSyntheticRoleIsForbiddenRatherThanUnauthorized(t *test
 
 	if rec.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+// §78: an unscoped token is refused distinguishably, logged separately from
+// an ordinary rejection, even though the caller still only learns that the
+// token was refused.
+func TestAnUnscopedTokenIsLoggedDistinguishably(t *testing.T) {
+	for _, err := range []error{tokenverifier.ErrUnscopedToken, tokenverifier.ErrAmbiguousOrganization} {
+		t.Run(err.Error(), func(t *testing.T) {
+			var logged strings.Builder
+			handler := tokenauth.Require(
+				tokenauth.Config{
+					Verifier: verifier{err: err},
+					Logger:   slog.New(slog.NewJSONHandler(&logged, nil)),
+				},
+				refuseToRun(t))
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, authorized("an-unscoped-token"))
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+			}
+			if !strings.Contains(logged.String(), "unscoped") {
+				t.Errorf("no log record named an unscoped token; log was:\n%s", logged.String())
+			}
+		})
 	}
 }
 

--- a/apps/resource-service/internal/tokenauth/tokenauth.go
+++ b/apps/resource-service/internal/tokenauth/tokenauth.go
@@ -84,6 +84,14 @@ func Require(cfg Config, next http.Handler) http.Handler {
 				writeError(w, http.StatusForbidden, "the token carries a role reserved for the platform")
 				return
 			}
+			// An unscoped token (issue #78) is a distinct, logged reason:
+			// it is not a forgery attempt, but it is not an ordinary
+			// expired-or-malformed rejection either.
+			if errors.Is(err, tokenverifier.ErrUnscopedToken) || errors.Is(err, tokenverifier.ErrAmbiguousOrganization) {
+				logger.WarnContext(r.Context(), "rejected an unscoped token", slog.Any("error", err))
+				writeError(w, http.StatusUnauthorized, "the token names no usable hospital scope")
+				return
+			}
 			logger.WarnContext(r.Context(), "rejected a bearer token", slog.Any("error", err))
 			writeError(w, http.StatusUnauthorized, "the bearer token was refused")
 			return

--- a/deploy/k8s/base/keycloak/deployment.yaml
+++ b/deploy/k8s/base/keycloak/deployment.yaml
@@ -20,7 +20,11 @@ spec:
       containers:
         - name: keycloak
           image: quay.io/keycloak/keycloak:26.4
-          args: ["start-dev", "--import-realm"]
+          # `organization` is a preview feature in 26.4: Keycloak Organizations
+          # (issue #75/#78) is disabled by default and every organization
+          # import 400s without it, matching docker-compose.yml's keycloak
+          # service.
+          args: ["start-dev", "--import-realm", "--features=organization"]
           envFrom:
             - secretRef:
                 name: keycloak-credentials

--- a/deploy/keycloak/realm-other-issuer.json
+++ b/deploy/keycloak/realm-other-issuer.json
@@ -3,7 +3,6 @@
   "displayName": "Wrong issuer fixture: genuine tokens the ADS must still refuse",
   "enabled": true,
   "sslRequired": "none",
-  "organizationsEnabled": true,
   "clients": [
     {
       "clientId": "patient-app",
@@ -17,7 +16,6 @@
       "redirectUris": [],
       "webOrigins": [],
       "defaultClientScopes": ["basic", "web-origins", "profile", "roles", "email"],
-      "optionalClientScopes": ["organization"],
       "protocolMappers": [
         {
           "name": "audience",

--- a/deploy/keycloak/realm-other-issuer.json
+++ b/deploy/keycloak/realm-other-issuer.json
@@ -3,6 +3,7 @@
   "displayName": "Wrong issuer fixture: genuine tokens the ADS must still refuse",
   "enabled": true,
   "sslRequired": "none",
+  "organizationsEnabled": true,
   "clients": [
     {
       "clientId": "patient-app",
@@ -16,6 +17,7 @@
       "redirectUris": [],
       "webOrigins": [],
       "defaultClientScopes": ["basic", "web-origins", "profile", "roles", "email"],
+      "optionalClientScopes": ["organization"],
       "protocolMappers": [
         {
           "name": "audience",

--- a/deploy/keycloak/realm-tenant-a.json
+++ b/deploy/keycloak/realm-tenant-a.json
@@ -12,7 +12,13 @@
       "alias": "north-hospital",
       "enabled": true,
       "domains": [{ "name": "north-hospital.example.test", "verified": false }],
-      "members": [{ "username": "user-doctor" }]
+      "members": [
+        { "username": "user-doctor" },
+        { "username": "user-doctor-revoked" },
+        { "username": "user-auditor" },
+        { "username": "user-clerk-granted" },
+        { "username": "user-unassigned" }
+      ]
     },
     {
       "name": "South Hospital",
@@ -58,30 +64,6 @@
             "included.client.audience": "patient-app",
             "access.token.claim": "true"
           }
-        },
-        {
-          "name": "tenant",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "config": {
-            "user.attribute": "tenant_id",
-            "claim.name": "tenant_id",
-            "jsonType.label": "String",
-            "access.token.claim": "true",
-            "id.token.claim": "true"
-          }
-        },
-        {
-          "name": "hospital",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "config": {
-            "user.attribute": "hospital_id",
-            "claim.name": "hospital_id",
-            "jsonType.label": "String",
-            "access.token.claim": "true",
-            "id.token.claim": "true"
-          }
         }
       ]
     },
@@ -125,6 +107,12 @@
     }
   ],
   "roles": {
+    "realm": [
+      {
+        "name": "admin",
+        "description": "The tenant-wide marker (issue #78): a token carrying this realm role and no active organization is still usable, scoped to the whole tenant rather than refused as unscoped."
+      }
+    ],
     "client": {
       "patient-app": [
         {
@@ -159,10 +147,6 @@
       "firstName": "Dana",
       "lastName": "Doctor",
       "email": "dana.doctor@example.test",
-      "attributes": {
-        "tenant_id": ["tenant-a"],
-        "hospital_id": ["hospital-1"]
-      },
       "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
       "clientRoles": { "patient-app": ["doctor"] }
     },
@@ -174,10 +158,6 @@
       "firstName": "Ravi",
       "lastName": "Doctor",
       "email": "ravi.doctor@example.test",
-      "attributes": {
-        "tenant_id": ["tenant-a"],
-        "hospital_id": ["hospital-1"]
-      },
       "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
       "clientRoles": { "patient-app": ["doctor"] }
     },
@@ -189,10 +169,6 @@
       "firstName": "Alex",
       "lastName": "Auditor",
       "email": "alex.auditor@example.test",
-      "attributes": {
-        "tenant_id": ["tenant-a"],
-        "hospital_id": ["hospital-1"]
-      },
       "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
       "clientRoles": { "patient-app": ["auditor"] }
     },
@@ -204,10 +180,6 @@
       "firstName": "Chris",
       "lastName": "Clerk",
       "email": "chris.clerk@example.test",
-      "attributes": {
-        "tenant_id": ["tenant-a"],
-        "hospital_id": ["hospital-1"]
-      },
       "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
       "clientRoles": { "patient-app": ["clerk"] }
     },
@@ -219,10 +191,6 @@
       "firstName": "Uma",
       "lastName": "Unassigned",
       "email": "uma.unassigned@example.test",
-      "attributes": {
-        "tenant_id": ["tenant-a"],
-        "hospital_id": ["hospital-1"]
-      },
       "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
       "clientRoles": {}
     },
@@ -234,11 +202,8 @@
       "firstName": "Ada",
       "lastName": "Admin",
       "email": "ada.admin@example.test",
-      "attributes": {
-        "tenant_id": ["tenant-a"],
-        "hospital_id": ["hospital-1"]
-      },
       "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "realmRoles": ["admin"],
       "clientRoles": { "patient-app": ["administrator"] }
     },
     {
@@ -249,10 +214,6 @@
       "firstName": "Mal",
       "lastName": "Forger",
       "email": "mal.forger@example.test",
-      "attributes": {
-        "tenant_id": ["tenant-a"],
-        "hospital_id": ["hospital-1"]
-      },
       "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
       "clientRoles": { "patient-app": ["sys:forged-evaluator"] }
     },

--- a/deploy/keycloak/realm-tenant-a.json
+++ b/deploy/keycloak/realm-tenant-a.json
@@ -80,6 +80,7 @@
       "webOrigins": [],
       "fullScopeAllowed": false,
       "defaultClientScopes": ["basic", "web-origins", "profile", "roles", "email"],
+      "optionalClientScopes": ["organization"],
       "protocolMappers": [
         {
           "name": "audience",

--- a/deploy/keycloak/realm-tenant-b.json
+++ b/deploy/keycloak/realm-tenant-b.json
@@ -6,6 +6,16 @@
   "registrationAllowed": false,
   "loginWithEmailAllowed": true,
   "accessTokenLifespan": 900,
+  "organizationsEnabled": true,
+  "organizations": [
+    {
+      "name": "Hospital B1",
+      "alias": "hospital-b1",
+      "enabled": true,
+      "domains": [{ "name": "hospital-b1.example.test", "verified": false }],
+      "members": [{ "username": "user-doctor-b" }]
+    }
+  ],
   "clients": [
     {
       "clientId": "patient-app",
@@ -19,6 +29,7 @@
       "redirectUris": ["http://localhost:4200/*", "http://127.0.0.1:4200/*"],
       "webOrigins": ["http://localhost:4200", "http://127.0.0.1:4200"],
       "defaultClientScopes": ["basic", "web-origins", "profile", "roles", "email"],
+      "optionalClientScopes": ["organization"],
       "protocolMappers": [
         {
           "name": "audience",
@@ -64,9 +75,6 @@
       "firstName": "Bailey",
       "lastName": "Doctor",
       "email": "bailey.doctor@tenant-b.example.test",
-      "attributes": {
-        "hospital_id": ["hospital-1"]
-      },
       "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
       "clientRoles": { "patient-app": ["doctor"] }
     },

--- a/libs/assignmentstore/demoseed/demoseed.go
+++ b/libs/assignmentstore/demoseed/demoseed.go
@@ -50,12 +50,16 @@ const (
 	// every decision taken against this matrix.
 	Revision = 184
 
-	// HospitalID is the hospital every demo principal belongs to, per the
-	// realm import's user attributes.
-	HospitalID = "hospital-1"
+	// HospitalID is the organization alias every demo principal belongs to
+	// (issue #78), per the realm import's organization membership - not a
+	// free-form attribute.
+	HospitalID = "north-hospital"
 	// OtherHospitalID holds a user override that must never reach a
-	// HospitalID decision, even for the very same user (§6.2, §8.3).
-	OtherHospitalID = "hospital-2"
+	// HospitalID decision, even for the very same user (§6.2, §8.3). It is
+	// a real organization alias too (south-hospital), not a placeholder:
+	// nothing in this demo installation is actually a member of it, which
+	// is what makes it a clean fixture for "must never leak".
+	OtherHospitalID = "south-hospital"
 
 	// DoctorWithRevokedUpdate is a real Keycloak user (§7.1's requirement
 	// that every seeded identity resolve through the real IdP) whose update
@@ -148,7 +152,7 @@ func Apply(ctx context.Context, writer Writer, at time.Time) error {
 		userOverride(HospitalID, ClerkWithGrantedRead, "update", "",
 			assignmentstore.EffectGrant, true, began, expired),
 		// The same user's live grant in another hospital, which must never
-		// reach a hospital-1 decision.
+		// reach a north-hospital decision.
 		userOverride(OtherHospitalID, DoctorWithRevokedUpdate, "delete", "",
 			assignmentstore.EffectGrant, true, began, ends),
 		// Scoped to one resource instance: it must apply there and nowhere

--- a/libs/tokenverifier/registry_test.go
+++ b/libs/tokenverifier/registry_test.go
@@ -132,6 +132,7 @@ func (f *realmFixture) valid(overrides claims) claims {
 		"preferred_username": f.realm + "-user",
 		"exp":                f.now.Add(time.Hour).Unix(),
 		"iat":                f.now.Unix(),
+		"organization":       []string{"hospital-1"},
 		"resource_access": map[string]any{
 			"patient-app": map[string]any{"roles": []string{"doctor"}},
 		},

--- a/libs/tokenverifier/tokenverifier.go
+++ b/libs/tokenverifier/tokenverifier.go
@@ -53,6 +53,17 @@ var (
 	// ErrReservedRole means the token claimed a role only the platform may
 	// assign.
 	ErrReservedRole = errors.New("the token carries a role reserved for the platform")
+	// ErrUnscopedToken means the token names no active organization and
+	// carries no tenant-wide marker either, so no server-side hospital
+	// context could be derived (issue #78). It is refused rather than
+	// treated as tenant-wide by default: silently widening an unscoped
+	// token's reach is the failure mode this check exists to prevent.
+	ErrUnscopedToken = errors.New("the token carries neither an active organization nor the administrator's tenant-wide marker")
+	// ErrAmbiguousOrganization means the organization claim named more than
+	// one alias. A session has exactly one active hospital, or none (§75);
+	// more than one is not a hospital to guess among, it is a claim this
+	// verifier does not trust.
+	ErrAmbiguousOrganization = errors.New("the token's organization claim names more than one active organization")
 )
 
 // RoleSource names which Keycloak role claim is authoritative (§7.3).
@@ -65,13 +76,19 @@ const (
 	RoleSourceRealm RoleSource = "REALM"
 )
 
-// Default claim names. Keycloak emits hospital through a user attribute
-// mapper, so the name is configurable rather than fixed. The tenant carries
-// no such claim (issue #77): it is always the realm that signed the token,
-// which is not something a caller's claim set can express.
-const (
-	DefaultHospitalClaim = "hospital_id"
-)
+// OrganizationClaim is Keycloak's own claim name for organization scope
+// selection. Unlike the retired free-form hospital attribute, this is not
+// configurable: it is Keycloak's organization feature's claim, not a
+// convention this installation invented (§75, issue #78).
+const OrganizationClaim = "organization"
+
+// TenantWideRealmRole is the realm role that lets a token carry no active
+// organization and still be usable: an administrator's deliberate
+// tenant-wide choice (issue #78), not a default anything else falls back
+// to. It is a realm role rather than a client role because it names who the
+// principal is to the identity provider, not what one application lets them
+// do.
+const TenantWideRealmRole = "admin"
 
 // DefaultLeeway absorbs clock drift between the identity provider and this
 // service. Without it a correctly issued token is intermittently rejected on
@@ -98,8 +115,6 @@ type Config struct {
 	// ClientID is the client whose roles are authoritative when RoleSource is
 	// CLIENT. It is also the audience Keycloak stamps on the token.
 	ClientID string
-
-	HospitalClaim string
 
 	Keys   KeySource
 	Now    func() time.Time
@@ -143,9 +158,6 @@ func New(cfg Config) (*Verifier, error) {
 	}
 	if cfg.RoleSource == RoleSourceClient && cfg.ClientID == "" {
 		return nil, errors.New("tokenverifier: a client id is required when roles come from a client")
-	}
-	if cfg.HospitalClaim == "" {
-		cfg.HospitalClaim = DefaultHospitalClaim
 	}
 	if cfg.Now == nil {
 		cfg.Now = time.Now
@@ -281,6 +293,11 @@ func (v *Verifier) Verify(ctx context.Context, raw string) (VerifiedToken, error
 		return VerifiedToken{}, err
 	}
 
+	hospital, err := hospitalOf(claims)
+	if err != nil {
+		return VerifiedToken{}, err
+	}
+
 	verified := VerifiedToken{
 		Subject:  claims.Subject,
 		Username: claims.Username,
@@ -289,7 +306,7 @@ func (v *Verifier) Verify(ctx context.Context, raw string) (VerifiedToken, error
 		// claim inside it: a caller who could put any value in a claim could
 		// put any tenant in it too.
 		TenantID:   v.cfg.Realm,
-		HospitalID: stringClaim(claims.rest, v.cfg.HospitalClaim),
+		HospitalID: hospital,
 		Roles:      roles,
 		ExpiresAt:  expiresAt,
 	}
@@ -352,12 +369,67 @@ func allRoles(claims jwtClaims) []string {
 	return roles
 }
 
-func stringClaim(rest map[string]any, name string) string {
-	value, ok := rest[name].(string)
+// hospitalOf derives the active hospital from the verified organization
+// claim (issue #78, §75): the hospital identifier is the organization
+// alias, and there is no other path to it - not a free-form attribute, not
+// request input. A token naming no active organization is only usable when
+// it also carries the administrator's tenant-wide marker; otherwise it is
+// refused rather than defaulted to tenant-wide.
+func hospitalOf(claims jwtClaims) (string, error) {
+	aliases, ok := organizationAliases(claims.rest)
 	if !ok {
-		return ""
+		if hasTenantWideMarker(claims) {
+			return "", nil
+		}
+		return "", ErrUnscopedToken
 	}
-	return value
+	if len(aliases) > 1 {
+		return "", ErrAmbiguousOrganization
+	}
+	return aliases[0], nil
+}
+
+// organizationAliases decodes the organization claim into its alias list
+// (§75's spike: a JSON array of alias strings, e.g.
+// "organization": ["north-hospital"]). Any other shape - absent, a map, a
+// bare scalar, an empty array - reports false: it is not a shape Keycloak's
+// own organization scope ever produces, so it is treated the same as no
+// organization at all rather than trusted to mean something.
+func organizationAliases(rest map[string]any) ([]string, bool) {
+	raw, ok := rest[OrganizationClaim]
+	if !ok {
+		return nil, false
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, false
+	}
+	aliases := make([]string, 0, len(items))
+	for _, item := range items {
+		alias, ok := item.(string)
+		if !ok {
+			return nil, false
+		}
+		aliases = append(aliases, alias)
+	}
+	if len(aliases) == 0 {
+		return nil, false
+	}
+	return aliases, true
+}
+
+// hasTenantWideMarker reports whether the token carries the administrator's
+// tenant-wide realm role. It reads realm_access.roles directly rather than
+// the configured RoleSource: the marker names who the principal is to the
+// identity provider, not which application-facing role claim this
+// installation happens to treat as authoritative.
+func hasTenantWideMarker(claims jwtClaims) bool {
+	for _, role := range claims.RealmAccess.Roles {
+		if role == TenantWideRealmRole {
+			return true
+		}
+	}
+	return false
 }
 
 func decodeSegment[T any](segment string) (T, error) {

--- a/libs/tokenverifier/tokenverifier_test.go
+++ b/libs/tokenverifier/tokenverifier_test.go
@@ -189,6 +189,96 @@ func TestATokenCarryingAReservedRoleIsRejectedOutright(t *testing.T) {
 	}
 }
 
+// The hospital identifier is the organization alias, taken from the
+// verified organization claim (§75, issue #78) - never a free-form
+// attribute, never request input. This covers every shape the claim can
+// take: present, absent, an unexpected shape, and more than one
+// organization at once.
+func TestHospitalIsDerivedFromTheVerifiedOrganizationClaim(t *testing.T) {
+	fixture := newFixture(t)
+	adminRole := map[string]any{"roles": []string{"admin"}}
+
+	tests := []struct {
+		name           string
+		overrides      claims
+		wantHospitalID string
+		wantErr        error
+	}{
+		{
+			name:           "a present organization",
+			overrides:      claims{"organization": []string{"north-hospital"}},
+			wantHospitalID: "north-hospital",
+		},
+		{
+			name:      "an absent organization with the tenant-wide marker",
+			overrides: claims{"organization": nil, "realm_access": adminRole},
+		},
+		{
+			name:      "an absent organization with no tenant-wide marker",
+			overrides: claims{"organization": nil},
+			wantErr:   tokenverifier.ErrUnscopedToken,
+		},
+		{
+			name:      "an unexpected claim shape: a map instead of an array",
+			overrides: claims{"organization": map[string]any{"north-hospital": true}},
+			wantErr:   tokenverifier.ErrUnscopedToken,
+		},
+		{
+			name:      "an unexpected claim shape: a bare scalar",
+			overrides: claims{"organization": "north-hospital"},
+			wantErr:   tokenverifier.ErrUnscopedToken,
+		},
+		{
+			name:      "an unexpected claim shape: an empty array",
+			overrides: claims{"organization": []string{}},
+			wantErr:   tokenverifier.ErrUnscopedToken,
+		},
+		{
+			name:      "an unexpected claim shape and the tenant-wide marker still applies",
+			overrides: claims{"organization": "north-hospital", "realm_access": adminRole},
+		},
+		{
+			name:      "multiple organizations in the claim",
+			overrides: claims{"organization": []string{"north-hospital", "south-hospital"}},
+			wantErr:   tokenverifier.ErrAmbiguousOrganization,
+		},
+		{
+			// The invariant is "exactly one, or none" - ambiguity is not
+			// resolved by also being an administrator.
+			name:      "multiple organizations even with the tenant-wide marker",
+			overrides: claims{"organization": []string{"north-hospital", "south-hospital"}, "realm_access": adminRole},
+			wantErr:   tokenverifier.ErrAmbiguousOrganization,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			payload := fixture.valid(nil)
+			for name, value := range test.overrides {
+				if value == nil {
+					delete(payload, name)
+					continue
+				}
+				payload[name] = value
+			}
+
+			verified, err := fixture.verifier(t).Verify(context.Background(), fixture.sign(t, payload))
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("Verify error = %v, want %v", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if verified.HospitalID != test.wantHospitalID {
+				t.Errorf("HospitalID = %q, want %q", verified.HospitalID, test.wantHospitalID)
+			}
+		})
+	}
+}
+
 // §16.1 says normalise *only* the configured role claims. An installation
 // reading client roles must not silently pick up realm roles as well, or a role
 // granted for an unrelated application becomes an authorization input.
@@ -281,8 +371,7 @@ func (f *fixture) valid(overrides claims) claims {
 		"preferred_username": "doctor",
 		"exp":                f.now.Add(time.Hour).Unix(),
 		"iat":                f.now.Unix(),
-		"tenant_id":          "tenant-a",
-		"hospital_id":        "hospital-1",
+		"organization":       []string{"hospital-1"},
 		"resource_access": map[string]any{
 			"patient-app": map[string]any{"roles": []string{"doctor"}},
 		},

--- a/scripts/tests/decision-e2e.sh
+++ b/scripts/tests/decision-e2e.sh
@@ -43,7 +43,7 @@ wait_for_decisions() {
   local required=3 streak=0 code token
   token="$(token_of user-unassigned)"
   local probe='{"resources":[{"kind":"patient_record","id":"patient-000",
-    "attributes":{"tenantId":"tenant-a","hospitalId":"hospital-1","status":"ACTIVE"},
+    "attributes":{"tenantId":"tenant-a","hospitalId":"north-hospital","status":"ACTIVE"},
     "actions":["read"]}]}'
 
   for _ in $(seq 1 60); do
@@ -83,7 +83,7 @@ decide() {
       resources: [{
         kind: "patient_record",
         id: "patient-456",
-        attributes: {tenantId: $resourceTenant, hospitalId: "hospital-1", status: $status},
+        attributes: {tenantId: $resourceTenant, hospitalId: "north-hospital", status: $status},
         actions: $actions
       }]
     }' \
@@ -132,7 +132,7 @@ decide_on() {
       resources: [{
         kind: "patient_record",
         id: $id,
-        attributes: {tenantId: "tenant-a", hospitalId: "hospital-1", status: "ACTIVE"},
+        attributes: {tenantId: "tenant-a", hospitalId: "north-hospital", status: "ACTIVE"},
         actions: [$action]
       }]
     }' \
@@ -218,8 +218,8 @@ expect_decision "a locked record still allows read" \
 expect_decision "a record in another tenant is denied" \
   user-doctor ACTIVE tenant-b read false
 
-# The seed also writes a live grant for user-doctor-revoked in hospital-2. The
-# token's hospital is hospital-1, so that grant must never be read: this is
+# The seed also writes a live grant for user-doctor-revoked in south-hospital. The
+# token's hospital is north-hospital, so that grant must never be read: this is
 # the same principal, same action, only the hospital differs.
 expect_decision "an override in another hospital does not reach this decision" \
   user-doctor-revoked ACTIVE tenant-a delete false

--- a/scripts/tests/identity-e2e.sh
+++ b/scripts/tests/identity-e2e.sh
@@ -31,7 +31,7 @@ expect_status() {
   fi
 }
 
-READ_REQUEST='{"resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-a","hospitalId":"hospital-1","status":"ACTIVE"},"actions":["read"]}]}'
+READ_REQUEST='{"resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-a","hospitalId":"north-hospital","status":"ACTIVE"},"actions":["read"]}]}'
 
 # decide_with <token> [body]
 # Echoes the HTTP status of a decision call, leaving the body in /tmp/identity-body.
@@ -66,17 +66,42 @@ else
   fail "the token's subject is the identifier the authorization database keys on (was '${subject}')"
 fi
 
-tenant="$(claim_of "${doctor_token}" '.tenant_id')"
-if [[ "${tenant}" == "tenant-a" ]]; then
-  pass "the token carries the tenant the ADS will derive its context from"
+issuer="$(claim_of "${doctor_token}" '.iss')"
+if [[ "${issuer}" == *"/realms/tenant-a" ]]; then
+  pass "the token's issuer is the realm the ADS derives the tenant from (issue #77)"
 else
-  fail "the token carries the tenant (was '${tenant}')"
+  fail "the token's issuer names the realm (was '${issuer}')"
+fi
+
+organization="$(claim_of "${doctor_token}" '.organization | tojson')"
+if [[ "${organization}" == '["north-hospital"]' ]]; then
+  pass "the token carries the organization the ADS derives the hospital from (issue #78)"
+else
+  fail "the token carries the organization claim (was '${organization}')"
 fi
 
 echo
 echo "--- what the ADS accepts ---"
 
 expect_status "a valid token is accepted" 200 "$(decide_with "${doctor_token}")" "$(cat /tmp/identity-body)"
+
+# §78: the decision just taken used a hospital that came from the verified
+# organization claim, not a free-form attribute - proven by changing only the
+# resource's hospital and watching the decision flip, still through the real
+# ADS and PDP.
+own_hospital_request='{"resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-a","hospitalId":"north-hospital","status":"ACTIVE"},"actions":["read"]}]}'
+decide_with "${doctor_token}" "${own_hospital_request}" >/dev/null
+own_hospital_allowed="$(jq -r '.resources[0].actions.read.allowed' /tmp/identity-body)"
+
+other_hospital_request='{"resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-a","hospitalId":"south-hospital","status":"ACTIVE"},"actions":["read"]}]}'
+decide_with "${doctor_token}" "${other_hospital_request}" >/dev/null
+other_hospital_allowed="$(jq -r '.resources[0].actions.read.allowed' /tmp/identity-body)"
+
+if [[ "${own_hospital_allowed}" == "true" && "${other_hospital_allowed}" == "false" ]]; then
+  pass "a real decision takes its hospital from the organization claim, not a fixed value"
+else
+  fail "a real decision takes its hospital from the organization claim (north-hospital allowed=${own_hospital_allowed}, south-hospital allowed=${other_hospital_allowed})"
+fi
 
 echo
 echo "--- what the ADS refuses ---"
@@ -104,7 +129,7 @@ expect_status "a token carrying a sys: role is refused outright" 403 "$(decide_w
 echo
 echo "--- the browser cannot name itself ---"
 
-smuggled='{"tenantId":"tenant-b","resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-b","hospitalId":"hospital-1","status":"ACTIVE"},"actions":["read"]}]}'
+smuggled='{"tenantId":"tenant-b","resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-b","hospitalId":"north-hospital","status":"ACTIVE"},"actions":["read"]}]}'
 expect_status "a request naming its own tenant is refused" 400 \
   "$(decide_with "${doctor_token}" "${smuggled}")"
 
@@ -132,7 +157,7 @@ expect_status "tenant-b's token is accepted by the same deployment tenant-a's is
 # database, never from request input) is tenant-b's: the isolation rule
 # denies it, so the identity check passing is not what stands between a
 # caller and another tenant's data - the policy is.
-cross_tenant_request='{"resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-b","hospitalId":"hospital-1","status":"ACTIVE"},"actions":["read"]}]}'
+cross_tenant_request='{"resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-b","hospitalId":"north-hospital","status":"ACTIVE"},"actions":["read"]}]}'
 decide_with "${doctor_token}" "${cross_tenant_request}" >/dev/null
 cross_tenant_allowed="$(jq -r '.resources[0].actions.read.allowed' /tmp/identity-body)"
 if [[ "${cross_tenant_allowed}" == "false" ]]; then
@@ -143,7 +168,7 @@ fi
 
 # The reverse direction proves the boundary runs both ways, not just
 # because tenant-a happens to be what every other case in this suite uses.
-reverse_cross_tenant_request='{"resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-a","hospitalId":"hospital-1","status":"ACTIVE"},"actions":["read"]}]}'
+reverse_cross_tenant_request='{"resources":[{"kind":"patient_record","id":"patient-456","attributes":{"tenantId":"tenant-a","hospitalId":"north-hospital","status":"ACTIVE"},"actions":["read"]}]}'
 decide_with "${doctor_b_token}" "${reverse_cross_tenant_request}" >/dev/null
 reverse_allowed="$(jq -r '.resources[0].actions.read.allowed' /tmp/identity-body)"
 if [[ "${reverse_allowed}" == "false" ]]; then

--- a/scripts/tests/lib-token.sh
+++ b/scripts/tests/lib-token.sh
@@ -16,32 +16,37 @@ DEMO_PASSWORD="${KEYCLOAK_DEMO_PASSWORD:-demo-password}"
 # Echoes the demo organization alias a realm's members belong to (issue
 # #78): the hospital now comes only from a real, Keycloak-confirmed
 # organization claim, never a free-form attribute, so every token this
-# suite mints requests one.
+# suite mints for a realm that has one requests it. Empty means the realm
+# is a hostile fixture (other-issuer) with nothing to gain from one: its
+# tests only care that the issuer check refuses it.
 organization_for_realm() {
   case "$1" in
+    tenant-a) echo "north-hospital" ;;
     tenant-b) echo "hospital-b1" ;;
-    *) echo "north-hospital" ;;
+    *) echo "" ;;
   esac
 }
 
 # token_for <username> [client-id] [realm]
 # Echoes an access token, or exits non-zero with the provider's message.
 #
-# Every grant requests the realm's demo organization scope (issue #78). A
-# principal who is not a member - user-admin, the hostile fixture users -
-# simply has it silently dropped by Keycloak (§75's spike finding), which is
-# exactly the "no active organization" case the tenant-wide marker or the
-# unscoped-token refusal then decides between.
+# Every grant against a realm with a demo organization requests its scope
+# (issue #78). A principal who is not a member - user-admin, the hostile
+# fixture users - simply has it silently dropped by Keycloak (§75's spike
+# finding), which is exactly the "no active organization" case the
+# tenant-wide marker or the unscoped-token refusal then decides between.
 token_for() {
   local username="$1" client="${2:-patient-app}" realm="${3:-${REALM}}"
   local org; org="$(organization_for_realm "${realm}")"
+  local scope="openid"
+  [[ -n "${org}" ]] && scope="openid organization:${org}"
   local response
   response="$(curl -sS --max-time 10 \
     -d "grant_type=password" \
     -d "client_id=${client}" \
     -d "username=${username}" \
     -d "password=${DEMO_PASSWORD}" \
-    -d "scope=openid organization:${org}" \
+    -d "scope=${scope}" \
     "${KEYCLOAK_URL}/realms/${realm}/protocol/openid-connect/token")" || return 1
 
   local token

--- a/scripts/tests/lib-token.sh
+++ b/scripts/tests/lib-token.sh
@@ -12,16 +12,36 @@ KEYCLOAK_URL="${KEYCLOAK_URL:-http://127.0.0.1:${KEYCLOAK_PORT:-8081}}"
 REALM="${IDP_REALM:-tenant-a}"
 DEMO_PASSWORD="${KEYCLOAK_DEMO_PASSWORD:-demo-password}"
 
+# organization_for_realm <realm>
+# Echoes the demo organization alias a realm's members belong to (issue
+# #78): the hospital now comes only from a real, Keycloak-confirmed
+# organization claim, never a free-form attribute, so every token this
+# suite mints requests one.
+organization_for_realm() {
+  case "$1" in
+    tenant-b) echo "hospital-b1" ;;
+    *) echo "north-hospital" ;;
+  esac
+}
+
 # token_for <username> [client-id] [realm]
 # Echoes an access token, or exits non-zero with the provider's message.
+#
+# Every grant requests the realm's demo organization scope (issue #78). A
+# principal who is not a member - user-admin, the hostile fixture users -
+# simply has it silently dropped by Keycloak (§75's spike finding), which is
+# exactly the "no active organization" case the tenant-wide marker or the
+# unscoped-token refusal then decides between.
 token_for() {
   local username="$1" client="${2:-patient-app}" realm="${3:-${REALM}}"
+  local org; org="$(organization_for_realm "${realm}")"
   local response
   response="$(curl -sS --max-time 10 \
     -d "grant_type=password" \
     -d "client_id=${client}" \
     -d "username=${username}" \
     -d "password=${DEMO_PASSWORD}" \
+    -d "scope=openid organization:${org}" \
     "${KEYCLOAK_URL}/realms/${realm}/protocol/openid-connect/token")" || return 1
 
   local token

--- a/scripts/tests/org-scope-spike.sh
+++ b/scripts/tests/org-scope-spike.sh
@@ -42,7 +42,9 @@ echo "--- the realm fixture ---"
 
 # The realm fixture (deploy/keycloak/realm-tenant-a.json) declares
 # organizationsEnabled, two organizations - north-hospital and
-# south-hospital - and user-doctor as a member of north-hospital only, via
+# south-hospital - and user-doctor as a member of north-hospital (issue #78
+# adds the rest of the demo principals north-hospital needs to take a
+# decision, but user-doctor is the one this spike asserts on), via
 # Keycloak's own realm import. Declarative membership import works with a
 # "username" reference in the member object; an "id" reference silently fails
 # import with a null-pointer deep in Keycloak's organization importer (tried
@@ -62,10 +64,10 @@ admin_org_members() {
 }
 
 north_members="$(admin_org_members north-hospital)"
-if [[ "${north_members}" == "user-doctor" ]]; then
-  pass "north-hospital has exactly the one member the fixture declares"
+if grep -qx "user-doctor" <<<"${north_members}"; then
+  pass "north-hospital has the member the fixture declares"
 else
-  fail "north-hospital has exactly the one member the fixture declares (was '${north_members}')"
+  fail "north-hospital has the member the fixture declares (was '${north_members}')"
 fi
 
 south_members="$(admin_org_members south-hospital)"

--- a/tests/architecture/hospitalinput.go
+++ b/tests/architecture/hospitalinput.go
@@ -1,0 +1,96 @@
+package architecture
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var hospitalLiteral = regexp.MustCompile(`(?i)hospital`)
+
+// hospitalReadingCalls names the HTTP-input accessors a hospital identifier
+// must never be read through (issue #78): §16.1 already requires tenant and
+// hospital context to be derived server-side, from the verified token, and
+// none of these methods ever touch a token.
+var hospitalReadingCalls = map[string]bool{
+	"Get":       true, // (*http.Header).Get, url.Values.Get
+	"FormValue": true, // (*http.Request).FormValue
+}
+
+// hospitalSearchFilterFiles are administration search endpoints that take a
+// hospital as a *search filter*, the same way they take a tenant, an actor
+// or a resource key: a caller narrows a query, authority.Validate checks
+// the narrowing is within the caller's own tenant/hospital scope, and the
+// store answers only within it (§8.2). This is not the identity-derivation
+// path §16.1 and issue #78 are about - the caller's own hospital still
+// comes only from the verified token, checked before the filter is ever
+// used - so these are named exceptions rather than a hole in the rule.
+var hospitalSearchFilterFiles = map[string]bool{
+	"apps/admin-service/internal/auditsearch/handler.go": true,
+}
+
+// ScanForRequestDerivedHospital reports every call to a header, query
+// string or form accessor whose argument names a hospital, which is what a
+// hospital read from request input looks like in source. It does not scan
+// for a hospital field on a request body: this codebase's decision
+// endpoint already refuses any unrecognised body field outright
+// (json.Decoder.DisallowUnknownFields), so a body-smuggled hospital is
+// caught before it is ever this far.
+func ScanForRequestDerivedHospital(filename, src string) ([]Finding, error) {
+	if hospitalSearchFilterFiles[filename] {
+		return nil, nil
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, src, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", filename, err)
+	}
+
+	var findings []Finding
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !hospitalReadingCalls[selector.Sel.Name] {
+			return true
+		}
+		if len(call.Args) == 0 {
+			return true
+		}
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		value := literalValueHospital(lit.Value)
+		if !hospitalLiteral.MatchString(value) {
+			return true
+		}
+		findings = append(findings, Finding{
+			File:   filename,
+			Line:   fset.Position(call.Pos()).Line,
+			Symbol: selector.Sel.Name,
+			Message: fmt.Sprintf(
+				"%s(%q) reads a hospital from request input; the hospital comes only from the verified token (§16.1, issue #78)",
+				selector.Sel.Name, value),
+		})
+		return true
+	})
+	return findings, nil
+}
+
+func literalValueHospital(raw string) string {
+	if strings.HasPrefix(raw, "`") {
+		return strings.Trim(raw, "`")
+	}
+	unquoted, err := strconv.Unquote(raw)
+	if err != nil {
+		return raw
+	}
+	return unquoted
+}

--- a/tests/architecture/hospitalinput_test.go
+++ b/tests/architecture/hospitalinput_test.go
@@ -1,0 +1,129 @@
+package architecture_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/tests/architecture"
+)
+
+// No code reads a hospital from a request header or query parameter (issue
+// #78): the hospital comes only from the verified token's organization
+// claim.
+func TestNoConsumerReadsAHospitalFromRequestInput(t *testing.T) {
+	root := repoRoot(t)
+
+	var findings []architecture.Finding
+	for _, path := range goFiles(t, root) {
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatalf("relativising %s: %v", path, err)
+		}
+		if strings.HasPrefix(filepath.ToSlash(relative), "tests/architecture/") {
+			continue
+		}
+
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+
+		found, err := architecture.ScanForRequestDerivedHospital(relative, string(source))
+		if err != nil {
+			t.Fatalf("scanning %s: %v", relative, err)
+		}
+		findings = append(findings, found...)
+	}
+
+	if len(findings) > 0 {
+		var report strings.Builder
+		report.WriteString("a hospital was read from request input:\n")
+		for _, finding := range findings {
+			report.WriteString("  " + finding.String() + "\n")
+		}
+		t.Fatal(report.String())
+	}
+}
+
+// An architecture test that cannot fail is decoration.
+func TestTheCheckerCatchesAHospitalReadFromAHeader(t *testing.T) {
+	const violation = `package pep
+
+func handle(r *http.Request) {
+	hospitalID := r.Header.Get("X-Hospital-Id")
+	_ = hospitalID
+}
+`
+
+	findings, err := architecture.ScanForRequestDerivedHospital("apps/resource-service/internal/pep/pep.go", violation)
+	if err != nil {
+		t.Fatalf("ScanForRequestDerivedHospital: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Symbol != "Get" {
+		t.Errorf("findings = %v, want one for the header read", findings)
+	}
+}
+
+// An architecture test that cannot fail is decoration.
+func TestTheCheckerCatchesAHospitalReadFromAQueryParameter(t *testing.T) {
+	const violation = `package pep
+
+func handle(r *http.Request) {
+	hospitalID := r.URL.Query().Get("hospitalId")
+	_ = hospitalID
+}
+`
+
+	findings, err := architecture.ScanForRequestDerivedHospital("apps/resource-service/internal/pep/pep.go", violation)
+	if err != nil {
+		t.Fatalf("ScanForRequestDerivedHospital: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Symbol != "Get" {
+		t.Errorf("findings = %v, want one for the query read", findings)
+	}
+}
+
+// The audit search endpoint's hospital is a search filter, authority-checked
+// against the caller's own scope, not an identity-derivation shortcut - it
+// is a named exception, not a gap the checker missed.
+func TestTheCheckerExemptsTheAuditSearchFilter(t *testing.T) {
+	const source = `package auditsearch
+
+func handle(r *http.Request) {
+	hospital := r.URL.Query().Get("hospital")
+	_ = hospital
+}
+`
+
+	findings, err := architecture.ScanForRequestDerivedHospital(
+		"apps/admin-service/internal/auditsearch/handler.go", source)
+	if err != nil {
+		t.Fatalf("ScanForRequestDerivedHospital: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("the audit search filter's exemption did not apply: %v", findings)
+	}
+}
+
+// An ordinary header or query read that has nothing to do with a hospital
+// must not be flagged.
+func TestTheCheckerAllowsOrdinaryHeaderAndQueryReads(t *testing.T) {
+	const source = `package pep
+
+func handle(r *http.Request) {
+	correlationID := r.Header.Get("X-Correlation-Id")
+	query := r.URL.Query().Get("query")
+	_, _ = correlationID, query
+}
+`
+
+	findings, err := architecture.ScanForRequestDerivedHospital("apps/resource-service/internal/pep/pep.go", source)
+	if err != nil {
+		t.Fatalf("ScanForRequestDerivedHospital: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("ordinary header/query reads were flagged: %v", findings)
+	}
+}


### PR DESCRIPTION
## What changed

Hospital derived from the verified organization claim (issue #78): the free-form `hospital_id` attribute is retired entirely, replaced by Keycloak's own organization claim (`§75`'s spike-confirmed shape: a JSON array of exactly one alias string).

- **`libs/tokenverifier`**: `hospitalOf` derives the hospital from the `organization` claim. Any other shape - absent, a map, a bare scalar, an empty array, more than one alias - is refused (`ErrUnscopedToken`) unless the token also carries the new `TenantWideRealmRole` ("admin") realm role, in which case the hospital is empty (tenant-wide). More than one organization at once is always refused (`ErrAmbiguousOrganization`), admin marker or not - a session has exactly one active hospital, or none. `HospitalClaim`/`DefaultHospitalClaim` are gone.
- **Distinct logging**: all three services' `tokenauth` middleware (deliberately not shared - see each file's own comment) log an unscoped/ambiguous-organization refusal separately from the generic rejection, mirroring the existing `ErrReservedRole` special case.
- **Architecture test**: `tests/architecture/hospitalinput.go` fails the build if any `Header.Get`/`Query().Get`/`FormValue` call names a hospital. The audit search endpoint's own `hospital` query parameter is a named exception - an authority-checked search filter over the caller's own scope, not an identity-derivation shortcut.
- **Demo realms**: `realm-tenant-a.json` makes every demo principal that needs a decision a member of `north-hospital`, drops the retired attribute/protocol-mapper pair, and gives `user-admin` the new `admin` realm role. `realm-tenant-b.json` and `realm-other-issuer.json` get their own organization (or the feature enabled) so every realm can grant an organization scope. `deploy/k8s/base/keycloak/deployment.yaml` gets `--features=organization` (a pre-existing gap from #75 - tenant-a's organizations were never actually importable on the k8s manifests).
- **Seeded data**: `demoseed.HospitalID`/`OtherHospitalID` are now the real organization aliases (`north-hospital`/`south-hospital`).
- **End-to-end proof**: `scripts/tests/lib-token.sh`'s `token_for` requests the realm's organization scope on every grant now (a non-member simply has it silently dropped, per §75's finding). `identity-e2e.sh` asserts the organization claim's exact shape and takes two real decisions differing only in the resource's hospital, proving the decision came from the claim rather than a fixed value.

## How each acceptance criterion is met

- [x] The hospital identifier is the organization alias, parsed per the shape #75 recorded - `hospitalOf`/`organizationAliases`, table-driven tests.
- [x] The hospital claim name configuration and the tenant-mapping mode are removed from code, compose and Kubernetes manifests - `HospitalClaim` deleted; `TenantMappingMode` was already removed in #77 (this issue's text anticipated it, since #78 depends on #77).
- [x] A token with no active organization and no tenant-wide marker is refused with a distinct, logged reason - `ErrUnscopedToken` + the `tokenauth` WARN log, unit-tested.
- [x] Table-driven verification tests cover present/absent/unexpected-shape/multiple organizations - `TestHospitalIsDerivedFromTheVerifiedOrganizationClaim`.
- [x] Demo realm fixtures contain organizations, seeded assignment data uses organization aliases - realm fixture + `demoseed.go` changes above.
- [x] An end-to-end test takes a real decision whose hospital came from the organization claim - `identity-e2e.sh`'s new assertions.
- [x] No code reads a hospital from a request body, header or query parameter, enforced by an architecture test - `tests/architecture/hospitalinput.go`; the request-body half is covered by the pre-existing `TestIdentityFieldsInTheRequestBodyAreRefused` unit test (the decision endpoint's `json.Decoder.DisallowUnknownFields` already refuses any unrecognised body field).

## Verified with

- `bash scripts/go.sh <module> test ./...` for every touched Go module (all green).
- `python3 scripts/tests/compose-contract.py` (satisfied).
- `docker compose config -q` (valid).
- `python3 -c "import json/yaml; ..."` against every touched realm fixture and k8s manifest.
- `go vet` / `gofmt -l` (clean).
- CI (docker compose walking skeleton - which runs `make smoke`, including the updated `identity-e2e.sh` and `decision-e2e.sh` against a real stack - architecture invariants, authorization schema on postgres, cerbos policy suite, dual dialect portability, nx affected).

Closes #78


Closes #78
