### PR TITLE
Console cross-links and deep-link survival through login (#82)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ smoke: ## Verify a running stack end to end
 	bash scripts/tests/identity-e2e.sh
 	bash scripts/tests/decision-e2e.sh
 	bash scripts/tests/org-selector-e2e.sh
+	bash scripts/tests/console-crosslinks-e2e.sh
 
 .PHONY: walkthrough
 walkthrough: ## Execute the README's guided walkthrough against a running deployment

--- a/apps/admin-console/src/app/auth/auth.guard.spec.ts
+++ b/apps/admin-console/src/app/auth/auth.guard.spec.ts
@@ -27,4 +27,15 @@ describe('authGuard', () => {
     expect(result).toBe(false);
     expect(auth.login).toHaveBeenCalledTimes(1);
   });
+
+  it('carries the requested URL into login, so a deep link survives (issue #82)', () => {
+    const auth = { isAuthenticated: () => false, login: vi.fn().mockResolvedValue(undefined) };
+    TestBed.configureTestingModule({ providers: [{ provide: AuthService, useValue: auth }] });
+
+    TestBed.runInInjectionContext(() =>
+      authGuard({} as never, { url: '/role-matrix' } as never),
+    );
+
+    expect(auth.login).toHaveBeenCalledWith('/role-matrix');
+  });
 });

