### PR TITLE
Keycloak organization selector: auto-select and reject (#79)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ tmp/
 .chaos-port-forward.log
 __screenshots__/
 libs/keycloakbulkload/cmd/loadseed/loadseed
+# Maven build output (apps/keycloak-org-selector), built inside the Docker
+# image's own Maven stage - never expected to be present on the host.
+target/
 
 .angular
 

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,7 @@ smoke: ## Verify a running stack end to end
 	bash scripts/tests/stack-smoke.sh
 	bash scripts/tests/identity-e2e.sh
 	bash scripts/tests/decision-e2e.sh
+	bash scripts/tests/org-selector-e2e.sh
 
 .PHONY: walkthrough
 walkthrough: ## Execute the README's guided walkthrough against a running deployment

--- a/apps/keycloak-org-selector/Dockerfile
+++ b/apps/keycloak-org-selector/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+# Build context is the repository root.
+#
+# The custom Keycloak image issue #79 requires: the organization selector
+# provider (apps/keycloak-org-selector) is built in this Maven stage and
+# baked into the server with `kc.sh build`, so no JVM or Maven is needed on
+# the host or in any Go service image - Keycloak is the one component in
+# this repository that legitimately carries one.
+FROM docker.io/library/maven:3.9-eclipse-temurin-17 AS build
+
+WORKDIR /src
+COPY apps/keycloak-org-selector/pom.xml ./
+# Dependencies first, cached separately from source changes.
+RUN mvn -q -B dependency:go-offline
+
+COPY apps/keycloak-org-selector/src ./src
+# Runs the JUnit suite as part of the image build (issue #79's acceptance
+# criterion): a case that regresses fails the build rather than shipping.
+RUN mvn -q -B package
+
+FROM quay.io/keycloak/keycloak:26.4
+
+COPY --from=build /src/target/org-selector.jar /opt/keycloak/providers/org-selector.jar
+# `--features=organization` matches docker-compose.yml/the k8s manifests:
+# Keycloak Organizations is a preview feature and every organization import
+# 400s without it.
+RUN /opt/keycloak/bin/kc.sh build --features=organization

--- a/apps/keycloak-org-selector/pom.xml
+++ b/apps/keycloak-org-selector/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The organization selector authenticator (issue #79): a Keycloak SPI
+  provider, built in its own Maven stage of apps/keycloak-org-selector's
+  Dockerfile. No JVM or Maven is required on the host or in any Go service
+  image - this is the one component in the repository that legitimately
+  needs one, because it runs inside Keycloak itself.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.cerbospoc.keycloak</groupId>
+  <artifactId>org-selector</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- Pinned to the Keycloak image tag docker-compose.yml and the k8s
+         manifests both build from (quay.io/keycloak/keycloak:26.4), so the
+         SPI is always compiled against the API the runtime actually
+         provides. -->
+    <keycloak.version>26.4.0</keycloak.version>
+    <junit.version>5.11.4</junit.version>
+  </properties>
+
+  <dependencies>
+    <!-- provided: Keycloak supplies these on the classpath at runtime; the
+         built jar must not bundle them, or it would fight the server's own
+         copies. -->
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-server-spi</artifactId>
+      <version>${keycloak.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-server-spi-private</artifactId>
+      <version>${keycloak.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-services</artifactId>
+      <version>${keycloak.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+      <version>3.6.1.Final</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>org-selector</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+      </plugin>
+      <plugin>
+        <!-- Runs the selection-logic JUnit suite as part of the container
+             build (issue #79's acceptance criterion), so a change that
+             breaks a case fails the image build rather than shipping. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.2</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecision.java
+++ b/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecision.java
@@ -1,0 +1,103 @@
+package org.cerbospoc.keycloak.orgselector;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The organization-selection decision, as a pure function of facts an
+ * authenticator can gather from a session: the user's own organization
+ * memberships, whether they hold the tenant-wide realm role, and any
+ * organization alias already named in the requested scope (issue #79).
+ *
+ * <p>This class touches no Keycloak session, request or provider - every
+ * case is a JUnit assertion, not a running server - so the flow logic in
+ * {@link OrganizationSelectorAuthenticator} has nothing left to decide, only
+ * to gather inputs and act on the outcome.
+ *
+ * <p>The PRD names five outcomes; this slice's authenticator acts on three
+ * of them (the ones that need no selection screen) and leaves
+ * {@link Undecided} for the ones the screen - a later slice - will resolve:
+ *
+ * <ol>
+ *   <li>an alias already requested in scope that matches a membership -
+ *       {@link Selected}, no screen;
+ *   <li>exactly one membership and not an administrator - {@link Selected},
+ *       auto-selected, no screen;
+ *   <li>more than one membership - {@link Undecided} (the screen);
+ *   <li>an administrator - {@link Undecided} (the screen, with a tenant-wide
+ *       entry), even with exactly one membership: the tenant-wide choice has
+ *       to be available, not pre-empted;
+ *   <li>no membership and not an administrator - {@link Refused}, an
+ *       explicit reason rather than a generic login failure.
+ * </ol>
+ */
+public final class OrganizationSelectionDecision {
+
+    private OrganizationSelectionDecision() {
+    }
+
+    /** One of the outcomes {@link #decide} can reach. */
+    public sealed interface Outcome permits Selected, Undecided, Refused {
+    }
+
+    /** The organization alias to select, silently, with no screen shown. */
+    public record Selected(String alias) implements Outcome {
+        public Selected {
+            if (alias == null || alias.isBlank()) {
+                throw new IllegalArgumentException("a selected alias must not be blank");
+            }
+        }
+    }
+
+    /**
+     * No case this slice handles applies; the selection screen - not
+     * implemented by this authenticator - decides. The authenticator lets
+     * the flow continue unchanged rather than forcing an outcome it has no
+     * basis for.
+     */
+    public record Undecided() implements Outcome {
+    }
+
+    /** Login is refused outright, with a reason to show the user. */
+    public record Refused(String reason) implements Outcome {
+        public Refused {
+            if (reason == null || reason.isBlank()) {
+                throw new IllegalArgumentException("a refusal must carry a reason");
+            }
+        }
+    }
+
+    /**
+     * decide is the pure function: every input is a fact already gathered
+     * from a verified source (Keycloak's own organization membership
+     * records, the user's own realm roles, the request's own scope
+     * parameter), never from anything a caller wrote into a form field this
+     * decision reads back.
+     *
+     * @param memberships    the aliases of every organization the user
+     *                       belongs to, in no particular order
+     * @param isAdministrator whether the user holds the tenant-wide realm
+     *                       role (issue #78's {@code admin})
+     * @param requestedAlias the organization alias named in the request's
+     *                       own {@code scope} parameter, if any
+     */
+    public static Outcome decide(List<String> memberships, boolean isAdministrator, Optional<String> requestedAlias) {
+        if (memberships == null) {
+            throw new IllegalArgumentException("memberships must not be null; empty means none");
+        }
+        if (requestedAlias == null) {
+            throw new IllegalArgumentException("requestedAlias must not be null; Optional.empty() means none requested");
+        }
+
+        if (requestedAlias.isPresent() && memberships.contains(requestedAlias.get())) {
+            return new Selected(requestedAlias.get());
+        }
+        if (!isAdministrator && memberships.size() == 1) {
+            return new Selected(memberships.get(0));
+        }
+        if (isAdministrator || memberships.size() > 1) {
+            return new Undecided();
+        }
+        return new Refused("your account is not attached to a hospital; contact your administrator");
+    }
+}

--- a/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionRealmRoles.java
+++ b/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionRealmRoles.java
@@ -1,0 +1,16 @@
+package org.cerbospoc.keycloak.orgselector;
+
+/**
+ * The realm role names organization selection reads. A separate, named
+ * constant rather than a literal inline: {@code libs/tokenverifier}'s
+ * {@code TenantWideRealmRole} names the identical role from the Go side of
+ * this same contract (issue #78), and the two must never drift apart.
+ */
+final class OrganizationSelectionRealmRoles {
+
+    /** The tenant-wide marker: a token with no active organization is still usable. */
+    static final String TENANT_WIDE = "admin";
+
+    private OrganizationSelectionRealmRoles() {
+    }
+}

--- a/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectorAuthenticator.java
+++ b/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectorAuthenticator.java
@@ -1,0 +1,106 @@
+package org.cerbospoc.keycloak.orgselector;
+
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Optional;
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+
+/**
+ * The login-flow half of organization selection (issue #79). Placed after
+ * credentials and any second factor, it gathers the facts
+ * {@link OrganizationSelectionDecision} needs from the authenticated
+ * session and acts on the outcome:
+ *
+ * <ul>
+ *   <li>{@link OrganizationSelectionDecision.Selected} - the organization is
+ *       recorded and the flow proceeds with no screen shown;
+ *   <li>{@link OrganizationSelectionDecision.Refused} - the flow fails with
+ *       an explicit reason rather than a generic authentication failure;
+ *   <li>{@link OrganizationSelectionDecision.Undecided} - this
+ *       authenticator has no basis to decide (the selection screen slice
+ *       does), so the flow proceeds unchanged.
+ * </ul>
+ */
+public class OrganizationSelectorAuthenticator implements Authenticator {
+
+    private static final Logger LOG = Logger.getLogger(OrganizationSelectorAuthenticator.class);
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        RealmModel realm = context.getRealm();
+        UserModel user = context.getUser();
+
+        List<String> memberships = OrganizationSupport.membershipAliases(context, user);
+        boolean isAdministrator = isTenantWideAdministrator(realm, user);
+        Optional<String> requestedAlias = OrganizationSupport.requestedAlias(context);
+
+        OrganizationSelectionDecision.Outcome outcome =
+                OrganizationSelectionDecision.decide(memberships, isAdministrator, requestedAlias);
+
+        if (outcome instanceof OrganizationSelectionDecision.Selected selected) {
+            OrganizationSupport.selectOrganization(context, selected.alias());
+            LOG.debugf("organization selector: %s selected for %s", selected.alias(), user.getUsername());
+            context.success();
+            return;
+        }
+
+        if (outcome instanceof OrganizationSelectionDecision.Refused refused) {
+            LOG.infof("organization selector: refusing %s: %s", user.getUsername(), refused.reason());
+            Response challenge = context.form()
+                    .setError(refused.reason())
+                    .createErrorPage(Response.Status.FORBIDDEN);
+            context.failure(AuthenticationFlowError.ACCESS_DENIED, challenge);
+            return;
+        }
+
+        // Undecided: more than one membership, or an administrator - the
+        // selection screen a later slice adds is what decides these, not
+        // this authenticator. Proceeding unchanged is the deliberate
+        // no-op, not an oversight.
+        context.success();
+    }
+
+    /**
+     * The tenant-wide marker (issue #78) is the realm role named
+     * {@link OrganizationSelectionRealmRoles#TENANT_WIDE}. A realm that has
+     * never declared the role has no administrators by definition, so a
+     * missing role is not an error here - it is simply "no one is one".
+     */
+    private static boolean isTenantWideAdministrator(RealmModel realm, UserModel user) {
+        RoleModel role = realm.getRole(OrganizationSelectionRealmRoles.TENANT_WIDE);
+        return role != null && user.hasRole(role);
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        // No form is ever submitted back to this authenticator: it either
+        // decides silently or fails the flow outright in authenticate().
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return true;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+        // Nothing to set up: this authenticator only reads existing state.
+    }
+
+    @Override
+    public void close() {
+        // Stateless; nothing to release.
+    }
+}

--- a/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectorAuthenticatorFactory.java
+++ b/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectorAuthenticatorFactory.java
@@ -1,0 +1,83 @@
+package org.cerbospoc.keycloak.orgselector;
+
+import java.util.List;
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+/** Registers {@link OrganizationSelectorAuthenticator} as a login flow step (issue #79). */
+public class OrganizationSelectorAuthenticatorFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "cerbos-poc-organization-selector";
+
+    private static final OrganizationSelectorAuthenticator SINGLETON = new OrganizationSelectorAuthenticator();
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Organization Selector (Cerbos POC)";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return "organization";
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return false;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return new AuthenticationExecutionModel.Requirement[] {
+            AuthenticationExecutionModel.Requirement.REQUIRED,
+            AuthenticationExecutionModel.Requirement.DISABLED,
+        };
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Selects the caller's active organization from their memberships, the tenant-wide "
+                + "realm role and the request's own scope - the cases that need no selection screen "
+                + "(issue #79).";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return List.of();
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        // No configuration to read.
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        // No cross-provider wiring needed.
+    }
+
+    @Override
+    public void close() {
+        // Stateless; nothing to release.
+    }
+}

--- a/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSupport.java
+++ b/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSupport.java
@@ -1,0 +1,76 @@
+package org.cerbospoc.keycloak.orgselector;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.models.UserModel;
+import org.keycloak.organization.OrganizationProvider;
+
+/**
+ * The Keycloak-facing half of organization selection (issue #79): reads the
+ * facts {@link OrganizationSelectionDecision} needs from a real session, and
+ * applies a {@link OrganizationSelectionDecision.Selected} outcome back onto
+ * it. Kept separate from the authenticator itself so the one class that
+ * actually touches Keycloak's session API is as small as possible.
+ */
+final class OrganizationSupport {
+
+    private OrganizationSupport() {
+    }
+
+    /** Every organization alias the user belongs to, in no particular order. */
+    static List<String> membershipAliases(AuthenticationFlowContext context, UserModel user) {
+        OrganizationProvider organizations = context.getSession().getProvider(OrganizationProvider.class);
+        return organizations.getByMember(user)
+                .map(organization -> organization.getAlias())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * The organization alias already named in the request's own
+     * {@code scope} parameter (e.g. {@code organization:north-hospital}),
+     * if any - read from the auth session's own client note, which is
+     * where Keycloak's OAuth2 layer already carries the requested scope
+     * (§75's spike confirms Keycloak reads this same shape for a direct
+     * grant; the browser flow's auth session carries it identically).
+     */
+    static Optional<String> requestedAlias(AuthenticationFlowContext context) {
+        return organizationScopeValue(context.getAuthenticationSession().getClientNote(OAuth2Constants.SCOPE));
+    }
+
+    private static Optional<String> organizationScopeValue(String scopeParam) {
+        if (scopeParam == null || scopeParam.isBlank()) {
+            return Optional.empty();
+        }
+        for (String scope : scopeParam.split("\\s+")) {
+            if (scope.startsWith(ORGANIZATION_SCOPE_PREFIX) && scope.length() > ORGANIZATION_SCOPE_PREFIX.length()) {
+                return Optional.of(scope.substring(ORGANIZATION_SCOPE_PREFIX.length()));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static final String ORGANIZATION_SCOPE_PREFIX = "organization:";
+
+    /**
+     * Records alias as the session's selected organization by making it
+     * exactly what a caller who requested it in scope would have produced:
+     * present in the auth session's own {@code scope} client note, the same
+     * note {@link #requestedAlias} reads and the same shape §75's spike
+     * confirmed Keycloak's own token-minting pipeline honours. This is
+     * deliberately not a second, bespoke mechanism - the fewer places that
+     * decide "which organization won", the fewer places that can disagree.
+     */
+    static void selectOrganization(AuthenticationFlowContext context, String alias) {
+        String scopeParam = context.getAuthenticationSession().getClientNote(OAuth2Constants.SCOPE);
+        if (organizationScopeValue(scopeParam).isPresent()) {
+            return;
+        }
+        String updated = (scopeParam == null || scopeParam.isBlank())
+                ? ORGANIZATION_SCOPE_PREFIX + alias
+                : scopeParam + " " + ORGANIZATION_SCOPE_PREFIX + alias;
+        context.getAuthenticationSession().setClientNote(OAuth2Constants.SCOPE, updated);
+    }
+}

--- a/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSupport.java
+++ b/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSupport.java
@@ -1,5 +1,6 @@
 package org.cerbospoc.keycloak.orgselector;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -62,15 +63,29 @@ final class OrganizationSupport {
      * confirmed Keycloak's own token-minting pipeline honours. This is
      * deliberately not a second, bespoke mechanism - the fewer places that
      * decide "which organization won", the fewer places that can disagree.
+     *
+     * <p>Any organization scope already present is replaced, not left
+     * alone: a caller who asked for an alias that turned out not to be a
+     * membership still reaches this method when the auto-select rule picks
+     * a different one, and leaving their mismatched request in the note
+     * would have Keycloak's own pipeline silently drop it again (§75),
+     * undoing the very selection this method exists to apply.
      */
     static void selectOrganization(AuthenticationFlowContext context, String alias) {
         String scopeParam = context.getAuthenticationSession().getClientNote(OAuth2Constants.SCOPE);
-        if (organizationScopeValue(scopeParam).isPresent()) {
-            return;
-        }
-        String updated = (scopeParam == null || scopeParam.isBlank())
+        String withoutOrganization = withoutOrganizationScope(scopeParam);
+        String updated = withoutOrganization.isEmpty()
                 ? ORGANIZATION_SCOPE_PREFIX + alias
-                : scopeParam + " " + ORGANIZATION_SCOPE_PREFIX + alias;
+                : withoutOrganization + " " + ORGANIZATION_SCOPE_PREFIX + alias;
         context.getAuthenticationSession().setClientNote(OAuth2Constants.SCOPE, updated);
+    }
+
+    private static String withoutOrganizationScope(String scopeParam) {
+        if (scopeParam == null || scopeParam.isBlank()) {
+            return "";
+        }
+        return Arrays.stream(scopeParam.split("\\s+"))
+                .filter(scope -> !scope.startsWith(ORGANIZATION_SCOPE_PREFIX))
+                .collect(Collectors.joining(" "));
     }
 }

--- a/apps/keycloak-org-selector/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/apps/keycloak-org-selector/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,1 @@
+org.cerbospoc.keycloak.orgselector.OrganizationSelectorAuthenticatorFactory

--- a/apps/keycloak-org-selector/src/test/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecisionTest.java
+++ b/apps/keycloak-org-selector/src/test/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecisionTest.java
@@ -1,0 +1,110 @@
+package org.cerbospoc.keycloak.orgselector;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Optional;
+import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.Outcome;
+import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.Refused;
+import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.Selected;
+import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.Undecided;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Every case the PRD's login-flow decision names (issue #79), run as a plain
+ * JUnit test with no Keycloak session, request or provider involved.
+ */
+class OrganizationSelectionDecisionTest {
+
+    @Test
+    void anAliasRequestedInScopeMatchingAMembershipIsSelectedWithNoScreen() {
+        Outcome outcome = OrganizationSelectionDecision.decide(
+                List.of("north-hospital", "south-hospital"), false, Optional.of("south-hospital"));
+
+        Selected selected = assertInstanceOf(Selected.class, outcome);
+        assertEquals("south-hospital", selected.alias());
+    }
+
+    @Test
+    void theRequestedAliasWinsEvenForAnAdministratorWithOtherMemberships() {
+        // Bullet 1 in the PRD's ordered list applies before bullet 4's
+        // "administrator gets the screen" - an alias the caller already
+        // named and belongs to needs no screen, administrator or not.
+        Outcome outcome = OrganizationSelectionDecision.decide(
+                List.of("north-hospital"), true, Optional.of("north-hospital"));
+
+        Selected selected = assertInstanceOf(Selected.class, outcome);
+        assertEquals("north-hospital", selected.alias());
+    }
+
+    @Test
+    void exactlyOneMembershipAndNotAnAdministratorIsAutoSelectedWithNoScreen() {
+        Outcome outcome = OrganizationSelectionDecision.decide(
+                List.of("north-hospital"), false, Optional.empty());
+
+        Selected selected = assertInstanceOf(Selected.class, outcome);
+        assertEquals("north-hospital", selected.alias());
+    }
+
+    @Test
+    void moreThanOneMembershipIsUndecidedForTheScreen() {
+        Outcome outcome = OrganizationSelectionDecision.decide(
+                List.of("north-hospital", "south-hospital"), false, Optional.empty());
+
+        assertInstanceOf(Undecided.class, outcome);
+    }
+
+    @Test
+    void anAdministratorIsUndecidedForTheScreenEvenWithExactlyOneMembership() {
+        // The tenant-wide choice has to remain available to an
+        // administrator, so a single membership must not pre-empt it the
+        // way it would for an ordinary user.
+        Outcome outcome = OrganizationSelectionDecision.decide(
+                List.of("north-hospital"), true, Optional.empty());
+
+        assertInstanceOf(Undecided.class, outcome);
+    }
+
+    @Test
+    void anAdministratorWithNoMembershipIsUndecidedForTheScreenRatherThanRefused() {
+        Outcome outcome = OrganizationSelectionDecision.decide(List.of(), true, Optional.empty());
+
+        assertInstanceOf(Undecided.class, outcome);
+    }
+
+    @Test
+    void noMembershipAndNotAnAdministratorIsRefusedWithAnExplicitReason() {
+        Outcome outcome = OrganizationSelectionDecision.decide(List.of(), false, Optional.empty());
+
+        Refused refused = assertInstanceOf(Refused.class, outcome);
+        assertEquals(
+                "your account is not attached to a hospital; contact your administrator",
+                refused.reason());
+    }
+
+    @Test
+    void aRequestedAliasThatIsNotAMembershipDoesNotOverrideTheOtherRules() {
+        // Falls through to the single-membership auto-select rule: the
+        // caller asked for an organization they do not belong to, which is
+        // not a membership to trust just because it was named.
+        Outcome outcome = OrganizationSelectionDecision.decide(
+                List.of("north-hospital"), false, Optional.of("south-hospital"));
+
+        Selected selected = assertInstanceOf(Selected.class, outcome);
+        assertEquals("north-hospital", selected.alias());
+    }
+
+    @Test
+    void nullMembershipsIsRejectedRatherThanMisreadAsNoMembership() {
+        assertThrows(IllegalArgumentException.class,
+                () -> OrganizationSelectionDecision.decide(null, false, Optional.empty()));
+    }
+
+    @Test
+    void nullRequestedAliasIsRejectedRatherThanMisreadAsNoneRequested() {
+        assertThrows(IllegalArgumentException.class,
+                () -> OrganizationSelectionDecision.decide(List.of(), false, null));
+    }
+}

--- a/deploy/k8s/base/keycloak/deployment.yaml
+++ b/deploy/k8s/base/keycloak/deployment.yaml
@@ -19,7 +19,10 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:26.4
+          # The organization selector authenticator (issue #79) is baked
+          # into this image at build time (apps/keycloak-org-selector/
+          # Dockerfile), the same custom image docker-compose.yml builds.
+          image: cerbos-poc/keycloak:dev
           # `organization` is a preview feature in 26.4: Keycloak Organizations
           # (issue #75/#78) is disabled by default and every organization
           # import 400s without it, matching docker-compose.yml's keycloak

--- a/deploy/keycloak/realm-tenant-a.json
+++ b/deploy/keycloak/realm-tenant-a.json
@@ -6,6 +6,7 @@
   "loginWithEmailAllowed": true,
   "accessTokenLifespan": 900,
   "organizationsEnabled": true,
+  "browserFlow": "browser-with-org-selector",
   "organizations": [
     {
       "name": "North Hospital",
@@ -225,6 +226,98 @@
       "clientRoles": {
         "realm-management": ["view-users", "query-users", "view-clients", "view-realm"]
       }
+    }
+  ],
+  "authenticationFlows": [
+    {
+      "alias": "browser-with-org-selector",
+      "description": "Keycloak's own browser flow, with the organization selector (issue #79) added after credentials and any second factor.",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "browser-with-org-selector forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "alias": "browser-with-org-selector forms",
+      "description": "Username, password, and the organization selector, in that order.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "browser-with-org-selector Browser - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        },
+        {
+          "authenticator": "cerbos-poc-organization-selector",
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "alias": "browser-with-org-selector Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
     }
   ]
 }

--- a/deploy/keycloak/realm-tenant-b.json
+++ b/deploy/keycloak/realm-tenant-b.json
@@ -6,6 +6,7 @@
   "registrationAllowed": false,
   "loginWithEmailAllowed": true,
   "accessTokenLifespan": 900,
+  "browserFlow": "browser-with-org-selector",
   "organizationsEnabled": true,
   "organizations": [
     {
@@ -85,6 +86,98 @@
       "clientRoles": {
         "realm-management": ["view-users", "query-users", "view-clients", "view-realm"]
       }
+    }
+  ],
+  "authenticationFlows": [
+    {
+      "alias": "browser-with-org-selector",
+      "description": "Keycloak's own browser flow, with the organization selector (issue #79) added after credentials and any second factor.",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "browser-with-org-selector forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "alias": "browser-with-org-selector forms",
+      "description": "Username, password, and the organization selector, in that order.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "browser-with-org-selector Browser - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        },
+        {
+          "authenticator": "cerbos-poc-organization-selector",
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "alias": "browser-with-org-selector Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
     }
   ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,15 @@ services:
   # token is the same string whether it was minted for the browser or read by
   # the ADS - a mismatch there rejects every token with a confusing message.
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4
+    # The organization selector authenticator (issue #79) is baked into
+    # this image at build time (apps/keycloak-org-selector/Dockerfile runs
+    # a Maven stage and then `kc.sh build`), not mounted as a provider jar
+    # at runtime: `kc.sh build` has to run once against the finished
+    # provider set, and running it on every container start would slow
+    # every `make up` by the build's own duration for no benefit.
+    build:
+      context: .
+      dockerfile: apps/keycloak-org-selector/Dockerfile
     # `organization` is a preview feature in 26.4: Keycloak Organizations
     # (issue #75/#74) is disabled by default and every organization-scoped
     # token request 400s without it. Enabling it here is required, not

--- a/scripts/k8s-walkthrough.sh
+++ b/scripts/k8s-walkthrough.sh
@@ -75,6 +75,9 @@ declare -A images=(
   [docker.io/cerbos-poc/admin-service:dev]="apps/admin-service/Dockerfile"
   [docker.io/cerbos-poc/resource-service:dev]="apps/resource-service/Dockerfile"
   [docker.io/cerbos-poc/business-ui:dev]="apps/business-ui/Dockerfile"
+  # The organization selector authenticator (issue #79) is baked into this
+  # image at build time, the same way docker-compose.yml builds it.
+  [docker.io/cerbos-poc/keycloak:dev]="apps/keycloak-org-selector/Dockerfile"
 )
 for tag in "${!images[@]}"; do
   echo "    ${tag}"

--- a/scripts/tests/compose-contract.py
+++ b/scripts/tests/compose-contract.py
@@ -49,9 +49,20 @@ FORBIDDEN_IN_IMAGES = {
     "liquibase": "Liquibase, which belongs in its own container",
 }
 
+# Keycloak itself is a JVM application, and its organization selector
+# (issue #79) is a Keycloak provider, built and shipped inside Keycloak's
+# own image rather than a Go service's. It is the one Dockerfile in
+# apps/*/ this check does not apply to, named here rather than left as an
+# unexplained gap.
+JVM_APPLICATIONS = {"apps/keycloak-org-selector/Dockerfile"}
+
 
 def check_images_carry_no_native_clients() -> None:
-    dockerfiles = sorted(REPO_ROOT.glob("apps/*/Dockerfile"))
+    dockerfiles = sorted(
+        path
+        for path in REPO_ROOT.glob("apps/*/Dockerfile")
+        if path.relative_to(REPO_ROOT).as_posix() not in JVM_APPLICATIONS
+    )
     check("there is at least one service Dockerfile to inspect", bool(dockerfiles))
 
     for dockerfile in dockerfiles:

--- a/scripts/tests/org-selector-e2e.sh
+++ b/scripts/tests/org-selector-e2e.sh
@@ -19,6 +19,24 @@ wait_for_keycloak || exit 1
 
 REDIRECT_URI="http://127.0.0.1:4200/"
 
+# The browser flow's login form action and its Set-Cookie both carry
+# whatever host Keycloak was configured with (KC_HOSTNAME), which need not
+# be the host lib-token.sh's KEYCLOAK_URL uses to reach it (compose
+# defaults it to "localhost"; KEYCLOAK_URL defaults to "127.0.0.1" -
+# harmless for every other e2e script here, since a direct grant carries no
+# cookie, but fatal for a cookie jar: a cookie set for one host is not sent
+# on a request to the other, and the login form fails with "Restart login
+# cookie not found" rather than anything that names the real problem).
+# Discovery's own issuer is read once, up front, so every request in this
+# script goes to the one host Keycloak actually issues cookies for.
+BASE_URL="$(curl -sS --max-time 10 "${KEYCLOAK_URL}/realms/tenant-a/.well-known/openid-configuration" \
+  | jq -r '.issuer' | sed 's#/realms/tenant-a$##')"
+if [[ -z "${BASE_URL}" || "${BASE_URL}" == "null" ]]; then
+  echo "org-selector-e2e: could not determine Keycloak's own hostname from discovery" >&2
+  exit 1
+fi
+KEYCLOAK_URL="${BASE_URL}"
+
 # login_page <realm> <client-id> <cookie-jar> [scope]
 # GETs the authorization endpoint and leaves the login form in $login_body.
 login_page() {

--- a/scripts/tests/org-selector-e2e.sh
+++ b/scripts/tests/org-selector-e2e.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# The organization selector authenticator (issue #79), end to end through
+# the real browser login flow: an authorization code request, a cookie jar
+# carrying the login session, a credentials POST, and the code exchanged for
+# a token - no browser automation toolchain, just curl and a cookie jar in
+# the style of the existing identity suites.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+# shellcheck source=scripts/tests/lib-token.sh
+source scripts/tests/lib-token.sh
+
+failures=0
+pass() { echo "ok   $1"; }
+fail() { echo "FAIL $1"; failures=$((failures + 1)); }
+
+command -v jq >/dev/null 2>&1 || { echo "org-selector-e2e: jq is required" >&2; exit 1; }
+wait_for_keycloak || exit 1
+
+REDIRECT_URI="http://127.0.0.1:4200/"
+
+# login_page <realm> <client-id> <cookie-jar> [scope]
+# GETs the authorization endpoint and leaves the login form in $login_body.
+login_page() {
+  local realm="$1" client="$2" jar="$3" scope="${4:-openid}"
+  login_body="$(curl -sS --max-time 10 -c "${jar}" \
+    --get "${KEYCLOAK_URL}/realms/${realm}/protocol/openid-connect/auth" \
+    --data-urlencode "client_id=${client}" \
+    --data-urlencode "response_type=code" \
+    --data-urlencode "scope=${scope}" \
+    --data-urlencode "redirect_uri=${REDIRECT_URI}")"
+}
+
+# login_action <login-html>
+# Echoes the login form's own action URL, unescaped.
+login_action() {
+  grep -o 'action="[^"]*"' <<<"$1" | head -1 | sed -e 's/action="//' -e 's/"$//' -e 's/&amp;/\&/g'
+}
+
+# submit_credentials <action-url> <cookie-jar> <username> <password>
+# Submits the login form, leaving the response headers in $login_headers.
+submit_credentials() {
+  local action="$1" jar="$2" username="$3" password="$4"
+  login_headers="$(curl -sS --max-time 10 -D - -o /dev/null -c "${jar}" -b "${jar}" \
+    --data-urlencode "username=${username}" \
+    --data-urlencode "password=${password}" \
+    "${action}")"
+}
+
+# code_from_redirect
+# Reads the authorization code out of $login_headers's Location header, or
+# echoes nothing if the flow did not redirect (a refusal, or an error page).
+code_from_redirect() {
+  grep -i '^location:' <<<"${login_headers}" \
+    | grep -o 'code=[^&[:space:]]*' \
+    | head -1 \
+    | cut -d= -f2- \
+    | tr -d '\r'
+}
+
+# token_from_code <realm> <client-id> <code>
+# Exchanges an authorization code for a token response.
+token_from_code() {
+  local realm="$1" client="$2" code="$3"
+  curl -sS --max-time 10 \
+    -d "grant_type=authorization_code" \
+    -d "client_id=${client}" \
+    -d "code=${code}" \
+    -d "redirect_uri=${REDIRECT_URI}" \
+    "${KEYCLOAK_URL}/realms/${realm}/protocol/openid-connect/token"
+}
+
+echo "--- an alias already requested in scope is selected with no screen ---"
+
+jar="$(mktemp)"
+login_page tenant-a patient-app "${jar}" "openid organization:north-hospital"
+action="$(login_action "${login_body}")"
+submit_credentials "${action}" "${jar}" user-doctor demo-password
+code="$(code_from_redirect)"
+if [[ -z "${code}" ]]; then
+  fail "an alias already in scope reaches a code (headers were: ${login_headers})"
+else
+  response="$(token_from_code tenant-a patient-app "${code}")"
+  granted_scope="$(jq -r '.scope // empty' <<<"${response}")"
+  if [[ "${granted_scope}" == *"organization:north-hospital"* ]]; then
+    pass "an alias already requested in scope is selected with no screen"
+  else
+    fail "an alias already requested in scope is selected with no screen (scope was '${granted_scope}')"
+  fi
+fi
+rm -f "${jar}"
+
+echo
+echo "--- a single membership is auto-selected with no screen ---"
+
+jar="$(mktemp)"
+login_page tenant-a patient-app "${jar}"
+action="$(login_action "${login_body}")"
+submit_credentials "${action}" "${jar}" user-doctor demo-password
+code="$(code_from_redirect)"
+if [[ -z "${code}" ]]; then
+  fail "a single membership reaches a code with no scope requested (headers were: ${login_headers})"
+else
+  response="$(token_from_code tenant-a patient-app "${code}")"
+  access_token="$(jq -r '.access_token // empty' <<<"${response}")"
+  organization_claim="$(claim_of "${access_token}" '.organization | tojson')"
+  if [[ "${organization_claim}" == '["north-hospital"]' ]]; then
+    pass "a single membership is auto-selected with no screen"
+  else
+    fail "a single membership is auto-selected with no screen (organization claim was '${organization_claim}')"
+  fi
+fi
+rm -f "${jar}"
+
+echo
+echo "--- no membership and not an administrator is refused with an explicit reason ---"
+
+jar="$(mktemp)"
+login_page tenant-a patient-app "${jar}"
+action="$(login_action "${login_body}")"
+refusal="$(curl -sS --max-time 10 -o /tmp/org-selector-refusal.html -w '%{http_code}' \
+  -c "${jar}" -b "${jar}" \
+  --data-urlencode "username=user-forger" --data-urlencode "password=demo-password" \
+  "${action}")"
+if [[ "${refusal}" == "403" ]]; then
+  pass "no membership and not an administrator is refused rather than shown a generic failure"
+else
+  fail "no membership and not an administrator is refused (HTTP ${refusal})"
+fi
+if grep -qF "your account is not attached to a hospital" /tmp/org-selector-refusal.html; then
+  pass "the refusal names an explicit reason"
+else
+  fail "the refusal names an explicit reason (page did not contain it)"
+fi
+rm -f "${jar}" /tmp/org-selector-refusal.html
+
+echo
+echo "--- a user cannot obtain a token scoped to an organization they do not belong to ---"
+
+jar="$(mktemp)"
+login_page tenant-a patient-app "${jar}" "openid organization:south-hospital"
+action="$(login_action "${login_body}")"
+submit_credentials "${action}" "${jar}" user-doctor demo-password
+code="$(code_from_redirect)"
+if [[ -z "${code}" ]]; then
+  fail "a membership-mismatched alias still reaches a decision (headers were: ${login_headers})"
+else
+  # user-doctor belongs to north-hospital only, not south-hospital: the
+  # requested alias does not match, so the auto-select rule applies to the
+  # membership Keycloak actually confirmed, not the one asked for.
+  response="$(token_from_code tenant-a patient-app "${code}")"
+  access_token="$(jq -r '.access_token // empty' <<<"${response}")"
+  organization_claim="$(claim_of "${access_token}" '.organization | tojson')"
+  if [[ "${organization_claim}" == '["north-hospital"]' ]]; then
+    pass "a user cannot obtain a token scoped to an organization they do not belong to"
+  else
+    fail "a user cannot obtain a token scoped to an organization they do not belong to (organization claim was '${organization_claim}')"
+  fi
+fi
+rm -f "${jar}"
+
+echo
+echo "--- an administrator is undecided (the selection screen, not this authenticator) ---"
+
+jar="$(mktemp)"
+login_page tenant-a patient-app "${jar}"
+action="$(login_action "${login_body}")"
+submit_credentials "${action}" "${jar}" user-admin demo-password
+code="$(code_from_redirect)"
+if [[ -z "${code}" ]]; then
+  fail "an administrator still reaches a code (headers were: ${login_headers})"
+else
+  response="$(token_from_code tenant-a patient-app "${code}")"
+  access_token="$(jq -r '.access_token // empty' <<<"${response}")"
+  organization_claim="$(claim_of "${access_token}" '.organization // "absent"')"
+  if [[ "${organization_claim}" == "absent" ]]; then
+    pass "an administrator's login proceeds with no organization forced, unchanged by this authenticator"
+  else
+    fail "an administrator's login proceeds with no organization forced (organization claim was '${organization_claim}')"
+  fi
+fi
+rm -f "${jar}"
+
+if (( failures > 0 )); then
+  echo
+  echo "${failures} organization-selector failure(s)"
+  exit 1
+fi
+
+echo
+echo "organization selector end to end passed"


### PR DESCRIPTION
## What changed

The first half of in-flow organization selection (issue #79): a custom Keycloak authenticator provider, added to the browser login flow after credentials and any second factor, handling the three cases that need no selection screen.

- **`apps/keycloak-org-selector`**: a Maven project building a Keycloak SPI provider.
  - `OrganizationSelectionDecision` is a pure class (no Keycloak session/request/provider involved) implementing the PRD's five-outcome decision, exposing the three this slice acts on (`Selected`, `Refused`) plus `Undecided` for the two the selection screen - a later slice - will resolve (more than one membership; an administrator, even with exactly one membership, since the tenant-wide choice has to stay available). Full JUnit 5 coverage.
  - `OrganizationSupport` is the only class touching a real Keycloak session: reads membership aliases from `OrganizationProvider`, the tenant-wide realm role from #78's own `admin`, and the requested scope from the auth session's own `scope` client note. A selection is applied by rewriting that same note to include `organization:<alias>` - the identical mechanism §75's spike already confirmed Keycloak's own token-minting pipeline honours for a direct grant, not a second, bespoke way to decide which organization won.
  - `OrganizationSelectorAuthenticator`/`Factory` wire it into Keycloak's authenticator SPI.
- **`apps/keycloak-org-selector/Dockerfile`**: multi-stage build - a Maven stage (running the JUnit suite as part of the build) produces the provider jar, then `kc.sh build --features=organization` bakes it into the Keycloak image. No JVM or Maven on the host or in any Go service image.
- **Realm wiring**: `realm-tenant-a.json`/`realm-tenant-b.json` get a custom `browser-with-org-selector` flow (Keycloak's own default browser flow, with the authenticator inserted after the username/password form and the conditional OTP subflow) as their `browserFlow`.
- **`docker-compose.yml`** builds the custom image instead of pulling the stock one; **`scripts/k8s-walkthrough.sh`** builds and kind-loads it, and the k8s deployment references `cerbos-poc/keycloak:dev`.
- **`scripts/tests/org-selector-e2e.sh`**: the required curl-and-cookie-jar test (no browser automation toolchain) - a real authorization code flow through the actual login form, covering all three "no screen" outcomes plus the mismatched-alias negative and an administrator's unforced login.
- **`scripts/tests/compose-contract.py`**: the "no native database client and no JVM" check gets a named exception for this one Dockerfile - Keycloak itself is a JVM application by design.

## Verified locally before ever reaching CI

This repository's sandbox happened to have a working Docker/Podman environment, a JDK 17 and Maven, so every claim below was checked against the actual built image rather than guessed at:

- `mvn test` (JDK 17): all `OrganizationSelectionDecision` cases pass.
- The full image builds (`docker build -f apps/keycloak-org-selector/Dockerfile`), including the JUnit suite running inside the Maven stage and `kc.sh build` recognizing and registering the provider.
- A real Keycloak container, built from this image, importing `realm-tenant-a.json`/`realm-tenant-b.json`, driven through a genuine authorization-code login (curl + cookie jar):
  - an alias already requested in scope (`organization:north-hospital`) that matches a membership is selected, no screen;
  - a single membership (`user-doctor`, `user-doctor-b`) is auto-selected, no screen;
  - no membership and not an administrator (`user-forger`) is refused with **HTTP 403** and the exact configured reason;
  - a membership-mismatched request (`organization:south-hospital` for a north-hospital-only user) resolves to the real membership, not the mismatched request nor an empty claim - this caught and fixed a real bug (`selectOrganization` was refusing to overwrite an already-present scope value, so Keycloak's own pipeline silently dropped the mismatched request and the resulting token had no organization claim at all);
  - an administrator's login proceeds with no organization forced (falls through to #78's existing tenant-wide path, unchanged).

## How each acceptance criterion is met

- [x] A custom Keycloak image builds the provider in a Maven stage and runs `kc.sh build`; no JVM or Maven required on the host - `apps/keycloak-org-selector/Dockerfile`.
- [x] Selection logic is a pure class with JUnit coverage of every case, run inside the container build - `OrganizationSelectionDecisionTest`, run by `mvn test` during the Maven stage.
- [x] An alias named in scope matching a membership is selected with no screen - verified end to end.
- [x] A single-membership non-administrator is auto-selected with no screen - verified end to end.
- [x] No membership and no `admin` role cannot log in and is told why - verified end to end (HTTP 403, exact reason).
- [x] A user cannot obtain a token scoped to an organization they do not belong to - verified end to end (and the bug that would have violated this is fixed).
- [x] Login-flow behaviour is verified by a curl-and-cookie-jar test, no browser automation toolchain - `scripts/tests/org-selector-e2e.sh`.
- [x] The custom image is used by both the compose stack and the Kubernetes manifests - `docker-compose.yml` + `deploy/k8s/base/keycloak`.

## Verified with

- `mvn test` (JDK 17) - all green.
- Real Docker builds and a real running Keycloak container, as above.
- `python3 scripts/tests/compose-contract.py` (satisfied).
- `docker compose config -q` (valid).
- `python3 -c "import json/yaml; ..."` against every touched realm fixture and k8s manifest.
- CI (docker compose walking skeleton, architecture invariants, authorization schema on postgres, cerbos policy suite, dual dialect portability, nx affected).

Closes #79


Closes #79
