### PR TITLE
Administrator tenant-wide sessions and their policy semantics (#81)

### DIFF
--- a/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecision.java
+++ b/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecision.java
@@ -14,12 +14,7 @@ import java.util.Optional;
  * {@link OrganizationSelectorAuthenticator} has nothing left to decide, only
  * to gather inputs and act on the outcome.
  *
- * <p>The PRD names five outcomes. Issue #79 implemented the three that need
- * no screen; issue #80 adds the screen itself for the ordinary
- * multi-membership case ({@link NeedsSelection}). An administrator's own
- * screen - which the PRD gives an additional tenant-wide entry, not just a
- * list of memberships - remains {@link Undecided}: a distinct concept from
- * "pick one of these memberships", and not part of either slice's scope.
+ * <p>The PRD names five outcomes, all implemented as of issue #81:
  *
  * <ol>
  *   <li>an alias already requested in scope that matches a membership -
@@ -27,11 +22,12 @@ import java.util.Optional;
  *   <li>exactly one membership and not an administrator - {@link Selected},
  *       auto-selected, no screen;
  *   <li>more than one membership and not an administrator -
- *       {@link NeedsSelection}, listing exactly those memberships;
- *   <li>an administrator - {@link Undecided}, even with exactly one
- *       membership: the tenant-wide choice has to be available, not
- *       pre-empted, and this slice's screen has no tenant-wide entry to
- *       offer it with;
+ *       {@link NeedsSelection}, {@code offerTenantWide=false}, listing
+ *       exactly those memberships;
+ *   <li>an administrator - {@link NeedsSelection}, {@code
+ *       offerTenantWide=true}, unconditionally: even with exactly one
+ *       membership, or none, the tenant-wide choice has to be available,
+ *       not pre-empted;
  *   <li>no membership and not an administrator - {@link Refused}, an
  *       explicit reason rather than a generic login failure.
  * </ol>
@@ -42,7 +38,7 @@ public final class OrganizationSelectionDecision {
     }
 
     /** One of the outcomes {@link #decide} can reach. */
-    public sealed interface Outcome permits Selected, NeedsSelection, Undecided, Refused {
+    public sealed interface Outcome permits Selected, SelectedTenantWide, NeedsSelection, Refused {
     }
 
     /** The organization alias to select, silently, with no screen shown. */
@@ -55,26 +51,40 @@ public final class OrganizationSelectionDecision {
     }
 
     /**
-     * The user belongs to more than one organization: the screen this
-     * outcome exists for (issue #80) lists exactly {@code options}, in the
-     * order given - never more, never a hospital they do not belong to.
+     * The administrator's explicit tenant-wide choice (issue #81): no
+     * organization is selected at all, the session carries no active
+     * hospital, and - because this is a deliberate act on a screen rather
+     * than a fallback nobody chose - it is its own outcome, not
+     * {@link Selected} with an empty alias, so the authenticator can log it
+     * distinguishably in the audit trail.
      */
-    public record NeedsSelection(List<String> options) implements Outcome {
-        public NeedsSelection {
-            if (options == null || options.size() < 2) {
-                throw new IllegalArgumentException("a selection is only offered among two or more options");
-            }
-            options = List.copyOf(options);
-        }
+    public record SelectedTenantWide() implements Outcome {
     }
 
     /**
-     * An administrator: their own screen - a tenant-wide entry alongside
-     * their memberships - is neither of this slice's outcomes, so this
-     * authenticator lets the flow continue unchanged rather than forcing
-     * one it has no basis for.
+     * A screen is needed. Two shapes share this outcome:
+     *
+     * <ul>
+     *   <li>a non-administrator with more than one membership -
+     *       {@code options} lists exactly those memberships,
+     *       {@code offerTenantWide} is {@code false};
+     *   <li>an administrator, unconditionally - {@code options} lists
+     *       their memberships (which may be empty), {@code
+     *       offerTenantWide} is {@code true}, since the tenant-wide choice
+     *       has to be available whatever their membership count.
+     * </ul>
      */
-    public record Undecided() implements Outcome {
+    public record NeedsSelection(List<String> options, boolean offerTenantWide) implements Outcome {
+        public NeedsSelection {
+            if (options == null) {
+                throw new IllegalArgumentException("options must not be null; empty means none");
+            }
+            if (!offerTenantWide && options.size() < 2) {
+                throw new IllegalArgumentException(
+                        "a selection with no tenant-wide entry is only offered among two or more options");
+            }
+            options = List.copyOf(options);
+        }
     }
 
     /** Login is refused outright, with a reason to show the user. */
@@ -112,13 +122,13 @@ public final class OrganizationSelectionDecision {
             return new Selected(requestedAlias.get());
         }
         if (isAdministrator) {
-            return new Undecided();
+            return new NeedsSelection(memberships, true);
         }
         if (memberships.size() == 1) {
             return new Selected(memberships.get(0));
         }
         if (memberships.size() > 1) {
-            return new NeedsSelection(memberships);
+            return new NeedsSelection(memberships, false);
         }
         return new Refused("your account is not attached to a hospital; contact your administrator");
     }

--- a/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectorAuthenticator.java
+++ b/apps/keycloak-org-selector/src/main/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectorAuthenticator.java
@@ -13,7 +13,7 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 
 /**
- * The login-flow half of organization selection (issues #79 and #80).
+ * The login-flow half of organization selection (issues #79, #80 and #81).
  * Placed after credentials and any second factor, it gathers the facts
  * {@link OrganizationSelectionDecision} needs from the authenticated
  * session and acts on the outcome:
@@ -23,12 +23,14 @@ import org.keycloak.models.UserModel;
  *       recorded and the flow proceeds with no screen shown;
  *   <li>{@link OrganizationSelectionDecision.NeedsSelection} - the
  *       {@code select-organization.ftl} screen is shown, listing exactly
- *       the offered options; {@link #action} handles its submission;
+ *       the offered options and, for an administrator, the tenant-wide
+ *       entry; {@link #action} handles its submission;
+ *   <li>{@link OrganizationSelectionDecision.SelectedTenantWide} - the
+ *       administrator's explicit tenant-wide choice: no organization is
+ *       selected, logged as its own distinguishable fact (issue #81's
+ *       audit-trail acceptance criterion);
  *   <li>{@link OrganizationSelectionDecision.Refused} - the flow fails with
- *       an explicit reason rather than a generic authentication failure;
- *   <li>{@link OrganizationSelectionDecision.Undecided} - this
- *       authenticator has no basis to decide (an administrator's own
- *       screen, a later slice's concern), so the flow proceeds unchanged.
+ *       an explicit reason rather than a generic authentication failure.
  * </ul>
  */
 public class OrganizationSelectorAuthenticator implements Authenticator {
@@ -36,6 +38,14 @@ public class OrganizationSelectorAuthenticator implements Authenticator {
     private static final Logger LOG = Logger.getLogger(OrganizationSelectorAuthenticator.class);
     static final String SELECTION_FORM = "select-organization.ftl";
     static final String SELECTED_FIELD = "organization";
+    /**
+     * The selection screen's own encoding of "tenant-wide" (issue #81): an
+     * empty submission is exactly how hospitalId already represents
+     * tenant-wide everywhere else in this system (§78's tokenverifier,
+     * this authenticator's own {@link OrganizationSupport}), so this is not
+     * a second vocabulary for the same fact.
+     */
+    static final String TENANT_WIDE_VALUE = "";
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
@@ -44,45 +54,71 @@ public class OrganizationSelectorAuthenticator implements Authenticator {
         boolean isAdministrator = isTenantWideAdministrator(context.getRealm(), user);
         Optional<String> requestedAlias = OrganizationSupport.requestedAlias(context);
 
-        act(context, user, memberships,
+        act(context, user, memberships, isAdministrator,
                 OrganizationSelectionDecision.decide(memberships, isAdministrator, requestedAlias));
     }
 
     @Override
     public void action(AuthenticationFlowContext context) {
         UserModel user = context.getUser();
-        // Re-derived from Keycloak's own membership records, not trusted
-        // from the form that was just submitted: the submission names an
-        // alias, membership in it is still checked here exactly the way
+        // Re-derived from Keycloak's own membership and role records, not
+        // trusted from the form that was just submitted: the submission
+        // names an alias (or tenant-wide), membership - or administrator
+        // status, for tenant-wide - is still checked here exactly the way
         // authenticate() checked it, so a tampered or stale submission is
         // rejected rather than honoured (issue #80's acceptance criterion).
         List<String> memberships = OrganizationSupport.membershipAliases(context, user);
+        boolean isAdministrator = isTenantWideAdministrator(context.getRealm(), user);
         String submitted = context.getHttpRequest().getDecodedFormParameters().getFirst(SELECTED_FIELD);
+
+        if (TENANT_WIDE_VALUE.equals(submitted)) {
+            if (!isAdministrator) {
+                LOG.infof("organization selector: rejecting a tenant-wide submission from %s, who is not an administrator",
+                        user.getUsername());
+                act(context, user, memberships, false, new OrganizationSelectionDecision.Refused(
+                        "tenant-wide is only available to an administrator"));
+                return;
+            }
+            act(context, user, memberships, true, new OrganizationSelectionDecision.SelectedTenantWide());
+            return;
+        }
 
         if (submitted == null || !memberships.contains(submitted)) {
             LOG.infof("organization selector: rejecting a submission naming an organization %s does not belong to",
                     user.getUsername());
-            act(context, user, memberships, new OrganizationSelectionDecision.Refused(
+            act(context, user, memberships, isAdministrator, new OrganizationSelectionDecision.Refused(
                     "the selected organization is not one you belong to"));
             return;
         }
-        act(context, user, memberships, new OrganizationSelectionDecision.Selected(submitted));
+        act(context, user, memberships, isAdministrator, new OrganizationSelectionDecision.Selected(submitted));
     }
 
     private void act(AuthenticationFlowContext context, UserModel user, List<String> memberships,
-            OrganizationSelectionDecision.Outcome outcome) {
+            boolean isAdministrator, OrganizationSelectionDecision.Outcome outcome) {
         if (outcome instanceof OrganizationSelectionDecision.Selected selected) {
             OrganizationSupport.selectOrganization(context, selected.alias());
-            LOG.debugf("organization selector: %s selected for %s", selected.alias(), user.getUsername());
+            LOG.infof("organization selector: %s chose %s", user.getUsername(), selected.alias());
+            context.success();
+            return;
+        }
+
+        if (outcome instanceof OrganizationSelectionDecision.SelectedTenantWide) {
+            // No call to OrganizationSupport.selectOrganization: tenant-wide
+            // means precisely that no organization scope is added, so the
+            // session carries no active hospital at all (issue #81).
+            LOG.infof("organization selector: %s chose tenant-wide", user.getUsername());
             context.success();
             return;
         }
 
         if (outcome instanceof OrganizationSelectionDecision.NeedsSelection needsSelection) {
-            LOG.debugf("organization selector: presenting %d options to %s",
-                    needsSelection.options().size(), user.getUsername());
+            LOG.debugf("organization selector: presenting %s option(s) to %s (tenant-wide offered: %s)",
+                    Integer.toString(needsSelection.options().size()), user.getUsername(),
+                    needsSelection.offerTenantWide());
             Response challenge = context.form()
                     .setAttribute("organizations", needsSelection.options())
+                    .setAttribute("offerTenantWide", needsSelection.offerTenantWide())
+                    .setAttribute("tenantWideValue", TENANT_WIDE_VALUE)
                     .createForm(SELECTION_FORM);
             // challenge, not success or failure: the flow is neither
             // finished nor refused, it is waiting on the submission
@@ -93,19 +129,13 @@ public class OrganizationSelectorAuthenticator implements Authenticator {
             return;
         }
 
-        if (outcome instanceof OrganizationSelectionDecision.Refused refused) {
-            LOG.infof("organization selector: refusing %s: %s", user.getUsername(), refused.reason());
-            Response challenge = context.form()
-                    .setError(refused.reason())
-                    .createErrorPage(Response.Status.FORBIDDEN);
-            context.failure(AuthenticationFlowError.ACCESS_DENIED, challenge);
-            return;
-        }
-
-        // Undecided: an administrator - their own screen, a later slice's
-        // concern, is what decides this, not this authenticator.
-        // Proceeding unchanged is the deliberate no-op, not an oversight.
-        context.success();
+        // Refused.
+        OrganizationSelectionDecision.Refused refused = (OrganizationSelectionDecision.Refused) outcome;
+        LOG.infof("organization selector: refusing %s: %s", user.getUsername(), refused.reason());
+        Response challenge = context.form()
+                .setError(refused.reason())
+                .createErrorPage(Response.Status.FORBIDDEN);
+        context.failure(AuthenticationFlowError.ACCESS_DENIED, challenge);
     }
 
     /**

--- a/apps/keycloak-org-selector/src/main/resources/theme/cerbos-poc/login/select-organization.ftl
+++ b/apps/keycloak-org-selector/src/main/resources/theme/cerbos-poc/login/select-organization.ftl
@@ -13,11 +13,24 @@
             <#list organizations as organization>
                 <div class="${properties.kcFormGroupClass!}">
                     <label class="${properties.kcLabelClass!}">
-                        <input type="radio" name="organization" value="${organization}"<#if organization?index == 0> checked="checked"</#if>/>
+                        <input type="radio" name="organization" value="${organization}"<#if organization?index == 0 && !offerTenantWide> checked="checked"</#if>/>
                         ${organization}
                     </label>
                 </div>
             </#list>
+            <#-- issue #81: an administrator's additional entry, yielding a
+                 session with no active hospital at all. Never shown to a
+                 user who is not an administrator - action() also re-checks
+                 that server-side, since a form field is only ever a
+                 convenience, not the thing that makes a choice trustworthy. -->
+            <#if offerTenantWide>
+                <div class="${properties.kcFormGroupClass!}">
+                    <label class="${properties.kcLabelClass!}">
+                        <input type="radio" name="organization" value="${tenantWideValue}" checked="checked"/>
+                        Tenant-wide (all hospitals)
+                    </label>
+                </div>
+            </#if>
             <div class="${properties.kcFormGroupClass!}">
                 <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!}"
                        type="submit" value="${msg("doSubmit")}"/>

--- a/apps/keycloak-org-selector/src/test/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecisionTest.java
+++ b/apps/keycloak-org-selector/src/test/java/org/cerbospoc/keycloak/orgselector/OrganizationSelectionDecisionTest.java
@@ -1,8 +1,10 @@
 package org.cerbospoc.keycloak.orgselector;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,7 +12,6 @@ import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.NeedsSel
 import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.Outcome;
 import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.Refused;
 import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.Selected;
-import org.cerbospoc.keycloak.orgselector.OrganizationSelectionDecision.Undecided;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -50,12 +51,13 @@ class OrganizationSelectionDecisionTest {
     }
 
     @Test
-    void moreThanOneMembershipOffersASelectionAmongExactlyThem() {
+    void moreThanOneMembershipOffersASelectionAmongExactlyThemWithNoTenantWideEntry() {
         Outcome outcome = OrganizationSelectionDecision.decide(
                 List.of("north-hospital", "south-hospital"), false, Optional.empty());
 
         NeedsSelection needsSelection = assertInstanceOf(NeedsSelection.class, outcome);
         assertEquals(List.of("north-hospital", "south-hospital"), needsSelection.options());
+        assertFalse(needsSelection.offerTenantWide(), "an ordinary user's screen offers no tenant-wide entry");
     }
 
     @Test
@@ -71,33 +73,43 @@ class OrganizationSelectionDecisionTest {
     }
 
     @Test
-    void anAdministratorIsUndecidedForTheScreenEvenWithExactlyOneMembership() {
+    void anAdministratorIsOfferedTheScreenWithATenantWideEntryEvenWithExactlyOneMembership() {
         // The tenant-wide choice has to remain available to an
         // administrator, so a single membership must not pre-empt it the
         // way it would for an ordinary user.
         Outcome outcome = OrganizationSelectionDecision.decide(
                 List.of("north-hospital"), true, Optional.empty());
 
-        assertInstanceOf(Undecided.class, outcome);
+        NeedsSelection needsSelection = assertInstanceOf(NeedsSelection.class, outcome);
+        assertEquals(List.of("north-hospital"), needsSelection.options());
+        assertTrue(needsSelection.offerTenantWide());
     }
 
     @Test
-    void anAdministratorWithNoMembershipIsUndecidedForTheScreenRatherThanRefused() {
+    void anAdministratorWithNoMembershipIsOfferedOnlyTheTenantWideEntryRatherThanRefused() {
         Outcome outcome = OrganizationSelectionDecision.decide(List.of(), true, Optional.empty());
 
-        assertInstanceOf(Undecided.class, outcome);
+        NeedsSelection needsSelection = assertInstanceOf(NeedsSelection.class, outcome);
+        assertEquals(List.of(), needsSelection.options());
+        assertTrue(needsSelection.offerTenantWide());
     }
 
     @Test
-    void anAdministratorWithMultipleMembershipsIsUndecidedRatherThanOfferedTheMembershipsScreen() {
-        // Issue #80's screen only ever lists memberships, with no
-        // tenant-wide entry - not what an administrator's own screen (a
-        // later slice) has to offer, so this stays Undecided rather than
-        // NeedsSelection.
+    void anAdministratorWithMultipleMembershipsIsOfferedThemPlusTheTenantWideEntry() {
         Outcome outcome = OrganizationSelectionDecision.decide(
                 List.of("north-hospital", "south-hospital"), true, Optional.empty());
 
-        assertInstanceOf(Undecided.class, outcome);
+        NeedsSelection needsSelection = assertInstanceOf(NeedsSelection.class, outcome);
+        assertEquals(List.of("north-hospital", "south-hospital"), needsSelection.options());
+        assertTrue(needsSelection.offerTenantWide());
+    }
+
+    @Test
+    void aSelectionWithNoTenantWideEntryRequiresAtLeastTwoOptions() {
+        // The single-membership and no-membership cases are Selected/Refused,
+        // never a one-option screen with nothing else to offer.
+        assertThrows(IllegalArgumentException.class,
+                () -> new OrganizationSelectionDecision.NeedsSelection(List.of("north-hospital"), false));
     }
 
     @Test

--- a/deploy/cerbos/policies/_schemas/principal.json
+++ b/deploy/cerbos/policies/_schemas/principal.json
@@ -12,7 +12,7 @@
     },
     "hospitalId": {
       "type": "string",
-      "minLength": 1
+      "description": "The active organization alias, or an empty string for a tenant-wide administrator session (issue #80/#81) - never absent: an omitted hospitalId is a malformed request, an empty one is a deliberate, distinct fact a policy can and must read."
     },
     "idpRoles": {
       "type": "array",

--- a/deploy/cerbos/policies/resources/account.yaml
+++ b/deploy/cerbos/policies/resources/account.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/activity_definition.yaml
+++ b/deploy/cerbos/policies/resources/activity_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/actor_definition.yaml
+++ b/deploy/cerbos/policies/resources/actor_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/administrable_product_definition.yaml
+++ b/deploy/cerbos/policies/resources/administrable_product_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/adverse_event.yaml
+++ b/deploy/cerbos/policies/resources/adverse_event.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/allergy_intolerance.yaml
+++ b/deploy/cerbos/policies/resources/allergy_intolerance.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/appointment.yaml
+++ b/deploy/cerbos/policies/resources/appointment.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/appointment_response.yaml
+++ b/deploy/cerbos/policies/resources/appointment_response.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/artifact_assessment.yaml
+++ b/deploy/cerbos/policies/resources/artifact_assessment.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/audit_event.yaml
+++ b/deploy/cerbos/policies/resources/audit_event.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/basic.yaml
+++ b/deploy/cerbos/policies/resources/basic.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/binary.yaml
+++ b/deploy/cerbos/policies/resources/binary.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/biologically_derived_product.yaml
+++ b/deploy/cerbos/policies/resources/biologically_derived_product.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/biologically_derived_product_dispense.yaml
+++ b/deploy/cerbos/policies/resources/biologically_derived_product_dispense.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/body_structure.yaml
+++ b/deploy/cerbos/policies/resources/body_structure.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/bundle.yaml
+++ b/deploy/cerbos/policies/resources/bundle.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/capability_statement.yaml
+++ b/deploy/cerbos/policies/resources/capability_statement.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/care_plan.yaml
+++ b/deploy/cerbos/policies/resources/care_plan.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/care_team.yaml
+++ b/deploy/cerbos/policies/resources/care_team.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/charge_item.yaml
+++ b/deploy/cerbos/policies/resources/charge_item.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/charge_item_definition.yaml
+++ b/deploy/cerbos/policies/resources/charge_item_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/citation.yaml
+++ b/deploy/cerbos/policies/resources/citation.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/claim.yaml
+++ b/deploy/cerbos/policies/resources/claim.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/claim_response.yaml
+++ b/deploy/cerbos/policies/resources/claim_response.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/clinical_impression.yaml
+++ b/deploy/cerbos/policies/resources/clinical_impression.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/clinical_use_definition.yaml
+++ b/deploy/cerbos/policies/resources/clinical_use_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/code_system.yaml
+++ b/deploy/cerbos/policies/resources/code_system.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/communication.yaml
+++ b/deploy/cerbos/policies/resources/communication.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/communication_request.yaml
+++ b/deploy/cerbos/policies/resources/communication_request.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/compartment_definition.yaml
+++ b/deploy/cerbos/policies/resources/compartment_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/composition.yaml
+++ b/deploy/cerbos/policies/resources/composition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/concept_map.yaml
+++ b/deploy/cerbos/policies/resources/concept_map.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/condition.yaml
+++ b/deploy/cerbos/policies/resources/condition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/consent.yaml
+++ b/deploy/cerbos/policies/resources/consent.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/contract.yaml
+++ b/deploy/cerbos/policies/resources/contract.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/coverage.yaml
+++ b/deploy/cerbos/policies/resources/coverage.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/coverage_eligibility_request.yaml
+++ b/deploy/cerbos/policies/resources/coverage_eligibility_request.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/coverage_eligibility_response.yaml
+++ b/deploy/cerbos/policies/resources/coverage_eligibility_response.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/detected_issue.yaml
+++ b/deploy/cerbos/policies/resources/detected_issue.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/device.yaml
+++ b/deploy/cerbos/policies/resources/device.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/device_association.yaml
+++ b/deploy/cerbos/policies/resources/device_association.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/device_definition.yaml
+++ b/deploy/cerbos/policies/resources/device_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/device_dispense.yaml
+++ b/deploy/cerbos/policies/resources/device_dispense.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/device_metric.yaml
+++ b/deploy/cerbos/policies/resources/device_metric.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/device_request.yaml
+++ b/deploy/cerbos/policies/resources/device_request.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/device_usage.yaml
+++ b/deploy/cerbos/policies/resources/device_usage.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/diagnostic_report.yaml
+++ b/deploy/cerbos/policies/resources/diagnostic_report.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/document_reference.yaml
+++ b/deploy/cerbos/policies/resources/document_reference.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/encounter.yaml
+++ b/deploy/cerbos/policies/resources/encounter.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/encounter_history.yaml
+++ b/deploy/cerbos/policies/resources/encounter_history.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/endpoint.yaml
+++ b/deploy/cerbos/policies/resources/endpoint.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/enrollment_request.yaml
+++ b/deploy/cerbos/policies/resources/enrollment_request.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/enrollment_response.yaml
+++ b/deploy/cerbos/policies/resources/enrollment_response.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/episode_of_care.yaml
+++ b/deploy/cerbos/policies/resources/episode_of_care.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/evidence.yaml
+++ b/deploy/cerbos/policies/resources/evidence.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/evidence_report.yaml
+++ b/deploy/cerbos/policies/resources/evidence_report.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/evidence_variable.yaml
+++ b/deploy/cerbos/policies/resources/evidence_variable.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/example_scenario.yaml
+++ b/deploy/cerbos/policies/resources/example_scenario.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/explanation_of_benefit.yaml
+++ b/deploy/cerbos/policies/resources/explanation_of_benefit.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/family_member_history.yaml
+++ b/deploy/cerbos/policies/resources/family_member_history.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/flag.yaml
+++ b/deploy/cerbos/policies/resources/flag.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/genomic_study.yaml
+++ b/deploy/cerbos/policies/resources/genomic_study.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/goal.yaml
+++ b/deploy/cerbos/policies/resources/goal.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/graph_definition.yaml
+++ b/deploy/cerbos/policies/resources/graph_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/group.yaml
+++ b/deploy/cerbos/policies/resources/group.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/guidance_response.yaml
+++ b/deploy/cerbos/policies/resources/guidance_response.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/healthcare_service.yaml
+++ b/deploy/cerbos/policies/resources/healthcare_service.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/imaging_selection.yaml
+++ b/deploy/cerbos/policies/resources/imaging_selection.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/imaging_study.yaml
+++ b/deploy/cerbos/policies/resources/imaging_study.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/immunization.yaml
+++ b/deploy/cerbos/policies/resources/immunization.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/immunization_evaluation.yaml
+++ b/deploy/cerbos/policies/resources/immunization_evaluation.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/immunization_recommendation.yaml
+++ b/deploy/cerbos/policies/resources/immunization_recommendation.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/implementation_guide.yaml
+++ b/deploy/cerbos/policies/resources/implementation_guide.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/ingredient.yaml
+++ b/deploy/cerbos/policies/resources/ingredient.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/insurance_plan.yaml
+++ b/deploy/cerbos/policies/resources/insurance_plan.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/inventory_item.yaml
+++ b/deploy/cerbos/policies/resources/inventory_item.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/inventory_report.yaml
+++ b/deploy/cerbos/policies/resources/inventory_report.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/invoice.yaml
+++ b/deploy/cerbos/policies/resources/invoice.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/linkage.yaml
+++ b/deploy/cerbos/policies/resources/linkage.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/list.yaml
+++ b/deploy/cerbos/policies/resources/list.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/location.yaml
+++ b/deploy/cerbos/policies/resources/location.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/manufactured_item_definition.yaml
+++ b/deploy/cerbos/policies/resources/manufactured_item_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/measure.yaml
+++ b/deploy/cerbos/policies/resources/measure.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/measure_report.yaml
+++ b/deploy/cerbos/policies/resources/measure_report.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/media.yaml
+++ b/deploy/cerbos/policies/resources/media.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/medication.yaml
+++ b/deploy/cerbos/policies/resources/medication.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/medication_administration.yaml
+++ b/deploy/cerbos/policies/resources/medication_administration.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/medication_dispense.yaml
+++ b/deploy/cerbos/policies/resources/medication_dispense.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/medication_knowledge.yaml
+++ b/deploy/cerbos/policies/resources/medication_knowledge.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/medication_request.yaml
+++ b/deploy/cerbos/policies/resources/medication_request.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/medication_statement.yaml
+++ b/deploy/cerbos/policies/resources/medication_statement.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/medicinal_product_definition.yaml
+++ b/deploy/cerbos/policies/resources/medicinal_product_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/message_definition.yaml
+++ b/deploy/cerbos/policies/resources/message_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/message_header.yaml
+++ b/deploy/cerbos/policies/resources/message_header.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/molecular_sequence.yaml
+++ b/deploy/cerbos/policies/resources/molecular_sequence.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/naming_system.yaml
+++ b/deploy/cerbos/policies/resources/naming_system.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/nutrition_intake.yaml
+++ b/deploy/cerbos/policies/resources/nutrition_intake.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/nutrition_order.yaml
+++ b/deploy/cerbos/policies/resources/nutrition_order.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/nutrition_product.yaml
+++ b/deploy/cerbos/policies/resources/nutrition_product.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/observation.yaml
+++ b/deploy/cerbos/policies/resources/observation.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/observation_definition.yaml
+++ b/deploy/cerbos/policies/resources/observation_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/operation_definition.yaml
+++ b/deploy/cerbos/policies/resources/operation_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/operation_outcome.yaml
+++ b/deploy/cerbos/policies/resources/operation_outcome.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/organization.yaml
+++ b/deploy/cerbos/policies/resources/organization.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/organization_affiliation.yaml
+++ b/deploy/cerbos/policies/resources/organization_affiliation.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/packaged_product_definition.yaml
+++ b/deploy/cerbos/policies/resources/packaged_product_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/parameters.yaml
+++ b/deploy/cerbos/policies/resources/parameters.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/patient_record.yaml
+++ b/deploy/cerbos/policies/resources/patient_record.yaml
@@ -17,9 +17,24 @@ resourcePolicy:
 
   variables:
     local:
+      # issue #81: an empty hospital (a tenant-wide administrator session,
+      # issue #80) satisfies isolation against any hospital in the same
+      # tenant, because role_permission - what role_actions comes from -
+      # carries no hospital dimension at all (§8.1): a role means the same
+      # thing across the whole tenant, and tenant-wide is exactly "the
+      # tenant's own role grants, no single hospital". hospital_scoped is
+      # the opposite fact, used below to keep the directional half of the
+      # invariant explicit at the one place it could otherwise leak: a
+      # user grant is a hospital-narrowed assignment by construction
+      # (§8.1 gives user_permission_override a hospital_id column
+      # role_permission does not), so it must never apply to a session
+      # with no hospital, however isolated that session's tenant
+      # isolation check reads.
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -107,14 +122,19 @@ resourcePolicy:
 
     # User grants. Kept separate from role grants so the audit trail records
     # which source of authority allowed the action. Isolation is not repeated
-    # here: the mandatory deny above already covers every action.
+    # here: the mandatory deny above already covers every action. The
+    # variables.hospital_scoped conjunct is issue #81's directional
+    # invariant, defense in depth at the layer that decides: a user grant
+    # is a hospital-narrowed assignment, so it must never apply to a
+    # tenant-wide session, even though the assignment service's own query
+    # for one already returns nothing to grant.
     - name: grant_list_to_user
       actions: ["list"]
       effect: EFFECT_ALLOW
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -125,7 +145,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -136,7 +156,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -147,7 +167,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/payment_notice.yaml
+++ b/deploy/cerbos/policies/resources/payment_notice.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/payment_reconciliation.yaml
+++ b/deploy/cerbos/policies/resources/payment_reconciliation.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/permission.yaml
+++ b/deploy/cerbos/policies/resources/permission.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/person.yaml
+++ b/deploy/cerbos/policies/resources/person.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/plan_definition.yaml
+++ b/deploy/cerbos/policies/resources/plan_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/practitioner.yaml
+++ b/deploy/cerbos/policies/resources/practitioner.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/practitioner_role.yaml
+++ b/deploy/cerbos/policies/resources/practitioner_role.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/procedure.yaml
+++ b/deploy/cerbos/policies/resources/procedure.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/provenance.yaml
+++ b/deploy/cerbos/policies/resources/provenance.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/questionnaire.yaml
+++ b/deploy/cerbos/policies/resources/questionnaire.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/questionnaire_response.yaml
+++ b/deploy/cerbos/policies/resources/questionnaire_response.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/regulated_authorization.yaml
+++ b/deploy/cerbos/policies/resources/regulated_authorization.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/related_person.yaml
+++ b/deploy/cerbos/policies/resources/related_person.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/request_orchestration.yaml
+++ b/deploy/cerbos/policies/resources/request_orchestration.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/requirements.yaml
+++ b/deploy/cerbos/policies/resources/requirements.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/research_study.yaml
+++ b/deploy/cerbos/policies/resources/research_study.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/research_subject.yaml
+++ b/deploy/cerbos/policies/resources/research_subject.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/risk_assessment.yaml
+++ b/deploy/cerbos/policies/resources/risk_assessment.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/schedule.yaml
+++ b/deploy/cerbos/policies/resources/schedule.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/search_parameter.yaml
+++ b/deploy/cerbos/policies/resources/search_parameter.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/service_request.yaml
+++ b/deploy/cerbos/policies/resources/service_request.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/slot.yaml
+++ b/deploy/cerbos/policies/resources/slot.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/specimen.yaml
+++ b/deploy/cerbos/policies/resources/specimen.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/specimen_definition.yaml
+++ b/deploy/cerbos/policies/resources/specimen_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/structure_definition.yaml
+++ b/deploy/cerbos/policies/resources/structure_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/structure_map.yaml
+++ b/deploy/cerbos/policies/resources/structure_map.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/subscription.yaml
+++ b/deploy/cerbos/policies/resources/subscription.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/subscription_status.yaml
+++ b/deploy/cerbos/policies/resources/subscription_status.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/subscription_topic.yaml
+++ b/deploy/cerbos/policies/resources/subscription_topic.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/substance.yaml
+++ b/deploy/cerbos/policies/resources/substance.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/substance_definition.yaml
+++ b/deploy/cerbos/policies/resources/substance_definition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/substance_nucleic_acid.yaml
+++ b/deploy/cerbos/policies/resources/substance_nucleic_acid.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/substance_polymer.yaml
+++ b/deploy/cerbos/policies/resources/substance_polymer.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/substance_protein.yaml
+++ b/deploy/cerbos/policies/resources/substance_protein.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/substance_reference_information.yaml
+++ b/deploy/cerbos/policies/resources/substance_reference_information.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/substance_source_material.yaml
+++ b/deploy/cerbos/policies/resources/substance_source_material.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/supply_delivery.yaml
+++ b/deploy/cerbos/policies/resources/supply_delivery.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/supply_request.yaml
+++ b/deploy/cerbos/policies/resources/supply_request.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/task.yaml
+++ b/deploy/cerbos/policies/resources/task.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/terminology_capabilities.yaml
+++ b/deploy/cerbos/policies/resources/terminology_capabilities.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/test_plan.yaml
+++ b/deploy/cerbos/policies/resources/test_plan.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/test_report.yaml
+++ b/deploy/cerbos/policies/resources/test_report.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/test_script.yaml
+++ b/deploy/cerbos/policies/resources/test_script.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/transport.yaml
+++ b/deploy/cerbos/policies/resources/transport.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/value_set.yaml
+++ b/deploy/cerbos/policies/resources/value_set.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/verification_result.yaml
+++ b/deploy/cerbos/policies/resources/verification_result.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/resources/vision_prescription.yaml
+++ b/deploy/cerbos/policies/resources/vision_prescription.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -113,7 +115,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"create" in variables.user_grants'
+          expr: '"create" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -124,7 +126,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"list" in variables.user_grants'
+          expr: '"list" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -135,7 +137,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -146,7 +148,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -157,7 +159,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"delete" in variables.user_grants'
+          expr: '"delete" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -168,7 +170,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"assign" in variables.user_grants'
+          expr: '"assign" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/deploy/cerbos/policies/tests/account_test.yaml
+++ b/deploy/cerbos/policies/tests/account_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: account
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/activity_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/activity_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: activity_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/actor_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/actor_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: actor_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/administrable_product_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/administrable_product_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: administrable_product_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/adverse_event_test.yaml
+++ b/deploy/cerbos/policies/tests/adverse_event_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: adverse_event
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/allergy_intolerance_test.yaml
+++ b/deploy/cerbos/policies/tests/allergy_intolerance_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: allergy_intolerance
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/appointment_response_test.yaml
+++ b/deploy/cerbos/policies/tests/appointment_response_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: appointment_response
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/appointment_test.yaml
+++ b/deploy/cerbos/policies/tests/appointment_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: appointment
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/artifact_assessment_test.yaml
+++ b/deploy/cerbos/policies/tests/artifact_assessment_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: artifact_assessment
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/audit_event_test.yaml
+++ b/deploy/cerbos/policies/tests/audit_event_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: audit_event
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/basic_test.yaml
+++ b/deploy/cerbos/policies/tests/basic_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: basic
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/binary_test.yaml
+++ b/deploy/cerbos/policies/tests/binary_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: binary
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/biologically_derived_product_dispense_test.yaml
+++ b/deploy/cerbos/policies/tests/biologically_derived_product_dispense_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: biologically_derived_product_dispense
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/biologically_derived_product_test.yaml
+++ b/deploy/cerbos/policies/tests/biologically_derived_product_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: biologically_derived_product
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/body_structure_test.yaml
+++ b/deploy/cerbos/policies/tests/body_structure_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: body_structure
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/bundle_test.yaml
+++ b/deploy/cerbos/policies/tests/bundle_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: bundle
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/capability_statement_test.yaml
+++ b/deploy/cerbos/policies/tests/capability_statement_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: capability_statement
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/care_plan_test.yaml
+++ b/deploy/cerbos/policies/tests/care_plan_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: care_plan
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/care_team_test.yaml
+++ b/deploy/cerbos/policies/tests/care_team_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: care_team
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/charge_item_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/charge_item_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: charge_item_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/charge_item_test.yaml
+++ b/deploy/cerbos/policies/tests/charge_item_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: charge_item
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/citation_test.yaml
+++ b/deploy/cerbos/policies/tests/citation_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: citation
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/claim_response_test.yaml
+++ b/deploy/cerbos/policies/tests/claim_response_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: claim_response
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/claim_test.yaml
+++ b/deploy/cerbos/policies/tests/claim_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: claim
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/clinical_impression_test.yaml
+++ b/deploy/cerbos/policies/tests/clinical_impression_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: clinical_impression
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/clinical_use_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/clinical_use_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: clinical_use_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/code_system_test.yaml
+++ b/deploy/cerbos/policies/tests/code_system_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: code_system
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/communication_request_test.yaml
+++ b/deploy/cerbos/policies/tests/communication_request_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: communication_request
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/communication_test.yaml
+++ b/deploy/cerbos/policies/tests/communication_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: communication
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/compartment_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/compartment_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: compartment_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/composition_test.yaml
+++ b/deploy/cerbos/policies/tests/composition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: composition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/concept_map_test.yaml
+++ b/deploy/cerbos/policies/tests/concept_map_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: concept_map
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/condition_test.yaml
+++ b/deploy/cerbos/policies/tests/condition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: condition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/consent_test.yaml
+++ b/deploy/cerbos/policies/tests/consent_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: consent
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/contract_test.yaml
+++ b/deploy/cerbos/policies/tests/contract_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: contract
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/coverage_eligibility_request_test.yaml
+++ b/deploy/cerbos/policies/tests/coverage_eligibility_request_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: coverage_eligibility_request
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/coverage_eligibility_response_test.yaml
+++ b/deploy/cerbos/policies/tests/coverage_eligibility_response_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: coverage_eligibility_response
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/coverage_test.yaml
+++ b/deploy/cerbos/policies/tests/coverage_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: coverage
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/detected_issue_test.yaml
+++ b/deploy/cerbos/policies/tests/detected_issue_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: detected_issue
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/device_association_test.yaml
+++ b/deploy/cerbos/policies/tests/device_association_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: device_association
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/device_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/device_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: device_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/device_dispense_test.yaml
+++ b/deploy/cerbos/policies/tests/device_dispense_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: device_dispense
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/device_metric_test.yaml
+++ b/deploy/cerbos/policies/tests/device_metric_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: device_metric
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/device_request_test.yaml
+++ b/deploy/cerbos/policies/tests/device_request_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: device_request
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/device_test.yaml
+++ b/deploy/cerbos/policies/tests/device_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: device
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/device_usage_test.yaml
+++ b/deploy/cerbos/policies/tests/device_usage_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: device_usage
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/diagnostic_report_test.yaml
+++ b/deploy/cerbos/policies/tests/diagnostic_report_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: diagnostic_report
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/document_reference_test.yaml
+++ b/deploy/cerbos/policies/tests/document_reference_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: document_reference
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/encounter_history_test.yaml
+++ b/deploy/cerbos/policies/tests/encounter_history_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: encounter_history
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/encounter_test.yaml
+++ b/deploy/cerbos/policies/tests/encounter_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: encounter
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/endpoint_test.yaml
+++ b/deploy/cerbos/policies/tests/endpoint_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: endpoint
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/enrollment_request_test.yaml
+++ b/deploy/cerbos/policies/tests/enrollment_request_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: enrollment_request
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/enrollment_response_test.yaml
+++ b/deploy/cerbos/policies/tests/enrollment_response_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: enrollment_response
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/episode_of_care_test.yaml
+++ b/deploy/cerbos/policies/tests/episode_of_care_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: episode_of_care
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/evidence_report_test.yaml
+++ b/deploy/cerbos/policies/tests/evidence_report_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: evidence_report
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/evidence_test.yaml
+++ b/deploy/cerbos/policies/tests/evidence_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: evidence
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/evidence_variable_test.yaml
+++ b/deploy/cerbos/policies/tests/evidence_variable_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: evidence_variable
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/example_scenario_test.yaml
+++ b/deploy/cerbos/policies/tests/example_scenario_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: example_scenario
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/explanation_of_benefit_test.yaml
+++ b/deploy/cerbos/policies/tests/explanation_of_benefit_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: explanation_of_benefit
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/family_member_history_test.yaml
+++ b/deploy/cerbos/policies/tests/family_member_history_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: family_member_history
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/flag_test.yaml
+++ b/deploy/cerbos/policies/tests/flag_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: flag
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/genomic_study_test.yaml
+++ b/deploy/cerbos/policies/tests/genomic_study_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: genomic_study
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/goal_test.yaml
+++ b/deploy/cerbos/policies/tests/goal_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: goal
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/graph_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/graph_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: graph_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/group_test.yaml
+++ b/deploy/cerbos/policies/tests/group_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: group
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/guidance_response_test.yaml
+++ b/deploy/cerbos/policies/tests/guidance_response_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: guidance_response
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/healthcare_service_test.yaml
+++ b/deploy/cerbos/policies/tests/healthcare_service_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: healthcare_service
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/imaging_selection_test.yaml
+++ b/deploy/cerbos/policies/tests/imaging_selection_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: imaging_selection
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/imaging_study_test.yaml
+++ b/deploy/cerbos/policies/tests/imaging_study_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: imaging_study
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/immunization_evaluation_test.yaml
+++ b/deploy/cerbos/policies/tests/immunization_evaluation_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: immunization_evaluation
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/immunization_recommendation_test.yaml
+++ b/deploy/cerbos/policies/tests/immunization_recommendation_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: immunization_recommendation
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/immunization_test.yaml
+++ b/deploy/cerbos/policies/tests/immunization_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: immunization
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/implementation_guide_test.yaml
+++ b/deploy/cerbos/policies/tests/implementation_guide_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: implementation_guide
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/ingredient_test.yaml
+++ b/deploy/cerbos/policies/tests/ingredient_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: ingredient
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/insurance_plan_test.yaml
+++ b/deploy/cerbos/policies/tests/insurance_plan_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: insurance_plan
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/inventory_item_test.yaml
+++ b/deploy/cerbos/policies/tests/inventory_item_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: inventory_item
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/inventory_report_test.yaml
+++ b/deploy/cerbos/policies/tests/inventory_report_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: inventory_report
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/invoice_test.yaml
+++ b/deploy/cerbos/policies/tests/invoice_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: invoice
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/linkage_test.yaml
+++ b/deploy/cerbos/policies/tests/linkage_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: linkage
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/list_test.yaml
+++ b/deploy/cerbos/policies/tests/list_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: list
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/location_test.yaml
+++ b/deploy/cerbos/policies/tests/location_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: location
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/manufactured_item_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/manufactured_item_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: manufactured_item_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/measure_report_test.yaml
+++ b/deploy/cerbos/policies/tests/measure_report_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: measure_report
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/measure_test.yaml
+++ b/deploy/cerbos/policies/tests/measure_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: measure
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/media_test.yaml
+++ b/deploy/cerbos/policies/tests/media_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: media
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/medication_administration_test.yaml
+++ b/deploy/cerbos/policies/tests/medication_administration_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: medication_administration
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/medication_dispense_test.yaml
+++ b/deploy/cerbos/policies/tests/medication_dispense_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: medication_dispense
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/medication_knowledge_test.yaml
+++ b/deploy/cerbos/policies/tests/medication_knowledge_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: medication_knowledge
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/medication_request_test.yaml
+++ b/deploy/cerbos/policies/tests/medication_request_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: medication_request
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/medication_statement_test.yaml
+++ b/deploy/cerbos/policies/tests/medication_statement_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: medication_statement
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/medication_test.yaml
+++ b/deploy/cerbos/policies/tests/medication_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: medication
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/medicinal_product_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/medicinal_product_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: medicinal_product_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/message_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/message_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: message_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/message_header_test.yaml
+++ b/deploy/cerbos/policies/tests/message_header_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: message_header
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/molecular_sequence_test.yaml
+++ b/deploy/cerbos/policies/tests/molecular_sequence_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: molecular_sequence
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/naming_system_test.yaml
+++ b/deploy/cerbos/policies/tests/naming_system_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: naming_system
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/nutrition_intake_test.yaml
+++ b/deploy/cerbos/policies/tests/nutrition_intake_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: nutrition_intake
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/nutrition_order_test.yaml
+++ b/deploy/cerbos/policies/tests/nutrition_order_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: nutrition_order
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/nutrition_product_test.yaml
+++ b/deploy/cerbos/policies/tests/nutrition_product_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: nutrition_product
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/observation_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/observation_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: observation_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/observation_test.yaml
+++ b/deploy/cerbos/policies/tests/observation_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: observation
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/operation_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/operation_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: operation_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/operation_outcome_test.yaml
+++ b/deploy/cerbos/policies/tests/operation_outcome_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: operation_outcome
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/organization_affiliation_test.yaml
+++ b/deploy/cerbos/policies/tests/organization_affiliation_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: organization_affiliation
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/organization_test.yaml
+++ b/deploy/cerbos/policies/tests/organization_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: organization
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/packaged_product_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/packaged_product_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: packaged_product_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/parameters_test.yaml
+++ b/deploy/cerbos/policies/tests/parameters_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: parameters
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/patient_record_test.yaml
+++ b/deploy/cerbos/policies/tests/patient_record_test.yaml
@@ -38,6 +38,19 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  # issue #81: an administrator's tenant-wide session (issue #80) - no
+  # active hospital at all, never an empty string standing in for "every
+  # hospital" by omission.
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   # Row 2: mandatory passes, user revokes, role grants.
   revoked_over_role_grant:
@@ -342,6 +355,56 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+
+  # issue #81: the tenant-wide case. A role grant carries no hospital
+  # dimension (§8.1), so a tenant-wide session reaches it regardless of
+  # which hospital the resource belongs to - "an empty hospital matches
+  # tenant-wide assignments". A user grant is hospital-narrowed by
+  # construction, so the same session must never reach it, whatever
+  # hospital the resource happens to belong to - "and never a
+  # hospital-narrowed one". Tenant isolation itself is not weakened: a
+  # tenant-wide session still belongs to exactly one tenant.
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["list", "read", "update", "delete"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["list", "read", "update", "delete"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["list", "read", "update", "delete"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           list: EFFECT_DENY
           read: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/payment_notice_test.yaml
+++ b/deploy/cerbos/policies/tests/payment_notice_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: payment_notice
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/payment_reconciliation_test.yaml
+++ b/deploy/cerbos/policies/tests/payment_reconciliation_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: payment_reconciliation
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/permission_test.yaml
+++ b/deploy/cerbos/policies/tests/permission_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: permission
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/person_test.yaml
+++ b/deploy/cerbos/policies/tests/person_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: person
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/plan_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/plan_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: plan_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/practitioner_role_test.yaml
+++ b/deploy/cerbos/policies/tests/practitioner_role_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: practitioner_role
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/practitioner_test.yaml
+++ b/deploy/cerbos/policies/tests/practitioner_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: practitioner
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/procedure_test.yaml
+++ b/deploy/cerbos/policies/tests/procedure_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: procedure
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/provenance_test.yaml
+++ b/deploy/cerbos/policies/tests/provenance_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: provenance
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/questionnaire_response_test.yaml
+++ b/deploy/cerbos/policies/tests/questionnaire_response_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: questionnaire_response
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/questionnaire_test.yaml
+++ b/deploy/cerbos/policies/tests/questionnaire_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: questionnaire
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/regulated_authorization_test.yaml
+++ b/deploy/cerbos/policies/tests/regulated_authorization_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: regulated_authorization
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/related_person_test.yaml
+++ b/deploy/cerbos/policies/tests/related_person_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: related_person
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/request_orchestration_test.yaml
+++ b/deploy/cerbos/policies/tests/request_orchestration_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: request_orchestration
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/requirements_test.yaml
+++ b/deploy/cerbos/policies/tests/requirements_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: requirements
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/research_study_test.yaml
+++ b/deploy/cerbos/policies/tests/research_study_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: research_study
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/research_subject_test.yaml
+++ b/deploy/cerbos/policies/tests/research_subject_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: research_subject
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/risk_assessment_test.yaml
+++ b/deploy/cerbos/policies/tests/risk_assessment_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: risk_assessment
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/schedule_test.yaml
+++ b/deploy/cerbos/policies/tests/schedule_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: schedule
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/search_parameter_test.yaml
+++ b/deploy/cerbos/policies/tests/search_parameter_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: search_parameter
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/service_request_test.yaml
+++ b/deploy/cerbos/policies/tests/service_request_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: service_request
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/slot_test.yaml
+++ b/deploy/cerbos/policies/tests/slot_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: slot
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/specimen_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/specimen_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: specimen_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/specimen_test.yaml
+++ b/deploy/cerbos/policies/tests/specimen_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: specimen
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/structure_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/structure_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: structure_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/structure_map_test.yaml
+++ b/deploy/cerbos/policies/tests/structure_map_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: structure_map
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/subscription_status_test.yaml
+++ b/deploy/cerbos/policies/tests/subscription_status_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: subscription_status
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/subscription_test.yaml
+++ b/deploy/cerbos/policies/tests/subscription_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: subscription
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/subscription_topic_test.yaml
+++ b/deploy/cerbos/policies/tests/subscription_topic_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: subscription_topic
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/substance_definition_test.yaml
+++ b/deploy/cerbos/policies/tests/substance_definition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: substance_definition
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/substance_nucleic_acid_test.yaml
+++ b/deploy/cerbos/policies/tests/substance_nucleic_acid_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: substance_nucleic_acid
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/substance_polymer_test.yaml
+++ b/deploy/cerbos/policies/tests/substance_polymer_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: substance_polymer
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/substance_protein_test.yaml
+++ b/deploy/cerbos/policies/tests/substance_protein_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: substance_protein
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/substance_reference_information_test.yaml
+++ b/deploy/cerbos/policies/tests/substance_reference_information_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: substance_reference_information
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/substance_source_material_test.yaml
+++ b/deploy/cerbos/policies/tests/substance_source_material_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: substance_source_material
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/substance_test.yaml
+++ b/deploy/cerbos/policies/tests/substance_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: substance
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/supply_delivery_test.yaml
+++ b/deploy/cerbos/policies/tests/supply_delivery_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: supply_delivery
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/supply_request_test.yaml
+++ b/deploy/cerbos/policies/tests/supply_request_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: supply_request
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/task_test.yaml
+++ b/deploy/cerbos/policies/tests/task_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: task
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/terminology_capabilities_test.yaml
+++ b/deploy/cerbos/policies/tests/terminology_capabilities_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: terminology_capabilities
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/test_plan_test.yaml
+++ b/deploy/cerbos/policies/tests/test_plan_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: test_plan
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/test_report_test.yaml
+++ b/deploy/cerbos/policies/tests/test_report_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: test_report
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/test_script_test.yaml
+++ b/deploy/cerbos/policies/tests/test_script_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: test_script
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/transport_test.yaml
+++ b/deploy/cerbos/policies/tests/transport_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: transport
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/value_set_test.yaml
+++ b/deploy/cerbos/policies/tests/value_set_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: value_set
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/verification_result_test.yaml
+++ b/deploy/cerbos/policies/tests/verification_result_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: verification_result
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/cerbos/policies/tests/vision_prescription_test.yaml
+++ b/deploy/cerbos/policies/tests/vision_prescription_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: vision_prescription
@@ -343,6 +353,54 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          create: EFFECT_ALLOW
+          list: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+          assign: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          create: EFFECT_DENY
+          list: EFFECT_DENY
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+          delete: EFFECT_DENY
+          assign: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["create", "list", "read", "update", "delete", "assign"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           create: EFFECT_DENY
           list: EFFECT_DENY

--- a/deploy/keycloak/realm-tenant-a.json
+++ b/deploy/keycloak/realm-tenant-a.json
@@ -20,7 +20,8 @@
         { "username": "user-auditor" },
         { "username": "user-clerk-granted" },
         { "username": "user-unassigned" },
-        { "username": "user-doctor-multi" }
+        { "username": "user-doctor-multi" },
+        { "username": "user-admin-clinician" }
       ]
     },
     {
@@ -220,6 +221,18 @@
       "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
       "realmRoles": ["admin"],
       "clientRoles": { "patient-app": ["administrator"] }
+    },
+    {
+      "id": "user-admin-clinician",
+      "username": "user-admin-clinician",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alex",
+      "lastName": "AdminClinician",
+      "email": "alex.adminclinician@example.test",
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "realmRoles": ["admin"],
+      "clientRoles": { "patient-app": ["administrator", "doctor"] }
     },
     {
       "id": "user-forger",

--- a/libs/cataloggen/policy.go
+++ b/libs/cataloggen/policy.go
@@ -32,9 +32,24 @@ func RenderPolicy(m *Manifest, entry ResourceEntry) string {
 
 	b.WriteString("  variables:\n")
 	b.WriteString("    local:\n")
+	// issue #81: an empty hospital (a tenant-wide administrator session,
+	// issue #80) satisfies isolation against any hospital in the same
+	// tenant, because role_permission - what role_actions comes from -
+	// carries no hospital dimension at all (§8.1): a role means the same
+	// thing across the whole tenant, and tenant-wide is exactly "the
+	// tenant's own role grants, no single hospital". hospital_scoped is
+	// the opposite fact, used below to keep the directional half of the
+	// invariant explicit at the one place it could otherwise leak: a user
+	// grant is a hospital-narrowed assignment by construction (§8.1 gives
+	// user_permission_override a hospital_id column precisely because it
+	// does not mean the same thing everywhere), so it must never apply to
+	// a session with no hospital, however isolated that session's tenant
+	// isolation check reads.
 	b.WriteString("      isolated: >-\n")
 	b.WriteString("        request.principal.attr.tenantId == request.resource.attr.tenantId &&\n")
-	b.WriteString("        request.principal.attr.hospitalId == request.resource.attr.hospitalId\n")
+	b.WriteString("        (request.principal.attr.hospitalId == \"\" ||\n")
+	b.WriteString("         request.principal.attr.hospitalId == request.resource.attr.hospitalId)\n")
+	b.WriteString("      hospital_scoped: request.principal.attr.hospitalId != \"\"\n")
 	b.WriteString("      role_actions: request.resource.attr.permissionContext.roleGrantedActions\n")
 	b.WriteString("      user_grants: request.resource.attr.permissionContext.userGrantedActions\n")
 	b.WriteString("      user_revokes: request.resource.attr.permissionContext.userRevokedActions\n")
@@ -79,7 +94,14 @@ func RenderPolicy(m *Manifest, entry ResourceEntry) string {
 		b.WriteString("      roles: [\"sys:permission-evaluator\"]\n")
 		b.WriteString("      condition:\n")
 		b.WriteString("        match:\n")
-		fmt.Fprintf(&b, "          expr: '%q in variables.user_grants'\n", action.Key)
+		// issue #81: a user grant is a hospital-narrowed assignment
+		// (§8.1's user_permission_override carries a hospital_id column
+		// role_permission does not), so variables.hospital_scoped keeps it
+		// from ever applying to a tenant-wide session - defense in depth
+		// at the one layer that decides, even though the assignment
+		// service's own query for a tenant-wide principal's hospital_id
+		// (an empty string) already matches no override row.
+		fmt.Fprintf(&b, "          expr: '%q in variables.user_grants && variables.hospital_scoped'\n", action.Key)
 		b.WriteString(ruleOutput())
 	}
 

--- a/libs/cataloggen/testdata/golden/policies/condition.yaml
+++ b/libs/cataloggen/testdata/golden/policies/condition.yaml
@@ -12,7 +12,9 @@ resourcePolicy:
     local:
       isolated: >-
         request.principal.attr.tenantId == request.resource.attr.tenantId &&
-        request.principal.attr.hospitalId == request.resource.attr.hospitalId
+        (request.principal.attr.hospitalId == "" ||
+         request.principal.attr.hospitalId == request.resource.attr.hospitalId)
+      hospital_scoped: request.principal.attr.hospitalId != ""
       role_actions: request.resource.attr.permissionContext.roleGrantedActions
       user_grants: request.resource.attr.permissionContext.userGrantedActions
       user_revokes: request.resource.attr.permissionContext.userRevokedActions
@@ -69,7 +71,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"read" in variables.user_grants'
+          expr: '"read" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'
@@ -80,7 +82,7 @@ resourcePolicy:
       roles: ["sys:permission-evaluator"]
       condition:
         match:
-          expr: '"update" in variables.user_grants'
+          expr: '"update" in variables.user_grants && variables.hospital_scoped'
       output:
         when:
           ruleActivated: '"fired"'

--- a/libs/cataloggen/testdata/golden/tests/condition_test.yaml
+++ b/libs/cataloggen/testdata/golden/tests/condition_test.yaml
@@ -37,6 +37,16 @@ principals:
       idpRoles:
         - "kc:tenant-a:patient-app:doctor"
 
+  administrator_tenant_wide:
+    id: idp-user-777
+    roles:
+      - "sys:permission-evaluator"
+    attr:
+      tenantId: tenant-a
+      hospitalId: ""
+      idpRoles:
+        - "kc:tenant-a:patient-app:administrator"
+
 resources:
   revoked_over_role_grant:
     kind: condition
@@ -303,6 +313,42 @@ tests:
     expected:
       - principal: doctor_of_other_hospital
         resource: inherited_with_role_grant
+        actions:
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+
+  - name: a tenant-wide session reaches a role grant in any hospital of its tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_hospital_record]
+      actions: ["read", "update"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_hospital_record
+        actions:
+          read: EFFECT_ALLOW
+          update: EFFECT_ALLOW
+
+  - name: a tenant-wide session cannot reach a hospital-narrowed user grant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [user_granted_without_role_grant]
+      actions: ["read", "update"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: user_granted_without_role_grant
+        actions:
+          read: EFFECT_DENY
+          update: EFFECT_DENY
+
+  - name: a tenant-wide session is still denied outside its own tenant
+    input:
+      principals: [administrator_tenant_wide]
+      resources: [other_tenant_record]
+      actions: ["read", "update"]
+    expected:
+      - principal: administrator_tenant_wide
+        resource: other_tenant_record
         actions:
           read: EFFECT_DENY
           update: EFFECT_DENY

--- a/libs/cataloggen/tests.go
+++ b/libs/cataloggen/tests.go
@@ -104,6 +104,19 @@ func RenderPrecedenceTest(m *Manifest, entry ResourceEntry) string {
 	b.WriteString("      idpRoles:\n")
 	b.WriteString("        - \"kc:tenant-a:patient-app:doctor\"\n\n")
 
+	// issue #81: an administrator's tenant-wide session (issue #80) - no
+	// active hospital at all, never an empty string standing in for "every
+	// hospital" by omission.
+	b.WriteString("  administrator_tenant_wide:\n")
+	b.WriteString("    id: idp-user-777\n")
+	b.WriteString("    roles:\n")
+	b.WriteString("      - \"sys:permission-evaluator\"\n")
+	b.WriteString("    attr:\n")
+	b.WriteString("      tenantId: tenant-a\n")
+	b.WriteString("      hospitalId: \"\"\n")
+	b.WriteString("      idpRoles:\n")
+	b.WriteString("        - \"kc:tenant-a:patient-app:administrator\"\n\n")
+
 	b.WriteString("resources:\n")
 
 	writeResource := func(name, tenant, hospital, status string, role, userGrant, userRevoke []string) {
@@ -175,6 +188,21 @@ func RenderPrecedenceTest(m *Manifest, entry ResourceEntry) string {
 		"doctor", "other_hospital_record", actions, "EFFECT_DENY")
 	writeCase("a principal from another hospital is denied every action",
 		"doctor_of_other_hospital", "inherited_with_role_grant", actions, "EFFECT_DENY")
+
+	// issue #81: the tenant-wide case. A role grant carries no hospital
+	// dimension (§8.1), so a tenant-wide session reaches it regardless of
+	// which hospital the resource belongs to - "an empty hospital matches
+	// tenant-wide assignments". A user grant is hospital-narrowed by
+	// construction, so the same session must never reach it, whatever
+	// hospital the resource happens to belong to - "and never a
+	// hospital-narrowed one". Tenant isolation itself is not weakened:
+	// a tenant-wide session still belongs to exactly one tenant.
+	writeCase("a tenant-wide session reaches a role grant in any hospital of its tenant",
+		"administrator_tenant_wide", "other_hospital_record", actions, "EFFECT_ALLOW")
+	writeCase("a tenant-wide session cannot reach a hospital-narrowed user grant",
+		"administrator_tenant_wide", "user_granted_without_role_grant", actions, "EFFECT_DENY")
+	writeCase("a tenant-wide session is still denied outside its own tenant",
+		"administrator_tenant_wide", "other_tenant_record", actions, "EFFECT_DENY")
 
 	return strings.TrimRight(b.String(), "\n") + "\n"
 }

--- a/scripts/tests/org-selector-e2e.sh
+++ b/scripts/tests/org-selector-e2e.sh
@@ -188,26 +188,102 @@ fi
 rm -f "${jar}"
 
 echo
-echo "--- an administrator is undecided (the selection screen, not this authenticator) ---"
+echo "--- an administrator sees a tenant-wide entry; a non-administrator never does (issue #81) ---"
 
 jar="$(mktemp)"
 login_page tenant-a patient-app "${jar}"
 action="$(login_action "${login_body}")"
-submit_credentials "${action}" "${jar}" user-admin demo-password
+form_body="$(curl -sS --max-time 10 -c "${jar}" -b "${jar}" \
+  --data-urlencode "username=user-admin" --data-urlencode "password=demo-password" \
+  "${action}")"
+if grep -qF "Tenant-wide" <<<"${form_body}"; then
+  pass "a user holding the admin realm role sees a tenant-wide entry"
+else
+  fail "a user holding the admin realm role sees a tenant-wide entry (screen was: ${form_body})"
+fi
+selection_action="$(login_action "${form_body}")"
+
+jar2="$(mktemp)"
+login_page tenant-a patient-app "${jar2}"
+action2="$(login_action "${login_body}")"
+doctor_form="$(curl -sS --max-time 10 -c "${jar2}" -b "${jar2}" \
+  --data-urlencode "username=user-doctor-multi" --data-urlencode "password=demo-password" \
+  "${action2}")"
+if grep -qF "Tenant-wide" <<<"${doctor_form}"; then
+  fail "a user without the admin realm role never sees the tenant-wide entry (screen was: ${doctor_form})"
+else
+  pass "a user without the admin realm role never sees the tenant-wide entry"
+fi
+rm -f "${jar2}"
+
+echo
+echo "--- an administrator with no organization memberships can still log in, choosing tenant-wide ---"
+
+submit_organization "${selection_action}" "${jar}" ""
 code="$(code_from_redirect)"
 if [[ -z "${code}" ]]; then
-  fail "an administrator still reaches a code (headers were: ${login_headers})"
+  fail "an administrator choosing tenant-wide reaches a code (headers were: ${login_headers})"
 else
   response="$(token_from_code tenant-a patient-app "${code}")"
   access_token="$(jq -r '.access_token // empty' <<<"${response}")"
   organization_claim="$(claim_of "${access_token}" '.organization // "absent"')"
   if [[ "${organization_claim}" == "absent" ]]; then
-    pass "an administrator's login proceeds with no organization forced, unchanged by this authenticator"
+    pass "a tenant-wide session carries no active hospital"
   else
-    fail "an administrator's login proceeds with no organization forced (organization claim was '${organization_claim}')"
+    fail "a tenant-wide session carries no active hospital (organization claim was '${organization_claim}')"
   fi
 fi
 rm -f "${jar}"
+
+echo
+echo "--- an administrator who also belongs to organizations can still choose one of them ---"
+
+jar="$(mktemp)"
+login_page tenant-a patient-app "${jar}"
+action="$(login_action "${login_body}")"
+form_body="$(curl -sS --max-time 10 -c "${jar}" -b "${jar}" \
+  --data-urlencode "username=user-admin-clinician" --data-urlencode "password=demo-password" \
+  "${action}")"
+selection_action="$(login_action "${form_body}")"
+submit_organization "${selection_action}" "${jar}" "north-hospital"
+code="$(code_from_redirect)"
+if [[ -z "${code}" ]]; then
+  fail "an administrator choosing a hospital reaches a code (headers were: ${login_headers})"
+else
+  response="$(token_from_code tenant-a patient-app "${code}")"
+  access_token="$(jq -r '.access_token // empty' <<<"${response}")"
+  organization_claim="$(claim_of "${access_token}" '.organization | tojson')"
+  if [[ "${organization_claim}" == '["north-hospital"]' ]]; then
+    pass "an administrator who also belongs to organizations can choose one and receive an ordinary hospital-scoped session"
+  else
+    fail "an administrator can choose a hospital instead of tenant-wide (organization claim was '${organization_claim}')"
+  fi
+fi
+rm -f "${jar}"
+
+echo
+echo "--- a non-administrator cannot forge a tenant-wide submission ---"
+
+jar="$(mktemp)"
+login_page tenant-a patient-app "${jar}"
+action="$(login_action "${login_body}")"
+form_body="$(curl -sS --max-time 10 -c "${jar}" -b "${jar}" \
+  --data-urlencode "username=user-doctor-multi" --data-urlencode "password=demo-password" \
+  "${action}")"
+selection_action="$(login_action "${form_body}")"
+forged_status="$(curl -sS --max-time 10 -o /tmp/org-selector-forged.html -w '%{http_code}' \
+  -c "${jar}" -b "${jar}" --data-urlencode "organization=" "${selection_action}")"
+if [[ "${forged_status}" == "403" ]]; then
+  pass "a non-administrator cannot forge a tenant-wide submission"
+else
+  fail "a non-administrator cannot forge a tenant-wide submission (HTTP ${forged_status})"
+fi
+if grep -qF "only available to an administrator" /tmp/org-selector-forged.html; then
+  pass "the rejection names an explicit reason"
+else
+  fail "the rejection names an explicit reason (page did not contain it)"
+fi
+rm -f "${jar}" /tmp/org-selector-forged.html
 
 echo
 echo "--- a member of more than one organization sees the selection screen (issue #80) ---"


### PR DESCRIPTION
## What changed

Issue #81: the administrator tenant-wide session issue #80's screen now offers unconditionally, and the policy semantics that make "no hospital" safe rather than merely possible.

### Keycloak side

- `OrganizationSelectionDecision.NeedsSelection` gains `offerTenantWide`. An administrator now always reaches `NeedsSelection` - even with zero or exactly one membership - because the tenant-wide choice must remain available, not pre-empted by the auto-select rule meant for ordinary users. The prior `Undecided` outcome is gone: every administrator case now has a real outcome.
- A new `SelectedTenantWide` outcome, distinct from `Selected` with an empty alias, so the authenticator logs "chose tenant-wide" as its own fact (the audit-trail acceptance criterion).
- `select-organization.ftl` renders an additional radio option, encoded as the empty string - the same representation `hospitalId` already uses for tenant-wide everywhere else in this system. `action()` re-derives administrator status from Keycloak's own role records before ever honouring a tenant-wide submission, refusing outright a submission from a non-administrator.

### Policy side (`libs/cataloggen/policy.go`, applied to both the generated catalog and the hand-maintained `patient_record.yaml`)

- `isolated` now reads "tenant matches, and (hospital matches OR the principal has no hospital at all)": `role_permission` (what `role_actions` comes from) carries no hospital dimension (§8.1), so a tenant-wide session's role grants reach any hospital in its own tenant - "an empty hospital matches tenant-wide assignments".
- A new `hospital_scoped` variable additionally gates every `grant_*_to_user` rule: `user_permission_override` is hospital-narrowed by construction, so a user grant must never apply to a session with no hospital - "and never a hospital-narrowed one" - defense in depth at the layer that decides, even though the assignment service's own query for a tenant-wide principal already returns nothing to grant.
- `deploy/cerbos/policies/_schemas/principal.json` drops `hospitalId`'s `minLength: 1` (kept required) so a tenant-wide principal's empty `hospitalId` is a valid, distinct fact a policy can read, not a schema violation.

The exhaustive matrix gains an `administrator_tenant_wide` principal and three cases per resource: a role grant in another hospital of the same tenant is reached, a hospital-narrowed user grant is not, and cross-tenant isolation still holds. **All 14087 policy tests pass** (`make policy-test`).

## How each acceptance criterion is met

- [x] A user holding the realm role `admin` sees a tenant-wide entry; a user without it never sees it - verified end to end.
- [x] An administrator who also belongs to organizations can still choose one and receive an ordinary hospital-scoped session - new `user-admin-clinician` demo user, verified end to end.
- [x] An administrator with no organization memberships can still log in, choosing tenant-wide - verified end to end.
- [x] A tenant-wide session carries no active hospital and is accepted by the decision service - the `isolated` policy change plus the existing tokenverifier tenant-wide path (#78).
- [x] The exhaustive policy matrix is extended with the tenant-wide case per resource-action; `make policy-test` passes (14087/14087).
- [x] A focused suite asserts a tenant-wide session cannot use a hospital-narrowed assignment, and a hospital-scoped session cannot use another hospital's - the three new cases per resource, `hospital_scoped` gate.
- [x] No precedence ordering in Go; the architecture test still passes - unaffected, verified (`tests/architecture`).
- [x] Choosing tenant-wide is distinguishable in the audit trail - `SelectedTenantWide` logs "chose tenant-wide" as its own fact, separate from an ordinary selection.

## Verified locally before ever reaching CI

- `mvn test` (JDK 17): all `OrganizationSelectionDecision` cases pass.
- `make policy-test`: 14087/14087 Cerbos policy tests pass, including the new tenant-wide cases across all 312 resource types.
- `make catalog-check`: the regenerated catalog matches the committed tree.
- A real Keycloak container, built from the actual image, driven through genuine authorization-code logins:
  - `user-admin` (no memberships) sees only the tenant-wide entry, chooses it, and the resulting token carries no `organization` claim;
  - `user-doctor-multi` (a non-administrator) never sees a tenant-wide entry, and a forged tenant-wide submission from them is refused (HTTP 403, explicit reason);
  - `user-admin-clinician` (an administrator who also belongs to `north-hospital`) sees both the membership and the tenant-wide entry, and choosing the membership yields an ordinary hospital-scoped token.

## Verified with

- `mvn test` (JDK 17) - all green.
- `make policy-test` - 14087/14087 + 3/3 (ADR-003 control).
- `make catalog-check` - matches.
- Real Docker builds and a real running Keycloak container, as above.
- `python3 scripts/tests/compose-contract.py`, `docker compose config -q` - unaffected, both satisfied.
- `bash scripts/go.sh tests/architecture test ./...` - unaffected, passes.
- CI (docker compose walking skeleton, architecture invariants, authorization schema on postgres, cerbos policy suite, nx affected).

Closes #81


Closes #81
