### PR TITLE
Organization selection screen for multi-hospital users (#80)

### DIFF
--- a/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecision.java
+++ b/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecision.java
@@ -14,19 +14,24 @@ import java.util.Optional;
  * {@link OrganizationSelectorAuthenticator} has nothing left to decide, only
  * to gather inputs and act on the outcome.
  *
- * <p>The PRD names five outcomes; this slice's authenticator acts on three
- * of them (the ones that need no selection screen) and leaves
- * {@link Undecided} for the ones the screen - a later slice - will resolve:
+ * <p>The PRD names five outcomes. Issue #79 implemented the three that need
+ * no screen; issue #80 adds the screen itself for the ordinary
+ * multi-membership case ({@link NeedsSelection}). An administrator's own
+ * screen - which the PRD gives an additional tenant-wide entry, not just a
+ * list of memberships - remains {@link Undecided}: a distinct concept from
+ * "pick one of these memberships", and not part of either slice's scope.
  *
  * <ol>
  *   <li>an alias already requested in scope that matches a membership -
  *       {@link Selected}, no screen;
  *   <li>exactly one membership and not an administrator - {@link Selected},
  *       auto-selected, no screen;
- *   <li>more than one membership - {@link Undecided} (the screen);
- *   <li>an administrator - {@link Undecided} (the screen, with a tenant-wide
- *       entry), even with exactly one membership: the tenant-wide choice has
- *       to be available, not pre-empted;
+ *   <li>more than one membership and not an administrator -
+ *       {@link NeedsSelection}, listing exactly those memberships;
+ *   <li>an administrator - {@link Undecided}, even with exactly one
+ *       membership: the tenant-wide choice has to be available, not
+ *       pre-empted, and this slice's screen has no tenant-wide entry to
+ *       offer it with;
  *   <li>no membership and not an administrator - {@link Refused}, an
  *       explicit reason rather than a generic login failure.
  * </ol>
@@ -37,7 +42,7 @@ public final class OrganizationSelectionDecision {
     }
 
     /** One of the outcomes {@link #decide} can reach. */
-    public sealed interface Outcome permits Selected, Undecided, Refused {
+    public sealed interface Outcome permits Selected, NeedsSelection, Undecided, Refused {
     }
 
     /** The organization alias to select, silently, with no screen shown. */
@@ -50,10 +55,24 @@ public final class OrganizationSelectionDecision {
     }
 
     /**
-     * No case this slice handles applies; the selection screen - not
-     * implemented by this authenticator - decides. The authenticator lets
-     * the flow continue unchanged rather than forcing an outcome it has no
-     * basis for.
+     * The user belongs to more than one organization: the screen this
+     * outcome exists for (issue #80) lists exactly {@code options}, in the
+     * order given - never more, never a hospital they do not belong to.
+     */
+    public record NeedsSelection(List<String> options) implements Outcome {
+        public NeedsSelection {
+            if (options == null || options.size() < 2) {
+                throw new IllegalArgumentException("a selection is only offered among two or more options");
+            }
+            options = List.copyOf(options);
+        }
+    }
+
+    /**
+     * An administrator: their own screen - a tenant-wide entry alongside
+     * their memberships - is neither of this slice's outcomes, so this
+     * authenticator lets the flow continue unchanged rather than forcing
+     * one it has no basis for.
      */
     public record Undecided() implements Outcome {
     }
@@ -92,11 +111,14 @@ public final class OrganizationSelectionDecision {
         if (requestedAlias.isPresent() && memberships.contains(requestedAlias.get())) {
             return new Selected(requestedAlias.get());
         }
-        if (!isAdministrator && memberships.size() == 1) {
+        if (isAdministrator) {
+            return new Undecided();
+        }
+        if (memberships.size() == 1) {
             return new Selected(memberships.get(0));
         }
-        if (isAdministrator || memberships.size() > 1) {
-            return new Undecided();
+        if (memberships.size() > 1) {
+            return new NeedsSelection(memberships);
         }
         return new Refused("your account is not attached to a hospital; contact your administrator");
     }

--- a/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectorAuthenticator.java
+++ b/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectorAuthenticator.java
@@ -13,41 +13,83 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 
 /**
- * The login-flow half of organization selection (issue #79). Placed after
- * credentials and any second factor, it gathers the facts
+ * The login-flow half of organization selection (issues #79 and #80).
+ * Placed after credentials and any second factor, it gathers the facts
  * {@link OrganizationSelectionDecision} needs from the authenticated
  * session and acts on the outcome:
  *
  * <ul>
  *   <li>{@link OrganizationSelectionDecision.Selected} - the organization is
  *       recorded and the flow proceeds with no screen shown;
+ *   <li>{@link OrganizationSelectionDecision.NeedsSelection} - the
+ *       {@code select-organization.ftl} screen is shown, listing exactly
+ *       the offered options; {@link #action} handles its submission;
  *   <li>{@link OrganizationSelectionDecision.Refused} - the flow fails with
  *       an explicit reason rather than a generic authentication failure;
  *   <li>{@link OrganizationSelectionDecision.Undecided} - this
- *       authenticator has no basis to decide (the selection screen slice
- *       does), so the flow proceeds unchanged.
+ *       authenticator has no basis to decide (an administrator's own
+ *       screen, a later slice's concern), so the flow proceeds unchanged.
  * </ul>
  */
 public class OrganizationSelectorAuthenticator implements Authenticator {
 
     private static final Logger LOG = Logger.getLogger(OrganizationSelectorAuthenticator.class);
+    static final String SELECTION_FORM = "select-organization.ftl";
+    static final String SELECTED_FIELD = "organization";
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
-        RealmModel realm = context.getRealm();
         UserModel user = context.getUser();
-
         List<String> memberships = OrganizationSupport.membershipAliases(context, user);
-        boolean isAdministrator = isTenantWideAdministrator(realm, user);
+        boolean isAdministrator = isTenantWideAdministrator(context.getRealm(), user);
         Optional<String> requestedAlias = OrganizationSupport.requestedAlias(context);
 
-        OrganizationSelectionDecision.Outcome outcome =
-                OrganizationSelectionDecision.decide(memberships, isAdministrator, requestedAlias);
+        act(context, user, memberships,
+                OrganizationSelectionDecision.decide(memberships, isAdministrator, requestedAlias));
+    }
 
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        UserModel user = context.getUser();
+        // Re-derived from Keycloak's own membership records, not trusted
+        // from the form that was just submitted: the submission names an
+        // alias, membership in it is still checked here exactly the way
+        // authenticate() checked it, so a tampered or stale submission is
+        // rejected rather than honoured (issue #80's acceptance criterion).
+        List<String> memberships = OrganizationSupport.membershipAliases(context, user);
+        String submitted = context.getHttpRequest().getDecodedFormParameters().getFirst(SELECTED_FIELD);
+
+        if (submitted == null || !memberships.contains(submitted)) {
+            LOG.infof("organization selector: rejecting a submission naming an organization %s does not belong to",
+                    user.getUsername());
+            act(context, user, memberships, new OrganizationSelectionDecision.Refused(
+                    "the selected organization is not one you belong to"));
+            return;
+        }
+        act(context, user, memberships, new OrganizationSelectionDecision.Selected(submitted));
+    }
+
+    private void act(AuthenticationFlowContext context, UserModel user, List<String> memberships,
+            OrganizationSelectionDecision.Outcome outcome) {
         if (outcome instanceof OrganizationSelectionDecision.Selected selected) {
             OrganizationSupport.selectOrganization(context, selected.alias());
             LOG.debugf("organization selector: %s selected for %s", selected.alias(), user.getUsername());
             context.success();
+            return;
+        }
+
+        if (outcome instanceof OrganizationSelectionDecision.NeedsSelection needsSelection) {
+            LOG.debugf("organization selector: presenting %d options to %s",
+                    needsSelection.options().size(), user.getUsername());
+            Response challenge = context.form()
+                    .setAttribute("organizations", needsSelection.options())
+                    .createForm(SELECTION_FORM);
+            // challenge, not success or failure: the flow is neither
+            // finished nor refused, it is waiting on the submission
+            // action() handles. Keycloak issues no token for a session
+            // left here, so abandoning the screen leaves nothing capable
+            // of taking a decision (issue #80's acceptance criterion).
+            context.challenge(challenge);
             return;
         }
 
@@ -60,10 +102,9 @@ public class OrganizationSelectorAuthenticator implements Authenticator {
             return;
         }
 
-        // Undecided: more than one membership, or an administrator - the
-        // selection screen a later slice adds is what decides these, not
-        // this authenticator. Proceeding unchanged is the deliberate
-        // no-op, not an oversight.
+        // Undecided: an administrator - their own screen, a later slice's
+        // concern, is what decides this, not this authenticator.
+        // Proceeding unchanged is the deliberate no-op, not an oversight.
         context.success();
     }
 
@@ -76,12 +117,6 @@ public class OrganizationSelectorAuthenticator implements Authenticator {
     private static boolean isTenantWideAdministrator(RealmModel realm, UserModel user) {
         RoleModel role = realm.getRole(OrganizationSelectionRealmRoles.TENANT_WIDE);
         return role != null && user.hasRole(role);
-    }
-
-    @Override
-    public void action(AuthenticationFlowContext context) {
-        // No form is ever submitted back to this authenticator: it either
-        // decides silently or fails the flow outright in authenticate().
     }
 
     @Override

--- a/apps/keycloak-org-selector/src/main/resources/META-INF/keycloak-themes.json
+++ b/apps/keycloak-org-selector/src/main/resources/META-INF/keycloak-themes.json
@@ -1,0 +1,8 @@
+{
+  "themes": [
+    {
+      "name": "cerbos-poc",
+      "types": ["login"]
+    }
+  ]
+}

--- a/apps/keycloak-org-selector/src/main/resources/theme/cerbos-poc/login/select-organization.ftl
+++ b/apps/keycloak-org-selector/src/main/resources/theme/cerbos-poc/login/select-organization.ftl
@@ -1,0 +1,27 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=true; section>
+    <#if section = "header">
+        Select your hospital
+    <#elseif section = "form">
+        <#-- issue #80: exactly the caller's own memberships, never more,
+             never one they do not belong to. The value submitted here is
+             re-checked against those same memberships server-side before
+             it is ever honoured (OrganizationSelectorAuthenticator#action) -
+             this list is a convenience for a legitimate caller, not the
+             thing that makes the choice trustworthy. -->
+        <form id="kc-select-organization-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+            <#list organizations as organization>
+                <div class="${properties.kcFormGroupClass!}">
+                    <label class="${properties.kcLabelClass!}">
+                        <input type="radio" name="organization" value="${organization}"<#if organization?index == 0> checked="checked"</#if>/>
+                        ${organization}
+                    </label>
+                </div>
+            </#list>
+            <div class="${properties.kcFormGroupClass!}">
+                <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!}"
+                       type="submit" value="${msg("doSubmit")}"/>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/apps/keycloak-org-selector/src/main/resources/theme/cerbos-poc/login/theme.properties
+++ b/apps/keycloak-org-selector/src/main/resources/theme/cerbos-poc/login/theme.properties
@@ -1,0 +1,6 @@
+# The stack's login theme (issue #80): everything but the one screen this
+# provider adds (select-organization.ftl) is Keycloak's own default theme,
+# inherited rather than copied, so a Keycloak upgrade's theme changes reach
+# every other page automatically.
+parent=keycloak.v2
+import=common/keycloak

--- a/apps/keycloak-org-selector/src/test/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecisionTest.java
+++ b/apps/keycloak-org-selector/src/test/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecisionTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Optional;
+import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.NeedsSelection;
 import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.Outcome;
 import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.Refused;
 import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.Selected;
@@ -49,11 +50,24 @@ class OrganizationSelectionDecisionTest {
     }
 
     @Test
-    void moreThanOneMembershipIsUndecidedForTheScreen() {
+    void moreThanOneMembershipOffersASelectionAmongExactlyThem() {
         Outcome outcome = OrganizationSelectionDecision.decide(
                 List.of("north-hospital", "south-hospital"), false, Optional.empty());
 
-        assertInstanceOf(Undecided.class, outcome);
+        NeedsSelection needsSelection = assertInstanceOf(NeedsSelection.class, outcome);
+        assertEquals(List.of("north-hospital", "south-hospital"), needsSelection.options());
+    }
+
+    @Test
+    void aRequestedAliasThatDoesNotMatchStillOffersASelectionAmongTheRealMemberships() {
+        // The requested alias is not a membership, so it does not win rule
+        // 1; falling through to more-than-one-membership is correct, not a
+        // side effect of ignoring the request.
+        Outcome outcome = OrganizationSelectionDecision.decide(
+                List.of("north-hospital", "south-hospital"), false, Optional.of("east-hospital"));
+
+        NeedsSelection needsSelection = assertInstanceOf(NeedsSelection.class, outcome);
+        assertEquals(List.of("north-hospital", "south-hospital"), needsSelection.options());
     }
 
     @Test
@@ -70,6 +84,18 @@ class OrganizationSelectionDecisionTest {
     @Test
     void anAdministratorWithNoMembershipIsUndecidedForTheScreenRatherThanRefused() {
         Outcome outcome = OrganizationSelectionDecision.decide(List.of(), true, Optional.empty());
+
+        assertInstanceOf(Undecided.class, outcome);
+    }
+
+    @Test
+    void anAdministratorWithMultipleMembershipsIsUndecidedRatherThanOfferedTheMembershipsScreen() {
+        // Issue #80's screen only ever lists memberships, with no
+        // tenant-wide entry - not what an administrator's own screen (a
+        // later slice) has to offer, so this stays Undecided rather than
+        // NeedsSelection.
+        Outcome outcome = OrganizationSelectionDecision.decide(
+                List.of("north-hospital", "south-hospital"), true, Optional.empty());
 
         assertInstanceOf(Undecided.class, outcome);
     }

--- a/deploy/keycloak/realm-tenant-a.json
+++ b/deploy/keycloak/realm-tenant-a.json
@@ -7,6 +7,7 @@
   "accessTokenLifespan": 900,
   "organizationsEnabled": true,
   "browserFlow": "browser-with-org-selector",
+  "loginTheme": "cerbos-poc",
   "organizations": [
     {
       "name": "North Hospital",
@@ -18,7 +19,8 @@
         { "username": "user-doctor-revoked" },
         { "username": "user-auditor" },
         { "username": "user-clerk-granted" },
-        { "username": "user-unassigned" }
+        { "username": "user-unassigned" },
+        { "username": "user-doctor-multi" }
       ]
     },
     {
@@ -26,7 +28,7 @@
       "alias": "south-hospital",
       "enabled": true,
       "domains": [{ "name": "south-hospital.example.test", "verified": false }],
-      "members": []
+      "members": [{ "username": "user-doctor-multi" }]
     }
   ],
   "clients": [
@@ -149,6 +151,17 @@
       "firstName": "Dana",
       "lastName": "Doctor",
       "email": "dana.doctor@example.test",
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "clientRoles": { "patient-app": ["doctor"] }
+    },
+    {
+      "id": "user-doctor-multi",
+      "username": "user-doctor-multi",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Morgan",
+      "lastName": "Doctor",
+      "email": "morgan.doctor@example.test",
       "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
       "clientRoles": { "patient-app": ["doctor"] }
     },

--- a/deploy/keycloak/realm-tenant-b.json
+++ b/deploy/keycloak/realm-tenant-b.json
@@ -7,6 +7,7 @@
   "loginWithEmailAllowed": true,
   "accessTokenLifespan": 900,
   "browserFlow": "browser-with-org-selector",
+  "loginTheme": "cerbos-poc",
   "organizationsEnabled": true,
   "organizations": [
     {

--- a/scripts/tests/org-scope-spike.sh
+++ b/scripts/tests/org-scope-spike.sh
@@ -71,10 +71,10 @@ else
 fi
 
 south_members="$(admin_org_members south-hospital)"
-if [[ -z "${south_members}" ]]; then
-  pass "south-hospital has no members, so it is a clean negative fixture"
+if [[ -n "${south_members}" ]] && ! grep -qx "user-doctor" <<<"${south_members}"; then
+  pass "south-hospital's members do not include user-doctor, so it remains a clean negative fixture for that user"
 else
-  fail "south-hospital has no members (was '${south_members}')"
+  fail "south-hospital's members do not include user-doctor (was '${south_members}')"
 fi
 
 echo

--- a/scripts/tests/org-selector-e2e.sh
+++ b/scripts/tests/org-selector-e2e.sh
@@ -88,6 +88,16 @@ token_from_code() {
     "${KEYCLOAK_URL}/realms/${realm}/protocol/openid-connect/token"
 }
 
+# submit_organization <action-url> <cookie-jar> <alias>
+# Submits the selection screen's own form, leaving the response headers in
+# $login_headers.
+submit_organization() {
+  local action="$1" jar="$2" alias="$3"
+  login_headers="$(curl -sS --max-time 10 -D - -o /tmp/org-selector-submission.html -c "${jar}" -b "${jar}" \
+    --data-urlencode "organization=${alias}" \
+    "${action}")"
+}
+
 echo "--- an alias already requested in scope is selected with no screen ---"
 
 jar="$(mktemp)"
@@ -198,6 +208,85 @@ else
   fi
 fi
 rm -f "${jar}"
+
+echo
+echo "--- a member of more than one organization sees the selection screen (issue #80) ---"
+
+# The credentials POST's own response body is the selection screen: a
+# member of more than one organization reaches it directly, no separate
+# navigation involved.
+jar="$(mktemp)"
+login_page tenant-a patient-app "${jar}"
+action="$(login_action "${login_body}")"
+form_body="$(curl -sS --max-time 10 -c "${jar}" -b "${jar}" \
+  --data-urlencode "username=user-doctor-multi" --data-urlencode "password=demo-password" \
+  "${action}")"
+listed_aliases="$(grep -o 'value="[a-z-]*hospital"' <<<"${form_body}" | sed -e 's/value="//' -e 's/"$//' | sort)"
+if [[ "${listed_aliases}" == $'north-hospital\nsouth-hospital' ]]; then
+  pass "the screen lists exactly the caller's own organizations"
+else
+  fail "the screen lists exactly the caller's own organizations (was: ${listed_aliases})"
+fi
+selection_action="$(login_action "${form_body}")"
+
+echo
+echo "--- each answer yields a token whose active hospital differs accordingly ---"
+
+submit_organization "${selection_action}" "${jar}" "south-hospital"
+code="$(code_from_redirect)"
+south_organization="absent"
+if [[ -n "${code}" ]]; then
+  response="$(token_from_code tenant-a patient-app "${code}")"
+  access_token="$(jq -r '.access_token // empty' <<<"${response}")"
+  south_organization="$(claim_of "${access_token}" '.organization | tojson')"
+fi
+
+jar="$(mktemp)"
+login_page tenant-a patient-app "${jar}"
+action="$(login_action "${login_body}")"
+form_body="$(curl -sS --max-time 10 -c "${jar}" -b "${jar}" \
+  --data-urlencode "username=user-doctor-multi" --data-urlencode "password=demo-password" \
+  "${action}")"
+selection_action="$(login_action "${form_body}")"
+submit_organization "${selection_action}" "${jar}" "north-hospital"
+code="$(code_from_redirect)"
+north_organization="absent"
+if [[ -n "${code}" ]]; then
+  response="$(token_from_code tenant-a patient-app "${code}")"
+  access_token="$(jq -r '.access_token // empty' <<<"${response}")"
+  north_organization="$(claim_of "${access_token}" '.organization | tojson')"
+fi
+
+if [[ "${south_organization}" == '["south-hospital"]' && "${north_organization}" == '["north-hospital"]' ]]; then
+  pass "the same user's two answers yield two different active hospitals"
+else
+  fail "the same user's two answers yield two different active hospitals (south answer -> ${south_organization}, north answer -> ${north_organization})"
+fi
+rm -f "${jar}"
+
+echo
+echo "--- a submitted organization the user is not a member of is rejected ---"
+
+jar="$(mktemp)"
+login_page tenant-a patient-app "${jar}"
+action="$(login_action "${login_body}")"
+form_body="$(curl -sS --max-time 10 -c "${jar}" -b "${jar}" \
+  --data-urlencode "username=user-doctor-multi" --data-urlencode "password=demo-password" \
+  "${action}")"
+selection_action="$(login_action "${form_body}")"
+tampered_status="$(curl -sS --max-time 10 -o /tmp/org-selector-tampered.html -w '%{http_code}' \
+  -c "${jar}" -b "${jar}" --data-urlencode "organization=a-hospital-nobody-belongs-to" "${selection_action}")"
+if [[ "${tampered_status}" == "403" ]]; then
+  pass "a submitted organization the user is not a member of is rejected, not honoured"
+else
+  fail "a submitted organization the user is not a member of is rejected (HTTP ${tampered_status})"
+fi
+if grep -qF "not one you belong to" /tmp/org-selector-tampered.html; then
+  pass "the rejection names an explicit reason"
+else
+  fail "the rejection names an explicit reason (page did not contain it)"
+fi
+rm -f "${jar}" /tmp/org-selector-submission.html /tmp/org-selector-tampered.html
 
 if (( failures > 0 )); then
   echo


### PR DESCRIPTION
## What changed

The second half of in-flow organization selection (issue #80): a login theme fragment presenting a member of more than one organization's own memberships, and completing authentication with the one they chose.

- **`OrganizationSelectionDecision`** gains `NeedsSelection(options)`: reached when a non-administrator belongs to more than one organization and no already-requested alias matched one of them. An administrator with the same shape of membership stays `Undecided` - their own screen (a tenant-wide entry alongside memberships) is a different concept this slice does not build.
- **`OrganizationSelectorAuthenticator`**: `authenticate()` challenges with `select-organization.ftl` for `NeedsSelection`; `action()` re-derives the user's memberships from Keycloak's own records (never trusting the submitted form) and checks the submission against them before ever honouring it - a submission naming an organization the user does not belong to is refused outright (HTTP 403, explicit reason), not silently corrected. `context.success()` is never called until that check passes, which is what leaves an abandoned or cancelled screen without a session capable of taking a decision.
- **Theme**: `apps/keycloak-org-selector/src/main/resources/theme/cerbos-poc` extends Keycloak's own `keycloak.v2` default (`parent=keycloak.v2`) rather than replacing it, so only the one new page needed writing - every other login page (and any future Keycloak theme update) is inherited unchanged. Both realms set it as their `loginTheme`.
- **`user-doctor-multi`** (realm-tenant-a.json) is the first demo principal with more than one organization membership (north-hospital and south-hospital), added so the screen has someone real to exercise end to end. `org-scope-spike.sh`'s "south-hospital has no members" assertion is updated accordingly (it now checks south-hospital's members exclude `user-doctor` specifically, which is what that spike actually needed).
- **`scripts/tests/org-selector-e2e.sh`** gains three new scenarios: the screen lists exactly the caller's own organizations; the same user logged in twice with different answers gets two different active hospitals; a tampered submission is rejected.

## How each acceptance criterion is met

- [x] A user who is a member of more than one organization is shown a selection screen listing exactly their own organizations - verified end to end.
- [x] Each answer yields a token whose active hospital differs accordingly, asserted by an end-to-end test that logs the same user in twice with different answers - `org-selector-e2e.sh`.
- [x] A submitted organization the user is not a member of is rejected, not honoured - re-checked server-side against Keycloak's own membership records in `action()`, verified end to end (HTTP 403).
- [x] The screen is reached only after credentials and any second factor have succeeded - unchanged placement in the flow from issue #79 (after the username/password form and the conditional OTP subflow).
- [x] The selection screen renders with the stack's existing theme rather than an unstyled default - extends `keycloak.v2`, verified by inspecting the actual rendered HTML against the built image.
- [x] Cancelling or abandoning the screen leaves no partially authenticated session capable of taking a decision - `context.challenge()` is used, never `context.success()`, until a valid submission is checked; Keycloak issues no token for an auth session that never reaches success.

## Verified locally before ever reaching CI

Same approach as #79 - a real Docker/Podman environment, JDK 17 and Maven were available in this sandbox:

- `mvn test`: all `OrganizationSelectionDecision` cases (including the new `NeedsSelection` branches) pass.
- The full image builds, bundling the theme resources into the provider jar.
- A real Keycloak container, driven through genuine authorization-code logins (curl + cookie jar):
  - `user-doctor-multi`'s selection screen lists exactly `north-hospital` and `south-hospital`, styled (a real 200 OK page from the actual login theme, not an unstyled fallback);
  - choosing `south-hospital` then `north-hospital` in two separate logins yields two tokens with the matching `organization` claim each time;
  - submitting an organization nobody belongs to is refused with HTTP 403 and the exact configured reason.

## Verified with

- `mvn test` (JDK 17) - all green.
- Real Docker builds and a real running Keycloak container, as above.
- `python3 scripts/tests/compose-contract.py` (satisfied).
- `docker compose config -q` (valid).
- `python3 -c "import json; ..."` against both touched realm fixtures.
- CI (docker compose walking skeleton, architecture invariants, authorization schema on postgres, cerbos policy suite, dual dialect portability, nx affected).

Closes #80


Closes #80