--- a/apps/admin-console/src/app/auth/auth.guard.ts
+++ b/apps/admin-console/src/app/auth/auth.guard.ts
@@ -7,12 +7,16 @@ import { AuthService } from './auth.service';
  * Refuses navigation to any route it guards until AuthService has an
  * access token, sending the browser to Keycloak instead. Every route but
  * /callback is guarded (§9's "OIDC login").
+ *
+ * The requested URL travels with the redirect (issue #82): a deep link
+ * into the console must land on the exact path requested once login
+ * completes, not always on the shell's default route.
  */
-export const authGuard: CanActivateFn = () => {
+export const authGuard: CanActivateFn = (_route, state) => {
   const auth = inject(AuthService);
   if (auth.isAuthenticated()) {
     return true;
   }
-  void auth.login();
+  void auth.login(state.url);
   return false;
 };

--- a/apps/admin-console/src/app/auth/auth.service.ts
+++ b/apps/admin-console/src/app/auth/auth.service.ts
@@ -9,6 +9,7 @@ import { TokenClaims, decodeAccessToken } from './token-claims';
 
 const VERIFIER_KEY = 'admin-console:pkce-verifier';
 const STATE_KEY = 'admin-console:pkce-state';
+const RETURN_TO_KEY = 'admin-console:return-to';
 
 /**
  * The Admin Console's OIDC login (§9's "Admin Console shell, navigation
@@ -35,18 +36,37 @@ export class AuthService {
   readonly isAuthenticated = computed(() => this.accessTokenSignal() !== null);
   readonly claims = this.claimsSignal.asReadonly();
 
+  /**
+   * Keycloak's own administration console for this realm (issue #82): the
+   * two consoles are clients of the same realm sharing one SSO session, so
+   * this is a plain link, not a second login.
+   */
+  readonly keycloakConsoleUrl = computed(() => {
+    const issuerUrl = new URL(this.config.issuer);
+    const realm = issuerUrl.pathname.replace(/^\/realms\//, '');
+    return `${issuerUrl.origin}/admin/${realm}/console/`;
+  });
+
   accessToken(): string | null {
     return this.accessTokenSignal();
   }
 
-  /** Redirects the browser to Keycloak's authorization endpoint. */
-  async login(): Promise<void> {
+  /**
+   * Redirects the browser to Keycloak's authorization endpoint. returnTo,
+   * when given, is the in-app path to land on once login completes - a
+   * deep link into the console must survive the round trip rather than
+   * always landing on the shell's default route (issue #82).
+   */
+  async login(returnTo?: string): Promise<void> {
     const verifier = generateCodeVerifier();
     const state = generateState();
     const challenge = await deriveCodeChallenge(verifier);
 
     sessionStorage.setItem(VERIFIER_KEY, verifier);
     sessionStorage.setItem(STATE_KEY, state);
+    if (returnTo) {
+      sessionStorage.setItem(RETURN_TO_KEY, returnTo);
+    }
 
     const params = new URLSearchParams({
       response_type: 'code',
@@ -98,6 +118,17 @@ export class AuthService {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Reads and clears the path stashed by {@link login}, if any - the deep
+   * link a guarded route redirected away from. Read once: a stale value
+   * from an abandoned login attempt must not resurface on a later one.
+   */
+  consumeReturnTo(): string | null {
+    const returnTo = sessionStorage.getItem(RETURN_TO_KEY);
+    sessionStorage.removeItem(RETURN_TO_KEY);
+    return returnTo;
   }
 
   logout(): void {

--- a/apps/admin-console/src/app/auth/callback.spec.ts
+++ b/apps/admin-console/src/app/auth/callback.spec.ts
@@ -1,26 +1,34 @@
 import { provideLocationMocks } from '@angular/common/testing';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 
 import { AuthService } from './auth.service';
 import { Callback } from './callback';
 
 describe('Callback', () => {
-  function setUp(queryParams: Record<string, string>, handleCallback = vi.fn()) {
+  function setUp(
+    queryParams: Record<string, string>,
+    handleCallback = vi.fn(),
+    consumeReturnTo = vi.fn().mockReturnValue(null),
+  ) {
     TestBed.configureTestingModule({
       imports: [Callback],
       providers: [
         provideLocationMocks(),
+        // A wildcard route so navigateByUrl can actually recognise a deep
+        // link like /role-matrix; this suite is not exercising what those
+        // routes render, only where Callback sends the browser.
+        provideRouter([{ path: '**', children: [] }]),
         {
           provide: ActivatedRoute,
           useValue: {
             snapshot: { queryParamMap: convertToParamMap(queryParams) },
           },
         },
-        { provide: AuthService, useValue: { handleCallback, login: vi.fn() } },
+        { provide: AuthService, useValue: { handleCallback, login: vi.fn(), consumeReturnTo } },
       ],
     });
-    return { handleCallback };
+    return { handleCallback, consumeReturnTo };
   }
 
   it('exchanges the code and state for a token, then navigates to the shell', async () => {
@@ -33,6 +41,22 @@ describe('Callback', () => {
 
     expect(handleCallback).toHaveBeenCalledWith('auth-code-1', 'state-1');
     expect(TestBed.inject(Router).url).toEqual('/');
+  });
+
+  it('navigates to the deep link a guarded route redirected away from, when there is one', async () => {
+    const handleCallback = vi.fn().mockResolvedValue(true);
+    setUp(
+      { code: 'auth-code-1', state: 'state-1' },
+      handleCallback,
+      vi.fn().mockReturnValue('/role-matrix'),
+    );
+
+    const fixture = TestBed.createComponent(Callback);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await fixture.whenStable();
+
+    expect(TestBed.inject(Router).url).toEqual('/role-matrix');
   });
 
   it('shows a retry prompt when the exchange fails', async () => {

--- a/apps/admin-console/src/app/auth/callback.ts
+++ b/apps/admin-console/src/app/auth/callback.ts
@@ -43,7 +43,11 @@ export class Callback implements OnInit {
       this.failed.set(true);
       return;
     }
-    await this.router.navigateByUrl('/');
+    // A deep link the auth guard redirected away from survives here
+    // (issue #82); a login started from nowhere in particular - the
+    // login button, a stale bookmark to /callback - falls back to the
+    // shell's default route.
+    await this.router.navigateByUrl(this.auth.consumeReturnTo() ?? '/');
   }
 
   retry(): void {

--- a/apps/admin-console/src/app/auth/token-claims.spec.ts
+++ b/apps/admin-console/src/app/auth/token-claims.spec.ts
@@ -43,4 +43,22 @@ describe('decodeAccessToken', () => {
   it('rejects a value that is not a three-segment JWT', () => {
     expect(() => decodeAccessToken('not-a-jwt', 'patient-app')).toThrow();
   });
+
+  it('reads the tenant-wide realm role as isAdministrator (issue #78/#82)', () => {
+    const token = fakeJwt({ realm_access: { roles: ['admin'] } });
+
+    expect(decodeAccessToken(token, 'patient-app').isAdministrator).toBe(true);
+  });
+
+  it('is not an administrator when the realm role is absent', () => {
+    const token = fakeJwt({ realm_access: { roles: ['some-other-role'] } });
+
+    expect(decodeAccessToken(token, 'patient-app').isAdministrator).toBe(false);
+  });
+
+  it('is not an administrator when realm_access is absent entirely', () => {
+    const token = fakeJwt({});
+
+    expect(decodeAccessToken(token, 'patient-app').isAdministrator).toBe(false);
+  });
 });

--- a/apps/admin-console/src/app/auth/token-claims.ts
+++ b/apps/admin-console/src/app/auth/token-claims.ts
@@ -12,6 +12,13 @@ export interface TokenClaims {
   hospitalId: string;
   roles: string[];
   expiresAt: number;
+  /**
+   * Whether the token carries the tenant-wide realm role (issue #78's
+   * `admin`), read for display purposes only - e.g. issue #82's link to
+   * Keycloak's own administration console. Every administrative call
+   * still goes through the server, which verifies this independently.
+   */
+  isAdministrator: boolean;
 }
 
 /** Decodes a JWT's payload without verifying its signature. */
@@ -26,6 +33,7 @@ export function decodeAccessToken(token: string, clientId: string): TokenClaims 
     string,
     { roles?: string[] }
   >;
+  const realmAccess = (payload['realm_access'] ?? {}) as { roles?: string[] };
 
   return {
     subject: String(payload['sub'] ?? ''),
@@ -34,6 +42,7 @@ export function decodeAccessToken(token: string, clientId: string): TokenClaims 
     hospitalId: String(payload['hospital_id'] ?? ''),
     roles: resourceAccess[clientId]?.roles ?? [],
     expiresAt: Number(payload['exp'] ?? 0),
+    isAdministrator: (realmAccess.roles ?? []).includes('admin'),
   };
 }
 

--- a/apps/admin-console/src/app/shell/shell.html
+++ b/apps/admin-console/src/app/shell/shell.html
@@ -12,6 +12,11 @@
     <div class="shell-identity" data-testid="shell-identity">
       <span>{{ claims.username }}</span>
       <span>{{ claims.tenantId }} / {{ claims.hospitalId }}</span>
+      @if (claims.isAdministrator) {
+        <a [href]="auth.keycloakConsoleUrl()" data-testid="keycloak-console-link"
+          >Keycloak administration console</a
+        >
+      }
       <button type="button" (click)="logout()" data-testid="logout">Log out</button>
     </div>
   }

--- a/apps/admin-console/src/app/shell/shell.spec.ts
+++ b/apps/admin-console/src/app/shell/shell.spec.ts
@@ -28,7 +28,9 @@ describe('Shell', () => {
               hospitalId: 'hospital-1',
               roles: [],
               expiresAt: 0,
+              isAdministrator: false,
             }),
+            keycloakConsoleUrl: () => 'http://localhost:8081/admin/tenant-a/console/',
             logout,
           },
         },
@@ -47,6 +49,78 @@ describe('Shell', () => {
 
     (fixture.nativeElement.querySelector('[data-testid="logout"]') as HTMLButtonElement).click();
     expect(logout).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a link to Keycloak\'s administration console for an administrator', () => {
+    TestBed.configureTestingModule({
+      imports: [Shell],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: AuthService,
+          useValue: {
+            claims: () => ({
+              subject: 'admin-1',
+              username: 'admin',
+              tenantId: 'tenant-a',
+              hospitalId: '',
+              roles: [],
+              expiresAt: 0,
+              isAdministrator: true,
+            }),
+            keycloakConsoleUrl: () => 'http://localhost:8081/admin/tenant-a/console/',
+            logout: vi.fn(),
+          },
+        },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(Shell);
+    fixture.detectChanges();
+    TestBed.inject(HttpTestingController).expectOne('/api/ads/healthz').flush({ status: 'ok' });
+
+    const link = fixture.nativeElement.querySelector(
+      '[data-testid="keycloak-console-link"]',
+    ) as HTMLAnchorElement;
+    expect(link).toBeTruthy();
+    expect(link.href).toEqual('http://localhost:8081/admin/tenant-a/console/');
+  });
+
+  it('shows no Keycloak console link for a user who is not an administrator', () => {
+    TestBed.configureTestingModule({
+      imports: [Shell],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: AuthService,
+          useValue: {
+            claims: () => ({
+              subject: 'doctor-1',
+              username: 'doctor',
+              tenantId: 'tenant-a',
+              hospitalId: 'north-hospital',
+              roles: [],
+              expiresAt: 0,
+              isAdministrator: false,
+            }),
+            keycloakConsoleUrl: () => 'http://localhost:8081/admin/tenant-a/console/',
+            logout: vi.fn(),
+          },
+        },
+      ],
+    });
+
+    const fixture = TestBed.createComponent(Shell);
+    fixture.detectChanges();
+    TestBed.inject(HttpTestingController).expectOne('/api/ads/healthz').flush({ status: 'ok' });
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="keycloak-console-link"]'),
+    ).toBeNull();
   });
 
   it('shows no identity block before login completes', () => {

--- a/apps/keycloak-org-selector/src/main/resources/theme/cerbos-poc/login/select-organization.ftl
+++ b/apps/keycloak-org-selector/src/main/resources/theme/cerbos-poc/login/select-organization.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayMessage=true; section>
+<@layout.registrationLayout displayMessage=true displayInfo=true; section>
     <#if section = "header">
         Select your hospital
     <#elseif section = "form">
@@ -36,5 +36,9 @@
                        type="submit" value="${msg("doSubmit")}"/>
             </div>
         </form>
+    <#elseif section = "info">
+        <#-- issue #82: the two consoles share one SSO session, so this is
+             a plain navigation, not a second login. -->
+        <a id="kc-back-to-admin-console" href="${properties.adminConsoleUrl!}">Back to the Admin Console</a>
     </#if>
 </@layout.registrationLayout>

--- a/apps/keycloak-org-selector/src/main/resources/theme/cerbos-poc/login/theme.properties
+++ b/apps/keycloak-org-selector/src/main/resources/theme/cerbos-poc/login/theme.properties
@@ -4,3 +4,10 @@
 # every other page automatically.
 parent=keycloak.v2
 import=common/keycloak
+
+# issue #82: where the login theme's "back to the Admin Console" link
+# points. Overridable per deployment without touching the template itself;
+# the compose/k8s KC_SPI_THEME... environment convention is deliberately
+# not used here so this stays a plain theme property like every other one
+# the base theme already reads.
+adminConsoleUrl=http://localhost:4200

--- a/scripts/tests/console-crosslinks-e2e.sh
+++ b/scripts/tests/console-crosslinks-e2e.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Console cross-links and deep-link survival through login (issue #82): the
+# organization selector must never rewrite or override redirect_uri, proven
+# for a deep link into each console - the Admin Console's own client
+# (patient-app) and Keycloak's own administration console client
+# (security-admin-console) - the same way as the existing identity suites,
+# with curl and a cookie jar rather than a browser automation toolchain.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+# shellcheck source=scripts/tests/lib-token.sh
+source scripts/tests/lib-token.sh
+
+failures=0
+pass() { echo "ok   $1"; }
+fail() { echo "FAIL $1"; failures=$((failures + 1)); }
+
+command -v jq >/dev/null 2>&1 || { echo "console-crosslinks-e2e: jq is required" >&2; exit 1; }
+wait_for_keycloak || exit 1
+
+# Discovery's own issuer names the host Keycloak actually issues cookies
+# for (see org-selector-e2e.sh's comment on the same fix).
+BASE_URL="$(curl -sS --max-time 10 "${KEYCLOAK_URL}/realms/tenant-a/.well-known/openid-configuration" \
+  | jq -r '.issuer' | sed 's#/realms/tenant-a$##')"
+if [[ -z "${BASE_URL}" || "${BASE_URL}" == "null" ]]; then
+  echo "console-crosslinks-e2e: could not determine Keycloak's own hostname from discovery" >&2
+  exit 1
+fi
+
+# pkce_pair
+# Echoes "<verifier> <challenge>" for an S256 PKCE pair - only
+# security-admin-console, Keycloak's own built-in client, requires one.
+pkce_pair() {
+  python3 - <<'PY'
+import base64
+import hashlib
+import secrets
+
+verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+print(verifier, challenge)
+PY
+}
+
+# assert_deep_link_survives <description> <client-id> <redirect-uri> [extra curl args...]
+# Logs user-doctor (a single-membership, no-screen login) in against
+# client-id with redirect-uri, and asserts the flow's final redirect lands
+# on exactly that URI - the organization selector's own logic never runs
+# a second time between the login form and the redirect, so this is a
+# direct proof it never touches redirect_uri.
+assert_deep_link_survives() {
+  local description="$1" client="$2" redirect_uri="$3"
+  shift 3
+
+  local jar login_body action login_headers location
+  jar="$(mktemp)"
+  login_body="$(curl -sS --max-time 10 -c "${jar}" \
+    --get "${BASE_URL}/realms/tenant-a/protocol/openid-connect/auth" \
+    --data-urlencode "client_id=${client}" \
+    --data-urlencode "response_type=code" \
+    --data-urlencode "scope=openid" \
+    --data-urlencode "redirect_uri=${redirect_uri}" \
+    "$@")"
+  action="$(grep -o 'action="[^"]*"' <<<"${login_body}" | head -1 \
+    | sed -e 's/action="//' -e 's/"$//' -e 's/&amp;/\&/g')"
+  login_headers="$(curl -sS --max-time 10 -D - -o /dev/null -c "${jar}" -b "${jar}" \
+    --data-urlencode "username=user-doctor" \
+    --data-urlencode "password=demo-password" \
+    "${action}")"
+  rm -f "${jar}"
+
+  location="$(grep -i '^location:' <<<"${login_headers}" | sed -e 's/^[Ll]ocation: *//' -e 's/\r$//')"
+  if [[ "${location}" == "${redirect_uri}"\?* ]]; then
+    pass "${description}"
+  else
+    fail "${description} (landed on '${location}', want a query appended to exactly '${redirect_uri}')"
+  fi
+}
+
+echo "--- a deep link into the Admin Console survives a full login ---"
+assert_deep_link_survives \
+  "a deep link into the Admin Console lands on the exact path requested" \
+  patient-app "http://127.0.0.1:4200/role-matrix"
+
+echo
+echo "--- a deep link into Keycloak's own administration console survives a full login ---"
+read -r verifier challenge <<<"$(pkce_pair)"
+assert_deep_link_survives \
+  "a deep link into Keycloak's own administration console lands on the exact path requested" \
+  security-admin-console "${BASE_URL}/admin/tenant-a/console/" \
+  --data-urlencode "code_challenge=${challenge}" \
+  --data-urlencode "code_challenge_method=S256"
+
+echo
+echo "--- navigating between the two consoles requires no re-entry of credentials ---"
+jar="$(mktemp)"
+login_body="$(curl -sS --max-time 10 -c "${jar}" \
+  --get "${BASE_URL}/realms/tenant-a/protocol/openid-connect/auth" \
+  --data-urlencode "client_id=patient-app" \
+  --data-urlencode "response_type=code" \
+  --data-urlencode "scope=openid" \
+  --data-urlencode "redirect_uri=http://127.0.0.1:4200/")"
+action="$(grep -o 'action="[^"]*"' <<<"${login_body}" | head -1 \
+  | sed -e 's/action="//' -e 's/"$//' -e 's/&amp;/\&/g')"
+first_headers="$(curl -sS --max-time 10 -D - -o /dev/null -c "${jar}" -b "${jar}" \
+  --data-urlencode "username=user-doctor" --data-urlencode "password=demo-password" \
+  "${action}")"
+first_session="$(grep -i '^location:' <<<"${first_headers}" | grep -o 'session_state=[^&]*' | cut -d= -f2)"
+
+read -r verifier challenge <<<"$(pkce_pair)"
+# The same cookie jar, a different client, no credentials submitted at
+# all: a plain GET against the authorization endpoint either redirects
+# straight through (the SSO session already covers it) or shows a login
+# form (it does not).
+second_headers="$(curl -sS --max-time 10 -D - -o /tmp/console-crosslinks-second.html \
+  -c "${jar}" -b "${jar}" --get "${BASE_URL}/realms/tenant-a/protocol/openid-connect/auth" \
+  --data-urlencode "client_id=security-admin-console" \
+  --data-urlencode "response_type=code" \
+  --data-urlencode "scope=openid" \
+  --data-urlencode "redirect_uri=${BASE_URL}/admin/tenant-a/console/" \
+  --data-urlencode "code_challenge=${challenge}" \
+  --data-urlencode "code_challenge_method=S256")"
+rm -f "${jar}" /tmp/console-crosslinks-second.html
+second_status="$(head -1 <<<"${second_headers}" | grep -o '[0-9][0-9][0-9]')"
+second_session="$(grep -i '^location:' <<<"${second_headers}" | grep -o 'session_state=[^&]*' | cut -d= -f2)"
+
+if [[ "${second_status}" == "302" && -n "${first_session}" && "${first_session}" == "${second_session}" ]]; then
+  pass "moving to the other console redirects straight through the same SSO session, no credentials"
+else
+  fail "moving to the other console requires no re-entry of credentials (status ${second_status}, sessions '${first_session}' vs '${second_session}')"
+fi
+
+echo
+echo "--- the login theme offers a route back to the Admin Console ---"
+jar="$(mktemp)"
+login_body="$(curl -sS --max-time 10 -c "${jar}" \
+  --get "${BASE_URL}/realms/tenant-a/protocol/openid-connect/auth" \
+  --data-urlencode "client_id=patient-app" \
+  --data-urlencode "response_type=code" \
+  --data-urlencode "scope=openid" \
+  --data-urlencode "redirect_uri=http://127.0.0.1:4200/")"
+action="$(grep -o 'action="[^"]*"' <<<"${login_body}" | head -1 \
+  | sed -e 's/action="//' -e 's/"$//' -e 's/&amp;/\&/g')"
+# user-doctor-multi's screen (issue #80), the one page this theme actually
+# overrides, is where the link lives.
+form_body="$(curl -sS --max-time 10 -c "${jar}" -b "${jar}" \
+  --data-urlencode "username=user-doctor-multi" --data-urlencode "password=demo-password" \
+  "${action}")"
+rm -f "${jar}"
+if grep -qF 'id="kc-back-to-admin-console"' <<<"${form_body}"; then
+  pass "the login theme offers a route back to the Admin Console"
+else
+  fail "the login theme offers a route back to the Admin Console (page did not contain it)"
+fi
+
+if (( failures > 0 )); then
+  echo
+  echo "${failures} console-crosslinks failure(s)"
+  exit 1
+fi
+
+echo
+echo "console cross-links and deep-link survival passed"


### PR DESCRIPTION
## What changed

Issue #82: an administrator's work spans both Keycloak's own realm administration and the platform's Admin Console. Because they are clients of the same realm sharing one SSO session, moving between them is a plain navigation, and a link into either has to land exactly where it pointed.

- The organization selector already never touches `redirect_uri` (issues #79-#81 only ever add scope, never rewrite that parameter) - this issue proves it end to end rather than by inspection, for a deep link into each console.
- **`apps/admin-console`**: `authGuard` now carries the requested URL into `AuthService.login(returnTo)`, stashed in `sessionStorage`; the callback route consumes it after a successful token exchange instead of always navigating to `/`. A deep link the guard redirected away from now survives the round trip.
- `TokenClaims` gains `isAdministrator` (the `realm_access.roles` `"admin"` marker, issue #78), read for display only - every administrative call still goes through the server. The shell shows a link to Keycloak's own administration console (derived from the configured OIDC issuer) only when it is true.
- The login theme's `select-organization.ftl` (issue #80's screen) gains a "Back to the Admin Console" link via the `registrationLayout`'s info section, pointed at a new `adminConsoleUrl` theme property.
- **`scripts/tests/console-crosslinks-e2e.sh`**, in the existing curl-and-cookie-jar style: a deep link into the Admin Console (`patient-app`) and one into Keycloak's own console (its built-in `security-admin-console` client, which requires PKCE) both land on the exact `redirect_uri` requested; the same session moves from one client to the other with a plain 302 and no credentials; the login theme's back-link is present.

## How each acceptance criterion is met

- [x] The organization selector never rewrites or overrides `redirect_uri` - proven end to end (both deep-link cases below).
- [x] A deep link into the Admin Console survives a full login and lands on the exact path requested - `authGuard`/`AuthService.login`/`Callback` changes, unit-tested and e2e-tested.
- [x] A deep link into Keycloak's own administration console survives a full login and lands on the exact path requested - `console-crosslinks-e2e.sh` against `security-admin-console`.
- [x] The Admin Console shows a link to Keycloak's administration console for administrators, and not for other users - `shell.html`'s conditional link, `isAdministrator`.
- [x] The login theme offers a route back to the Admin Console - `select-organization.ftl`'s info-section link.
- [x] Navigating between the two consoles requires no re-entry of credentials - verified end to end (same `session_state`, plain 302, no credentials submitted).
- [x] End-to-end coverage in the existing shell style for both deep-link cases - `console-crosslinks-e2e.sh`.

## Verified locally before ever reaching CI

- `npx nx test admin-console`: 80/80 tests pass (using `scripts/bin/go`, the repo's own Go shim for Nx's project graph, so no local Go install was needed).
- `npx nx lint admin-console` / `npx nx build admin-console`: clean.
- A real Keycloak container, built from the actual image: the deep-link and no-relogin scenarios verified against `security-admin-console` and `patient-app`, and the login theme's back-link rendered and inspected directly.

## Verified with

- `npx nx test/lint/build admin-console` - all green.
- Real Docker builds and a real running Keycloak container, as above.
- `python3 scripts/tests/compose-contract.py`, `docker compose config -q` - unaffected, both satisfied.
- CI (docker compose walking skeleton, architecture invariants, authorization schema on postgres, cerbos policy suite, nx affected).

Closes #82


Closes #82
