### PR TITLE
Read-only organizations in the identity directory and Admin Console (#85)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ smoke: ## Verify a running stack end to end
 	bash scripts/tests/console-crosslinks-e2e.sh
 	bash scripts/tests/tenant-subdomain-e2e.sh
 	bash scripts/tests/hospital-switch-e2e.sh
+	bash scripts/tests/organizations-e2e.sh
 
 .PHONY: walkthrough
 walkthrough: ## Execute the README's guided walkthrough against a running deployment

--- a/apps/admin-console/src/app/app.routes.ts
+++ b/apps/admin-console/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { AuditSearch } from './audit-search/audit-search';
 import { authGuard } from './auth/auth.guard';
 import { Callback } from './auth/callback';
 import { IdPDiagnostics } from './idp-diagnostics/idp-diagnostics';
+import { Organizations } from './organizations/organizations';
 import { ResourceCatalogBrowser } from './resource-catalog-browser/resource-catalog-browser';
 import { RevisionActivation } from './revision-activation/revision-activation';
 import { RoleMatrix } from './role-matrix/role-matrix';
@@ -21,6 +22,7 @@ export const appRoutes: Route[] = [
       { path: '', redirectTo: 'role-matrix', pathMatch: 'full' },
       { path: 'role-matrix', component: RoleMatrix },
       { path: 'user-overrides', component: UserOverride },
+      { path: 'organizations', component: Organizations },
       { path: 'resource-catalog', component: ResourceCatalogBrowser },
       { path: 'simulator', component: Simulator },
       { path: 'audit', component: AuditSearch },

--- a/apps/admin-console/src/app/organizations/organizations-api.ts
+++ b/apps/admin-console/src/app/organizations/organizations-api.ts
@@ -1,0 +1,59 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ADS_BASE_URL } from '../platform-status/ads-base-url';
+
+/** An organization as the identity directory reports it (issue #85). */
+export interface OrganizationRef {
+  externalId: string;
+  alias: string;
+  name: string;
+}
+
+export interface OrganizationsResult {
+  items: OrganizationRef[];
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+/** A member of an organization, the same shape the user picker already
+ * shows elsewhere in the console (§7.2). */
+export interface OrganizationMemberRef {
+  externalId: string;
+  username: string;
+  displayName: string;
+  email: string;
+  enabled: boolean;
+}
+
+export interface OrganizationMembersResult {
+  items: OrganizationMemberRef[];
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class OrganizationsApi {
+  private readonly http = inject(HttpClient);
+  private readonly adsBaseUrl = inject(ADS_BASE_URL);
+
+  getOrganizations(offset: number, limit: number): Observable<OrganizationsResult> {
+    return this.http.get<OrganizationsResult>(`${this.adsBaseUrl}/internal/directory/organizations`, {
+      params: { offset: String(offset), limit: String(limit) },
+    });
+  }
+
+  getOrganizationMembers(
+    organizationExternalId: string,
+    offset: number,
+    limit: number,
+  ): Observable<OrganizationMembersResult> {
+    return this.http.get<OrganizationMembersResult>(
+      `${this.adsBaseUrl}/internal/directory/organizations/${organizationExternalId}/members`,
+      { params: { offset: String(offset), limit: String(limit) } },
+    );
+  }
+}

--- a/apps/admin-console/src/app/organizations/organizations.css
+++ b/apps/admin-console/src/app/organizations/organizations.css
@@ -1,0 +1,3 @@
+.error {
+  color: darkred;
+}

--- a/apps/admin-console/src/app/organizations/organizations.html
+++ b/apps/admin-console/src/app/organizations/organizations.html
@@ -1,0 +1,73 @@
+<h1>Organizations</h1>
+<p>
+  Read only: Keycloak stays the only place an organization or a membership is created or
+  changed.
+</p>
+
+@if (loadError()) {
+  <p data-testid="organizations-error" class="error">{{ loadError() }}</p>
+}
+
+<ul data-testid="organization-list">
+  @for (organization of organizations(); track organization.externalId) {
+    <li>
+      <button
+        type="button"
+        [attr.data-testid]="'organization-option-' + organization.alias"
+        (click)="selectOrganization(organization)"
+      >
+        {{ organization.name || organization.alias }}
+      </button>
+    </li>
+  }
+</ul>
+
+<div class="pagination">
+  <button type="button" data-testid="prev-page" [disabled]="offset() === 0" (click)="previousPage()">
+    Previous
+  </button>
+  <button type="button" data-testid="next-page" [disabled]="!hasMore()" (click)="nextPage()">
+    Next
+  </button>
+</div>
+
+@if (selectedOrganization(); as organization) {
+  <section data-testid="organization-members">
+    <h2>{{ organization.name || organization.alias }} members</h2>
+
+    @if (membersError()) {
+      <p data-testid="members-error" class="error">{{ membersError() }}</p>
+    }
+
+    @if (members().length > 0) {
+      <ul data-testid="member-list">
+        @for (member of members(); track member.externalId) {
+          <li [attr.data-testid]="'member-' + member.externalId">
+            {{ member.displayName || member.username }}
+          </li>
+        }
+      </ul>
+    } @else {
+      <p data-testid="no-members">No members.</p>
+    }
+
+    <div class="pagination">
+      <button
+        type="button"
+        data-testid="members-prev-page"
+        [disabled]="membersOffset() === 0"
+        (click)="membersPreviousPage()"
+      >
+        Previous
+      </button>
+      <button
+        type="button"
+        data-testid="members-next-page"
+        [disabled]="!membersHasMore()"
+        (click)="membersNextPage()"
+      >
+        Next
+      </button>
+    </div>
+  </section>
+}

--- a/apps/admin-console/src/app/organizations/organizations.spec.ts
+++ b/apps/admin-console/src/app/organizations/organizations.spec.ts
@@ -1,0 +1,80 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { Organizations } from './organizations';
+
+function setUp() {
+  TestBed.configureTestingModule({
+    imports: [Organizations],
+    providers: [provideHttpClient(), provideHttpClientTesting()],
+  });
+  return TestBed.inject(HttpTestingController);
+}
+
+describe('Organizations', () => {
+  it("lists a tenant's organizations (issue #85)", async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(Organizations);
+    httpMock.expectOne('/api/ads/internal/directory/organizations?offset=0&limit=20').flush({
+      items: [
+        { externalId: 'org-north', alias: 'north-hospital', name: 'North Hospital' },
+        { externalId: 'org-south', alias: 'south-hospital', name: 'South Hospital' },
+      ],
+      offset: 0, limit: 20, hasMore: false,
+    });
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="organization-option-north-hospital"]'),
+    ).toBeTruthy();
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="organization-option-south-hospital"]'),
+    ).toBeTruthy();
+  });
+
+  it("shows an organization's members on selection", async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(Organizations);
+    httpMock.expectOne('/api/ads/internal/directory/organizations?offset=0&limit=20').flush({
+      items: [{ externalId: 'org-north', alias: 'north-hospital', name: 'North Hospital' }],
+      offset: 0, limit: 20, hasMore: false,
+    });
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    (fixture.nativeElement.querySelector(
+      '[data-testid="organization-option-north-hospital"]',
+    ) as HTMLButtonElement).click();
+    httpMock
+      .expectOne('/api/ads/internal/directory/organizations/org-north/members?offset=0&limit=20')
+      .flush({
+        items: [{ externalId: 'user-doctor', username: 'doctor', displayName: 'Dana Doctor' }],
+        offset: 0, limit: 20, hasMore: false,
+      });
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    const members = fixture.nativeElement.querySelector(
+      '[data-testid="member-user-doctor"]',
+    ) as HTMLElement;
+    expect(members.textContent).toContain('Dana Doctor');
+  });
+
+  it('shows an error when the organization list itself fails to load', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(Organizations);
+    httpMock.expectOne('/api/ads/internal/directory/organizations?offset=0&limit=20').flush(
+      { error: 'unavailable' },
+      { status: 503, statusText: 'Service Unavailable' },
+    );
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="organizations-error"]')).toBeTruthy();
+  });
+});

--- a/apps/admin-console/src/app/organizations/organizations.ts
+++ b/apps/admin-console/src/app/organizations/organizations.ts
@@ -1,0 +1,98 @@
+import { Component, inject, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+import {
+  OrganizationMemberRef,
+  OrganizationRef,
+  OrganizationsApi,
+} from './organizations-api';
+
+const DEFAULT_PAGE_LIMIT = 20;
+
+/**
+ * The organizations module (§9.1, issue #85): a tenant's organizations and
+ * an organization's members, read only - Keycloak stays the only place
+ * one is created or changed. An administrator granting a permission needs
+ * to see the reach of what they are about to do; this is where they see it.
+ */
+@Component({
+  standalone: true,
+  imports: [],
+  selector: 'app-organizations',
+  templateUrl: './organizations.html',
+  styleUrl: './organizations.css',
+})
+export class Organizations {
+  private readonly api = inject(OrganizationsApi);
+
+  readonly organizations = signal<OrganizationRef[]>([]);
+  readonly offset = signal(0);
+  readonly hasMore = signal(false);
+  readonly loadError = signal<string | null>(null);
+
+  readonly selectedOrganization = signal<OrganizationRef | null>(null);
+  readonly members = signal<OrganizationMemberRef[]>([]);
+  readonly membersOffset = signal(0);
+  readonly membersHasMore = signal(false);
+  readonly membersError = signal<string | null>(null);
+
+  constructor() {
+    void this.loadOrganizations();
+  }
+
+  async loadOrganizations(): Promise<void> {
+    this.loadError.set(null);
+    try {
+      const result = await firstValueFrom(
+        this.api.getOrganizations(this.offset(), DEFAULT_PAGE_LIMIT),
+      );
+      this.organizations.set(result.items);
+      this.hasMore.set(result.hasMore);
+    } catch {
+      this.loadError.set('The organization list could not be loaded.');
+    }
+  }
+
+  async nextPage(): Promise<void> {
+    this.offset.set(this.offset() + DEFAULT_PAGE_LIMIT);
+    await this.loadOrganizations();
+  }
+
+  async previousPage(): Promise<void> {
+    this.offset.set(Math.max(0, this.offset() - DEFAULT_PAGE_LIMIT));
+    await this.loadOrganizations();
+  }
+
+  async selectOrganization(organization: OrganizationRef): Promise<void> {
+    this.selectedOrganization.set(organization);
+    this.membersOffset.set(0);
+    await this.loadMembers();
+  }
+
+  async loadMembers(): Promise<void> {
+    const organization = this.selectedOrganization();
+    if (!organization) {
+      return;
+    }
+    this.membersError.set(null);
+    try {
+      const result = await firstValueFrom(
+        this.api.getOrganizationMembers(organization.externalId, this.membersOffset(), DEFAULT_PAGE_LIMIT),
+      );
+      this.members.set(result.items);
+      this.membersHasMore.set(result.hasMore);
+    } catch {
+      this.membersError.set("The organization's members could not be loaded.");
+    }
+  }
+
+  async membersNextPage(): Promise<void> {
+    this.membersOffset.set(this.membersOffset() + DEFAULT_PAGE_LIMIT);
+    await this.loadMembers();
+  }
+
+  async membersPreviousPage(): Promise<void> {
+    this.membersOffset.set(Math.max(0, this.membersOffset() - DEFAULT_PAGE_LIMIT));
+    await this.loadMembers();
+  }
+}

--- a/apps/admin-console/src/app/shell/shell.html
+++ b/apps/admin-console/src/app/shell/shell.html
@@ -2,6 +2,7 @@
   <nav>
     <a routerLink="/role-matrix" data-testid="nav-role-matrix">Role matrix</a>
     <a routerLink="/user-overrides" data-testid="nav-user-overrides">User overrides</a>
+    <a routerLink="/organizations" data-testid="nav-organizations">Organizations</a>
     <a routerLink="/resource-catalog" data-testid="nav-resource-catalog">Resource catalog</a>
     <a routerLink="/simulator" data-testid="nav-simulator">Simulator</a>
     <a routerLink="/audit" data-testid="nav-audit">Audit</a>

--- a/apps/admin-console/src/app/user-override/user-override-api.ts
+++ b/apps/admin-console/src/app/user-override/user-override-api.ts
@@ -34,6 +34,18 @@ export interface UserRolesResult {
   items: UserRoleRef[];
 }
 
+/** An organization a user belongs to (issue #85): the reach an
+ * administrator sees before granting or revoking a permission. */
+export interface UserOrganizationRef {
+  externalId: string;
+  alias: string;
+  name: string;
+}
+
+export interface UserOrganizationsResult {
+  items: UserOrganizationRef[];
+}
+
 export type OverrideEffectInput = 'INHERIT' | 'GRANT' | 'REVOKE';
 
 export interface SaveOverrideRequest {
@@ -103,6 +115,12 @@ export class UserOverrideApi {
   getUserRoles(userExternalId: string): Observable<UserRolesResult> {
     return this.http.get<UserRolesResult>(
       `${this.adsBaseUrl}/internal/directory/users/${userExternalId}/roles`,
+    );
+  }
+
+  getUserOrganizations(userExternalId: string): Observable<UserOrganizationsResult> {
+    return this.http.get<UserOrganizationsResult>(
+      `${this.adsBaseUrl}/internal/directory/users/${userExternalId}/organizations`,
     );
   }
 

--- a/apps/admin-console/src/app/user-override/user-override.html
+++ b/apps/admin-console/src/app/user-override/user-override.html
@@ -37,6 +37,18 @@
   <section class="override-editor" data-testid="editor">
     <h2>{{ user.displayName || user.username }}</h2>
 
+    @if (userOrganizations().length > 0) {
+      <ul data-testid="user-organizations" aria-label="Hospital memberships">
+        @for (organization of userOrganizations(); track organization.externalId) {
+          <li [attr.data-testid]="'user-organization-' + organization.alias">
+            {{ organization.name || organization.alias }}
+          </li>
+        }
+      </ul>
+    } @else {
+      <p data-testid="no-user-organizations">No hospital memberships.</p>
+    }
+
     <label>
       Resource
       <select data-testid="resource-select" [ngModel]="selectedResourceKey()" (ngModelChange)="selectResource($event)">

--- a/apps/admin-console/src/app/user-override/user-override.spec.ts
+++ b/apps/admin-console/src/app/user-override/user-override.spec.ts
@@ -50,6 +50,51 @@ describe('UserOverride', () => {
     expect(note.textContent).toContain('hospital-1');
   });
 
+  it("shows a user's hospital memberships before granting or revoking a permission (issue #85)", async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+
+    const selectPromise = fixture.componentInstance.selectUser({
+      externalId: 'user-1', username: 'doctor', displayName: 'Dana Doctor', email: '', enabled: true,
+    });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/organizations').flush({
+      items: [
+        { externalId: 'org-north', alias: 'north-hospital', name: 'North Hospital' },
+        { externalId: 'org-south', alias: 'south-hospital', name: 'South Hospital' },
+      ],
+    });
+    httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
+    await selectPromise;
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="user-organization-north-hospital"]'),
+    ).toBeTruthy();
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="user-organization-south-hospital"]'),
+    ).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="no-user-organizations"]')).toBeNull();
+  });
+
+  it('shows no memberships when a user belongs to no hospital', async () => {
+    const httpMock = setUp();
+    const fixture = TestBed.createComponent(UserOverride);
+    httpMock.expectOne('/api/admin/authz/resources').flush(catalog);
+
+    const selectPromise = fixture.componentInstance.selectUser({
+      externalId: 'user-1', username: 'doctor', displayName: 'Dana Doctor', email: '', enabled: true,
+    });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/organizations').flush({ items: [] });
+    httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
+    await selectPromise;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="no-user-organizations"]')).toBeTruthy();
+  });
+
   it('distinguishes Inherit, Grant and Revoke as three separate controls', async () => {
     const httpMock = setUp();
     const fixture = TestBed.createComponent(UserOverride);
@@ -59,6 +104,7 @@ describe('UserOverride', () => {
       externalId: 'user-1', username: 'doctor', displayName: 'Dana Doctor', email: '', enabled: true,
     });
     httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/organizations').flush({ items: [] });
     httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
     await selectPromise;
     fixture.detectChanges();
@@ -79,6 +125,7 @@ describe('UserOverride', () => {
     httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({
       items: [{ canonicalId: 'role-doctor', externalId: 'doctor', name: 'Doctor', description: '' }],
     });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/organizations').flush({ items: [] });
     httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 3 });
     await selectPromise;
 
@@ -110,6 +157,7 @@ describe('UserOverride', () => {
       externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
     });
     httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/organizations').flush({ items: [] });
     httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
     await selectPromise;
 
@@ -137,6 +185,7 @@ describe('UserOverride', () => {
       externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
     });
     httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/organizations').flush({ items: [] });
     httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
     await selectPromise;
 
@@ -160,6 +209,7 @@ describe('UserOverride', () => {
       externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
     });
     httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/organizations').flush({ items: [] });
     httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
     await selectPromise;
 
@@ -179,6 +229,7 @@ describe('UserOverride', () => {
       externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
     });
     httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/organizations').flush({ items: [] });
     httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
     await selectPromise;
 
@@ -214,6 +265,7 @@ describe('UserOverride', () => {
       externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
     });
     httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/organizations').flush({ items: [] });
     httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
     await selectPromise;
 
@@ -245,6 +297,7 @@ describe('UserOverride', () => {
       externalId: 'user-1', username: 'doctor', displayName: '', email: '', enabled: true,
     });
     httpMock.expectOne('/api/ads/internal/directory/users/user-1/roles').flush({ items: [] });
+    httpMock.expectOne('/api/ads/internal/directory/users/user-1/organizations').flush({ items: [] });
     httpMock.expectOne('/api/admin/authz/tenants/tenant-a/permission-revision').flush({ revision: 0 });
     await selectPromise;
 

--- a/apps/admin-console/src/app/user-override/user-override.ts
+++ b/apps/admin-console/src/app/user-override/user-override.ts
@@ -9,6 +9,7 @@ import {
   OverrideEffectInput,
   OverrideRow,
   PreviewResult,
+  UserOrganizationRef,
   UserOverrideApi,
   UserRef,
   UserRoleRef,
@@ -50,6 +51,9 @@ export class UserOverride {
 
   readonly selectedUser = signal<UserRef | null>(null);
   private readonly userRoles = signal<UserRoleRef[]>([]);
+  /** The reach an administrator sees before granting or revoking a
+   * permission (issue #85). */
+  readonly userOrganizations = signal<UserOrganizationRef[]>([]);
 
   readonly resources = signal<ResourceEntry[]>([]);
   readonly selectedResourceKey = signal('');
@@ -120,18 +124,26 @@ export class UserOverride {
     this.staleRevision.set(false);
     this.preview.set(null);
 
-    // Both requests are dispatched together rather than one after the
-    // other: neither depends on the other's result, and awaiting them in
-    // sequence would double the round-trip latency for no reason.
+    // All three requests are dispatched together rather than one after
+    // the other: none depends on another's result, and awaiting them in
+    // sequence would multiply the round-trip latency for no reason.
     const rolesRequest = firstValueFrom(this.api.getUserRoles(user.externalId)).catch(
       () => ({ items: [] as UserRoleRef[] }),
     );
+    const organizationsRequest = firstValueFrom(
+      this.api.getUserOrganizations(user.externalId),
+    ).catch(() => ({ items: [] as UserOrganizationRef[] }));
     const revisionRequest = firstValueFrom(this.api.getCurrentRevision(this.tenant())).catch(
       () => ({ revision: 0 }),
     );
 
-    const [roles, current] = await Promise.all([rolesRequest, revisionRequest]);
+    const [roles, organizations, current] = await Promise.all([
+      rolesRequest,
+      organizationsRequest,
+      revisionRequest,
+    ]);
     this.userRoles.set(roles.items);
+    this.userOrganizations.set(organizations.items);
     this.lastKnownRevision = current.revision;
   }
 

--- a/apps/ads/cmd/ads/main.go
+++ b/apps/ads/cmd/ads/main.go
@@ -324,6 +324,18 @@ func main() {
 			Directories: directories,
 			Logger:      logger,
 		})),
+		DirectoryOrganizationsHandler: authenticated(directoryapi.NewOrganizationsHandler(directoryapi.Config{
+			Directories: directories,
+			Logger:      logger,
+		})),
+		DirectoryOrganizationMembersHandler: authenticated(directoryapi.NewOrganizationMembersHandler(directoryapi.Config{
+			Directories: directories,
+			Logger:      logger,
+		})),
+		DirectoryUserOrganizationsHandler: authenticated(directoryapi.NewUserOrganizationsHandler(directoryapi.Config{
+			Directories: directories,
+			Logger:      logger,
+		})),
 		CapabilityHandler: authenticated(capability.NewHandler(capability.Config{
 			PDP:               pdp,
 			CapabilityCatalog: capability.NewFSCatalog(cfg.CapabilityCatalogDir, cfg.CapabilityCatalogRevision, nil),

--- a/apps/ads/internal/directoryapi/directoryapi.go
+++ b/apps/ads/internal/directoryapi/directoryapi.go
@@ -180,6 +180,128 @@ func NewUserRolesHandler(cfg Config) http.Handler {
 	})
 }
 
+type organizationPayload struct {
+	ExternalID string `json:"externalId"`
+	Alias      string `json:"alias"`
+	Name       string `json:"name"`
+}
+
+func toOrganizationPayload(organization idpdirectory.OrganizationRef) organizationPayload {
+	return organizationPayload{
+		ExternalID: organization.ExternalID,
+		Alias:      organization.Alias,
+		Name:       organization.Name,
+	}
+}
+
+// NewOrganizationsHandler serves GET /internal/directory/organizations
+// (issue #85): the reach an administrator sees before granting a
+// permission, in the caller's own tenant only.
+func NewOrganizationsHandler(cfg Config) http.Handler {
+	logger := loggerOf(cfg)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity, page, ok := requestContext(w, r)
+		if !ok {
+			return
+		}
+		directory, ok := directoryFor(cfg, identity.TenantID)
+		if !ok {
+			fail(w, logger, r, "listing organizations", errNoDirectoryForTenant(identity.TenantID))
+			return
+		}
+
+		found, err := directory.OrganizationsOfTenant(r.Context(),
+			idpdirectory.TenantID(identity.TenantID),
+			idpdirectory.OrganizationSearch{Query: r.URL.Query().Get("query"), Page: page})
+		if err != nil {
+			fail(w, logger, r, "listing organizations", err)
+			return
+		}
+
+		items := make([]organizationPayload, 0, len(found.Items))
+		for _, organization := range found.Items {
+			items = append(items, toOrganizationPayload(organization))
+		}
+		writeJSON(w, http.StatusOK, pagePayload[organizationPayload]{
+			Items: items, Offset: found.Offset, Limit: found.Limit, HasMore: found.HasMore,
+		})
+	})
+}
+
+// NewOrganizationMembersHandler serves GET
+// /internal/directory/organizations/{externalId}/members (issue #85).
+func NewOrganizationMembersHandler(cfg Config) http.Handler {
+	logger := loggerOf(cfg)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity, page, ok := requestContext(w, r)
+		if !ok {
+			return
+		}
+		directory, ok := directoryFor(cfg, identity.TenantID)
+		if !ok {
+			fail(w, logger, r, "listing an organization's members", errNoDirectoryForTenant(identity.TenantID))
+			return
+		}
+
+		externalID := r.PathValue("externalId")
+		found, err := directory.MembersOfOrganization(r.Context(),
+			idpdirectory.TenantID(identity.TenantID), externalID, page)
+		if err != nil {
+			fail(w, logger, r, "listing an organization's members", err)
+			return
+		}
+
+		items := make([]userPayload, 0, len(found.Items))
+		for _, user := range found.Items {
+			items = append(items, userPayload{
+				ExternalID:  user.ExternalID,
+				Username:    user.Username,
+				DisplayName: user.DisplayName,
+				Email:       user.Email,
+				Enabled:     user.Enabled,
+			})
+		}
+		writeJSON(w, http.StatusOK, pagePayload[userPayload]{
+			Items: items, Offset: found.Offset, Limit: found.Limit, HasMore: found.HasMore,
+		})
+	})
+}
+
+// NewUserOrganizationsHandler serves GET
+// /internal/directory/users/{externalId}/organizations (issue #85): the
+// Admin Console's user-override screen shows a user's hospital memberships
+// when granting or revoking a permission.
+func NewUserOrganizationsHandler(cfg Config) http.Handler {
+	logger := loggerOf(cfg)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity, ok := tokenauth.From(r.Context())
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "a bearer token is required")
+			return
+		}
+
+		directory, ok := directoryFor(cfg, identity.TenantID)
+		if !ok {
+			fail(w, logger, r, "reading a user's organizations", errNoDirectoryForTenant(identity.TenantID))
+			return
+		}
+
+		externalID := r.PathValue("externalId")
+		organizations, err := directory.OrganizationsOfUser(r.Context(),
+			idpdirectory.TenantID(identity.TenantID), externalID)
+		if err != nil {
+			fail(w, logger, r, "reading a user's organizations", err)
+			return
+		}
+
+		items := make([]organizationPayload, 0, len(organizations))
+		for _, organization := range organizations {
+			items = append(items, toOrganizationPayload(organization))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": items})
+	})
+}
+
 // requestContext resolves who is asking and which window they want, answering
 // the caller itself when either is unusable.
 func requestContext(w http.ResponseWriter, r *http.Request) (tokenauth.Identity, idpdirectory.PageRequest, bool) {

--- a/apps/ads/internal/directoryapi/directoryapi_test.go
+++ b/apps/ads/internal/directoryapi/directoryapi_test.go
@@ -185,6 +185,98 @@ func TestRoleSearchReportsCanonicalIdentifiers(t *testing.T) {
 	}
 }
 
+func TestOrganizationsReturnsOnePageAndSaysWhetherThereIsAnother(t *testing.T) {
+	directory := &recordingDirectory{
+		organizations: idpdirectory.Page[idpdirectory.OrganizationRef]{
+			Items: []idpdirectory.OrganizationRef{
+				{ExternalID: "org-north", Alias: "north-hospital", Name: "North Hospital"},
+			},
+			Offset: 0, Limit: 50, HasMore: true,
+		},
+	}
+	handler := directoryapi.NewOrganizationsHandler(directoryapi.Config{Directory: directory})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, get("/internal/directory/organizations"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "north-hospital") {
+		t.Errorf("response carries no organization alias: %s", rec.Body)
+	}
+	if directory.tenant != "tenant-a" {
+		t.Errorf("tenant = %q, want the caller's own tenant", directory.tenant)
+	}
+}
+
+func TestOrganizationMembersReportsOneWindowOfMembers(t *testing.T) {
+	directory := &recordingDirectory{
+		organizationMembers: idpdirectory.Page[idpdirectory.UserRef]{
+			Items: []idpdirectory.UserRef{{ExternalID: "user-doctor", Username: "doctor"}},
+			Limit: 50,
+		},
+	}
+	handler := directoryapi.NewOrganizationMembersHandler(directoryapi.Config{Directory: directory})
+
+	req := get("/internal/directory/organizations/org-north/members")
+	req.SetPathValue("externalId", "org-north")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+	if directory.organizationMembersFor != "org-north" {
+		t.Errorf("organization queried = %q, want org-north", directory.organizationMembersFor)
+	}
+	if !strings.Contains(rec.Body.String(), "user-doctor") {
+		t.Errorf("response carries no member: %s", rec.Body)
+	}
+}
+
+func TestUserOrganizationsReportsTheOrganizationsThatUserBelongsTo(t *testing.T) {
+	directory := &recordingDirectory{
+		userOrganizations: []idpdirectory.OrganizationRef{
+			{ExternalID: "org-north", Alias: "north-hospital"},
+			{ExternalID: "org-south", Alias: "south-hospital"},
+		},
+	}
+	handler := directoryapi.NewUserOrganizationsHandler(directoryapi.Config{Directory: directory})
+
+	req := get("/internal/directory/users/user-doctor-multi/organizations")
+	req.SetPathValue("externalId", "user-doctor-multi")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+	if directory.userOrganizationsFor != "user-doctor-multi" {
+		t.Errorf("user queried = %q, want user-doctor-multi", directory.userOrganizationsFor)
+	}
+	if !strings.Contains(rec.Body.String(), "north-hospital") || !strings.Contains(rec.Body.String(), "south-hospital") {
+		t.Errorf("response is missing a membership: %s", rec.Body)
+	}
+}
+
+func TestUserOrganizationsRequiresAuthentication(t *testing.T) {
+	directory := &recordingDirectory{}
+	handler := directoryapi.NewUserOrganizationsHandler(directoryapi.Config{Directory: directory})
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/directory/users/user-doctor/organizations", nil)
+	req.SetPathValue("externalId", "user-doctor")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if directory.calls != 0 {
+		t.Error("the directory was queried for an unauthenticated request")
+	}
+}
+
 // §16.1 and §7.4: the IdP machine credential must never reach a browser. The
 // realistic leak is an error path, so the failing case is the one asserted.
 func TestADirectoryFailureNeverEchoesTheAdminCredential(t *testing.T) {
@@ -287,16 +379,23 @@ func get(target string) *http.Request {
 }
 
 type recordingDirectory struct {
-	calls        int
-	tenant       idpdirectory.TenantID
-	userSearch   idpdirectory.UserSearch
-	roleSearch   idpdirectory.RoleSearch
-	userRolesFor string
+	calls                   int
+	tenant                  idpdirectory.TenantID
+	userSearch              idpdirectory.UserSearch
+	roleSearch              idpdirectory.RoleSearch
+	userRolesFor            string
+	organizationSearch      idpdirectory.OrganizationSearch
+	userOrganizationsFor    string
+	organizationMembersFor  string
+	organizationMembersPage idpdirectory.PageRequest
 
-	users     idpdirectory.Page[idpdirectory.UserRef]
-	roles     idpdirectory.Page[idpdirectory.RoleRef]
-	userRoles []idpdirectory.RoleRef
-	err       error
+	users               idpdirectory.Page[idpdirectory.UserRef]
+	roles               idpdirectory.Page[idpdirectory.RoleRef]
+	userRoles           []idpdirectory.RoleRef
+	organizations       idpdirectory.Page[idpdirectory.OrganizationRef]
+	userOrganizations   []idpdirectory.OrganizationRef
+	organizationMembers idpdirectory.Page[idpdirectory.UserRef]
+	err                 error
 }
 
 func (d *recordingDirectory) SearchUsers(_ context.Context, tenant idpdirectory.TenantID, query idpdirectory.UserSearch) (idpdirectory.Page[idpdirectory.UserRef], error) {
@@ -323,6 +422,24 @@ func (d *recordingDirectory) GetUserRoles(_ context.Context, tenant idpdirectory
 	d.calls++
 	d.tenant, d.userRolesFor = tenant, userExternalID
 	return d.userRoles, d.err
+}
+
+func (d *recordingDirectory) OrganizationsOfTenant(_ context.Context, tenant idpdirectory.TenantID, query idpdirectory.OrganizationSearch) (idpdirectory.Page[idpdirectory.OrganizationRef], error) {
+	d.calls++
+	d.tenant, d.organizationSearch = tenant, query
+	return d.organizations, d.err
+}
+
+func (d *recordingDirectory) OrganizationsOfUser(_ context.Context, tenant idpdirectory.TenantID, userExternalID string) ([]idpdirectory.OrganizationRef, error) {
+	d.calls++
+	d.tenant, d.userOrganizationsFor = tenant, userExternalID
+	return d.userOrganizations, d.err
+}
+
+func (d *recordingDirectory) MembersOfOrganization(_ context.Context, tenant idpdirectory.TenantID, organizationExternalID string, page idpdirectory.PageRequest) (idpdirectory.Page[idpdirectory.UserRef], error) {
+	d.calls++
+	d.tenant, d.organizationMembersFor, d.organizationMembersPage = tenant, organizationExternalID, page
+	return d.organizationMembers, d.err
 }
 
 func (d *recordingDirectory) ResolveRuntimeRoles(_ context.Context, token tokenverifier.VerifiedToken, _ idpdirectory.TenantID) ([]string, error) {

--- a/apps/ads/internal/server/server.go
+++ b/apps/ads/internal/server/server.go
@@ -46,6 +46,13 @@ type Config struct {
 	// user (issue #17's user-override screen). Nil means the route does
 	// not exist.
 	DirectoryUserRolesHandler http.Handler
+	// DirectoryOrganizationsHandler, DirectoryOrganizationMembersHandler
+	// and DirectoryUserOrganizationsHandler serve the identity
+	// directory's organization reads (issue #85). Nil means the
+	// corresponding route does not exist.
+	DirectoryOrganizationsHandler       http.Handler
+	DirectoryOrganizationMembersHandler http.Handler
+	DirectoryUserOrganizationsHandler   http.Handler
 
 	// CapabilityHandler serves POST /internal/capabilities/evaluate, the
 	// §12.3 capability snapshot endpoint (issue #11). Nil means the route
@@ -88,6 +95,15 @@ func New(cfg Config) http.Handler {
 	}
 	if cfg.DirectoryUserRolesHandler != nil {
 		mux.Handle("GET /internal/directory/users/{externalId}/roles", cfg.DirectoryUserRolesHandler)
+	}
+	if cfg.DirectoryOrganizationsHandler != nil {
+		mux.Handle("GET /internal/directory/organizations", cfg.DirectoryOrganizationsHandler)
+	}
+	if cfg.DirectoryOrganizationMembersHandler != nil {
+		mux.Handle("GET /internal/directory/organizations/{externalId}/members", cfg.DirectoryOrganizationMembersHandler)
+	}
+	if cfg.DirectoryUserOrganizationsHandler != nil {
+		mux.Handle("GET /internal/directory/users/{externalId}/organizations", cfg.DirectoryUserOrganizationsHandler)
 	}
 	if cfg.CapabilityHandler != nil {
 		mux.Handle("POST /internal/capabilities/evaluate", cfg.CapabilityHandler)

--- a/deploy/keycloak/realm-tenant-a.json
+++ b/deploy/keycloak/realm-tenant-a.json
@@ -256,7 +256,7 @@
       "enabled": true,
       "serviceAccountClientId": "authorization-admin-service",
       "clientRoles": {
-        "realm-management": ["view-users", "query-users", "view-clients", "view-realm"]
+        "realm-management": ["view-users", "query-users", "view-clients", "view-realm", "manage-realm"]
       }
     }
   ],

--- a/deploy/keycloak/realm-tenant-b.json
+++ b/deploy/keycloak/realm-tenant-b.json
@@ -91,7 +91,7 @@
       "enabled": true,
       "serviceAccountClientId": "authorization-admin-service",
       "clientRoles": {
-        "realm-management": ["view-users", "query-users", "view-clients", "view-realm"]
+        "realm-management": ["view-users", "query-users", "view-clients", "view-realm", "manage-realm"]
       }
     }
   ],

--- a/docs/MEASURED_FINDINGS.md
+++ b/docs/MEASURED_FINDINGS.md
@@ -249,6 +249,33 @@ accept a full interactive round trip for a hospital switch. Recorded here
 rather than silently declared done; see the issue #84 pull request for the
 resulting scope decision.
 
+## Listing organizations requires the broad manage-realm role (issue #85)
+
+Issue #85's directory reads are read-only by design - the acceptance
+criterion is an architecture test forbidding a write path on the adapter
+surface. Wiring them up against a real Keycloak 26.4 found that Keycloak's
+own admin REST API does not offer a narrower permission for the two
+listing endpoints:
+
+| Endpoint | Role actually required |
+|---|---|
+| `GET /organizations` (organizations of a tenant) | `manage-realm` - confirmed by testing: `view-realm`, `view-users`, `query-users` and `view-clients` together still 403. |
+| `GET /organizations/{id}/members` (members of an organization) | `manage-realm`, same finding. |
+| `GET /organizations/members/{id}/organizations` (organizations of a user) | None of the above - this one succeeds with the roles already granted for #76/#77. |
+
+**Finding: the two listing endpoints hard-require `manage-realm` in this
+Keycloak version, with no narrower alternative found.** `manage-realm` is
+a materially broader grant than the read-only claim this feature makes -
+it is realm-wide write access, not scoped to organizations. `deploy/keycloak/realm-tenant-a.json`
+and `realm-tenant-b.json` grant it to each tenant's own
+`authorization-admin-service` service account (already isolated per
+tenant per issue #76's design, so the blast radius of a leaked credential
+is still one tenant, not the platform), because there was no other way to
+serve the acceptance criteria against this Keycloak version. If Keycloak
+ever ships a narrower fine-grained permission for organization reads,
+this grant should be narrowed to match; recorded here so that gap is
+visible rather than silently accepted.
+
 ## What has not been measured
 
 Stated plainly, so nobody mistakes an absence for a pass:

--- a/libs/idpdirectory/directorycontract/contract.go
+++ b/libs/idpdirectory/directorycontract/contract.go
@@ -1,0 +1,63 @@
+// Package directorycontract is the suite every identity directory adapter's
+// organization reads must pass, unchanged, whatever provider is behind them
+// (issue #85).
+//
+// The assertions here never depend on adapter-specific fixture data for the
+// one guarantee that has to hold identically everywhere: a lookup naming a
+// tenant the adapter does not serve is an error, never a filtered or empty
+// result. A leaked service-account credential is scoped to one tenant only
+// if every adapter refuses to answer for another one.
+package directorycontract
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+)
+
+// Factory builds the directory under test, and OtherTenant is a tenant the
+// built directory does not serve - the cross-tenant case every case below
+// exercises.
+type Factory func(t *testing.T) (directory idpdirectory.IdentityDirectory, otherTenant idpdirectory.TenantID)
+
+// Run executes the whole contract against one adapter.
+func Run(t *testing.T, newDirectory Factory) {
+	t.Helper()
+
+	t.Run("organizations of another tenant is refused, not filtered or empty", func(t *testing.T) {
+		directory, otherTenant := newDirectory(t)
+		_, err := directory.OrganizationsOfTenant(context.Background(), otherTenant, idpdirectory.OrganizationSearch{})
+		assertUnknownTenant(t, "OrganizationsOfTenant", err)
+	})
+
+	t.Run("a user's organizations in another tenant is refused, not filtered or empty", func(t *testing.T) {
+		directory, otherTenant := newDirectory(t)
+		_, err := directory.OrganizationsOfUser(context.Background(), otherTenant, "a-user")
+		assertUnknownTenant(t, "OrganizationsOfUser", err)
+	})
+
+	t.Run("members of an organization in another tenant is refused, not filtered or empty", func(t *testing.T) {
+		directory, otherTenant := newDirectory(t)
+		_, err := directory.MembersOfOrganization(context.Background(), otherTenant, "an-organization", idpdirectory.PageRequest{})
+		assertUnknownTenant(t, "MembersOfOrganization", err)
+	})
+}
+
+// assertUnknownTenant requires an error - ErrUnknownTenant for an adapter
+// that actually serves organizations, or any other error (ErrUnimplemented,
+// for a stub that serves none of them) for one that does not. Either way,
+// nothing about another tenant's organizations is ever returned as data.
+func assertUnknownTenant(t *testing.T, operation string, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s for another tenant returned no error; a cross-tenant lookup must never succeed", operation)
+	}
+	if errors.Is(err, idpdirectory.ErrUnimplemented) {
+		return
+	}
+	if !errors.Is(err, idpdirectory.ErrUnknownTenant) {
+		t.Errorf("%s error = %v, want %v (or %v for a stub)", operation, err, idpdirectory.ErrUnknownTenant, idpdirectory.ErrUnimplemented)
+	}
+}

--- a/libs/idpdirectory/keycloak/keycloak.go
+++ b/libs/idpdirectory/keycloak/keycloak.go
@@ -242,6 +242,82 @@ func (d *Directory) ResolveRuntimeRoles(_ context.Context, token tokenverifier.V
 	return append([]string(nil), token.Roles...), nil
 }
 
+// OrganizationsOfTenant returns one window of the realm's organizations
+// (issue #85). Keycloak's own Organizations admin API (`GET
+// /organizations`) is a read; nothing in this adapter ever writes one.
+func (d *Directory) OrganizationsOfTenant(ctx context.Context, tenant idpdirectory.TenantID, query idpdirectory.OrganizationSearch) (idpdirectory.Page[idpdirectory.OrganizationRef], error) {
+	var empty idpdirectory.Page[idpdirectory.OrganizationRef]
+	if err := d.checkTenant(tenant); err != nil {
+		return empty, err
+	}
+
+	page := query.Page.Normalised()
+	params := url.Values{}
+	if query.Query != "" {
+		params.Set("search", query.Query)
+	}
+	applyWindow(params, page)
+
+	var found []organizationRepresentation
+	if err := d.getJSON(ctx, d.adminPath("organizations"), params, &found); err != nil {
+		return empty, err
+	}
+
+	items, hasMore := trim(found, page.Limit)
+	refs := make([]idpdirectory.OrganizationRef, 0, len(items))
+	for _, representation := range items {
+		refs = append(refs, representation.toRef())
+	}
+	return idpdirectory.Page[idpdirectory.OrganizationRef]{
+		Items: refs, Offset: page.Offset, Limit: page.Limit, HasMore: hasMore,
+	}, nil
+}
+
+// OrganizationsOfUser returns every organization a user belongs to
+// (issue #85), via Keycloak's `GET
+// /organizations/members/{member-id}/organizations`.
+func (d *Directory) OrganizationsOfUser(ctx context.Context, tenant idpdirectory.TenantID, userExternalID string) ([]idpdirectory.OrganizationRef, error) {
+	if err := d.checkTenant(tenant); err != nil {
+		return nil, err
+	}
+	var found []organizationRepresentation
+	if err := d.getJSON(ctx, d.adminPath("organizations", "members", userExternalID, "organizations"), nil, &found); err != nil {
+		return nil, err
+	}
+	refs := make([]idpdirectory.OrganizationRef, 0, len(found))
+	for _, representation := range found {
+		refs = append(refs, representation.toRef())
+	}
+	return refs, nil
+}
+
+// MembersOfOrganization returns one window of an organization's members
+// (issue #85), via Keycloak's `GET /organizations/{id}/members`.
+func (d *Directory) MembersOfOrganization(ctx context.Context, tenant idpdirectory.TenantID, organizationExternalID string, page idpdirectory.PageRequest) (idpdirectory.Page[idpdirectory.UserRef], error) {
+	var empty idpdirectory.Page[idpdirectory.UserRef]
+	if err := d.checkTenant(tenant); err != nil {
+		return empty, err
+	}
+
+	normalised := page.Normalised()
+	params := url.Values{}
+	applyWindow(params, normalised)
+
+	var found []userRepresentation
+	if err := d.getJSON(ctx, d.adminPath("organizations", organizationExternalID, "members"), params, &found); err != nil {
+		return empty, err
+	}
+
+	items, hasMore := trim(found, normalised.Limit)
+	refs := make([]idpdirectory.UserRef, 0, len(items))
+	for _, representation := range items {
+		refs = append(refs, representation.toRef())
+	}
+	return idpdirectory.Page[idpdirectory.UserRef]{
+		Items: refs, Offset: normalised.Offset, Limit: normalised.Limit, HasMore: hasMore,
+	}, nil
+}
+
 func (d *Directory) checkTenant(tenant idpdirectory.TenantID) error {
 	if tenant != d.cfg.TenantID {
 		return fmt.Errorf("%w: %q", idpdirectory.ErrUnknownTenant, tenant)
@@ -488,4 +564,14 @@ type roleRepresentation struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
+}
+
+type organizationRepresentation struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Alias string `json:"alias"`
+}
+
+func (o organizationRepresentation) toRef() idpdirectory.OrganizationRef {
+	return idpdirectory.OrganizationRef{ExternalID: o.ID, Alias: o.Alias, Name: o.Name}
 }

--- a/libs/idpdirectory/keycloak/keycloak_test.go
+++ b/libs/idpdirectory/keycloak/keycloak_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/directorycontract"
 	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/keycloak"
 	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
 )
@@ -292,6 +293,125 @@ func TestRuntimeRolesForATokenFromAnotherTenantAreRefused(t *testing.T) {
 	}
 }
 
+// Paging organizations of a tenant follows the same window contract as
+// SearchUsers and SearchRoles (issue #85).
+func TestOrganizationsOfTenantAsksKeycloakForTheRequestedWindowAndReportsMore(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.organizations = []organization{
+		{ID: "org-north", Name: "North Hospital", Alias: "north-hospital"},
+		{ID: "org-south", Name: "South Hospital", Alias: "south-hospital"},
+		{ID: "org-east", Name: "East Hospital", Alias: "east-hospital"},
+	}
+	defer fake.Close()
+
+	page, err := fake.directory(t).OrganizationsOfTenant(context.Background(), tenant, idpdirectory.OrganizationSearch{
+		Page: idpdirectory.PageRequest{Offset: 0, Limit: 2},
+	})
+	if err != nil {
+		t.Fatalf("OrganizationsOfTenant: %v", err)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("returned %d organizations, want the 2 that were asked for", len(page.Items))
+	}
+	if page.Items[0].ExternalID != "org-north" || page.Items[0].Alias != "north-hospital" {
+		t.Errorf("first organization = %+v, want org-north/north-hospital", page.Items[0])
+	}
+	if !page.HasMore {
+		t.Error("HasMore = false, want true: a third organization remains")
+	}
+}
+
+// A cross-tenant lookup is an error, not a filtered or empty result
+// (issue #85's acceptance criterion).
+func TestOrganizationsOfTenantForAnotherTenantIsRefused(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	defer fake.Close()
+
+	_, err := fake.directory(t).OrganizationsOfTenant(context.Background(), idpdirectory.TenantID("tenant-b"), idpdirectory.OrganizationSearch{})
+	if !errors.Is(err, idpdirectory.ErrUnknownTenant) {
+		t.Errorf("OrganizationsOfTenant error = %v, want %v", err, idpdirectory.ErrUnknownTenant)
+	}
+}
+
+// A user's own memberships are a small, bounded list - unpaged, like
+// GetUserRoles.
+func TestOrganizationsOfUserReportsEveryMembership(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.organizations = []organization{
+		{ID: "org-north", Name: "North Hospital", Alias: "north-hospital"},
+		{ID: "org-south", Name: "South Hospital", Alias: "south-hospital"},
+	}
+	fake.organizationMembers = map[string][]user{
+		"org-north": {{ID: "user-doctor-multi"}},
+		"org-south": {{ID: "user-doctor-multi"}},
+	}
+	defer fake.Close()
+
+	orgs, err := fake.directory(t).OrganizationsOfUser(context.Background(), tenant, "user-doctor-multi")
+	if err != nil {
+		t.Fatalf("OrganizationsOfUser: %v", err)
+	}
+	if len(orgs) != 2 {
+		t.Fatalf("organizations = %v, want both memberships", orgs)
+	}
+}
+
+func TestOrganizationsOfUserForAnotherTenantIsRefused(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	defer fake.Close()
+
+	_, err := fake.directory(t).OrganizationsOfUser(context.Background(), idpdirectory.TenantID("tenant-b"), "user-doctor-multi")
+	if !errors.Is(err, idpdirectory.ErrUnknownTenant) {
+		t.Errorf("OrganizationsOfUser error = %v, want %v", err, idpdirectory.ErrUnknownTenant)
+	}
+}
+
+// The reach of a permission grant: paging an organization's members
+// follows the same window contract as SearchUsers.
+func TestMembersOfOrganizationAsksKeycloakForTheRequestedWindowAndReportsMore(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	fake.organizationMembers = map[string][]user{
+		"org-north": {
+			{ID: "user-1", Username: "doctor-1"},
+			{ID: "user-2", Username: "doctor-2"},
+			{ID: "user-3", Username: "doctor-3"},
+		},
+	}
+	defer fake.Close()
+
+	page, err := fake.directory(t).MembersOfOrganization(context.Background(), tenant, "org-north",
+		idpdirectory.PageRequest{Offset: 0, Limit: 2})
+	if err != nil {
+		t.Fatalf("MembersOfOrganization: %v", err)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("returned %d members, want the 2 that were asked for", len(page.Items))
+	}
+	if !page.HasMore {
+		t.Error("HasMore = false, want true: a third member remains")
+	}
+}
+
+func TestMembersOfOrganizationForAnotherTenantIsRefused(t *testing.T) {
+	fake := newFakeKeycloak(t)
+	defer fake.Close()
+
+	_, err := fake.directory(t).MembersOfOrganization(context.Background(), idpdirectory.TenantID("tenant-b"), "org-north", idpdirectory.PageRequest{})
+	if !errors.Is(err, idpdirectory.ErrUnknownTenant) {
+		t.Errorf("MembersOfOrganization error = %v, want %v", err, idpdirectory.ErrUnknownTenant)
+	}
+}
+
+// The shared cross-tenant contract (issue #85): a directory built for
+// tenant-a never answers an organization read for tenant-b.
+func TestDirectoryContract(t *testing.T) {
+	directorycontract.Run(t, func(t *testing.T) (idpdirectory.IdentityDirectory, idpdirectory.TenantID) {
+		fake := newFakeKeycloak(t)
+		t.Cleanup(fake.Close)
+		return fake.directory(t), idpdirectory.TenantID("tenant-b")
+	})
+}
+
 // --- a fake Keycloak admin API ---------------------------------------------
 
 type user struct {
@@ -309,6 +429,12 @@ type role struct {
 	Description string `json:"description"`
 }
 
+type organization struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Alias string `json:"alias"`
+}
+
 type fakeKeycloak struct {
 	*httptest.Server
 	t *testing.T
@@ -319,6 +445,10 @@ type fakeKeycloak struct {
 	// reports as directly assigned, from the same authoritative source
 	// clientRoles models.
 	userRoleMappings map[string][]role
+	organizations    []organization
+	// organizationMembers keys an organization's external id to its
+	// members, the same shape Keycloak's own membership endpoint reports.
+	organizationMembers map[string][]user
 	// clientUUID is the internal id the fake currently reports for the client.
 	// Changing it stands in for a realm that was rebuilt.
 	clientUUID string
@@ -376,6 +506,23 @@ func (f *fakeKeycloak) serve(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		w.WriteHeader(http.StatusNotFound)
+	case path == "/admin/realms/"+realm+"/organizations":
+		writeJSON(f.t, w, window(f.organizations, r))
+	case strings.HasPrefix(path, "/admin/realms/"+realm+"/organizations/members/") && strings.HasSuffix(path, "/organizations"):
+		id := strings.TrimSuffix(strings.TrimPrefix(path, "/admin/realms/"+realm+"/organizations/members/"), "/organizations")
+		var found []organization
+		for _, org := range f.organizations {
+			for _, member := range f.organizationMembers[org.ID] {
+				if member.ID == id {
+					found = append(found, org)
+					break
+				}
+			}
+		}
+		writeJSON(f.t, w, found)
+	case strings.HasPrefix(path, "/admin/realms/"+realm+"/organizations/") && strings.HasSuffix(path, "/members"):
+		id := strings.TrimSuffix(strings.TrimPrefix(path, "/admin/realms/"+realm+"/organizations/"), "/members")
+		writeJSON(f.t, w, window(f.organizationMembers[id], r))
 	case path == "/admin/realms/"+realm+"/clients":
 		writeJSON(f.t, w, []map[string]string{{"id": f.clientUUID, "clientId": clientID}})
 	case path == "/admin/realms/"+realm+"/clients/"+f.clientUUID+"/roles":

--- a/libs/idpdirectory/port.go
+++ b/libs/idpdirectory/port.go
@@ -52,6 +52,17 @@ type RoleRef struct {
 	Description string
 }
 
+// OrganizationRef is an organization as the directory knows it (issue #85).
+// Alias is the identifier §78's OrganizationClaim and HospitalID carry - the
+// same string, not a display name that happens to look similar - so a
+// caller can match this ref against a verified token's hospital with no
+// translation step.
+type OrganizationRef struct {
+	ExternalID string
+	Alias      string
+	Name       string
+}
+
 // PageRequest is one window over a result set. Both fields are honoured by
 // every adapter: the Admin Console pages through hundreds of thousands of
 // users, so an adapter that quietly returned everything would be unusable.
@@ -95,6 +106,12 @@ type RoleSearch struct {
 	Page  PageRequest
 }
 
+// OrganizationSearch selects organizations of a tenant.
+type OrganizationSearch struct {
+	Query string
+	Page  PageRequest
+}
+
 // Page is one window of results plus what a caller needs to ask for the next.
 type Page[T any] struct {
 	Items   []T
@@ -122,4 +139,17 @@ type IdentityDirectory interface {
 	// directory round trip on the decision path would put the identity
 	// provider's availability in front of every authorization call.
 	ResolveRuntimeRoles(ctx context.Context, token tokenverifier.VerifiedToken, tenant TenantID) ([]string, error)
+
+	// OrganizationsOfTenant reports one window of the organizations a
+	// tenant declares (issue #85). Keycloak stays the only place that
+	// creates or changes one; this is a read.
+	OrganizationsOfTenant(ctx context.Context, tenant TenantID, query OrganizationSearch) (Page[OrganizationRef], error)
+	// OrganizationsOfUser reports every organization a user belongs to,
+	// unpaged like GetUserRoles: a person's own memberships are a small,
+	// bounded list, not a directory-scale search.
+	OrganizationsOfUser(ctx context.Context, tenant TenantID, userExternalID string) ([]OrganizationRef, error)
+	// MembersOfOrganization reports one window of an organization's
+	// members, so an administrator granting a permission can see the
+	// reach of what they are about to do.
+	MembersOfOrganization(ctx context.Context, tenant TenantID, organizationExternalID string, page PageRequest) (Page[UserRef], error)
 }

--- a/libs/idpdirectory/wso2/wso2.go
+++ b/libs/idpdirectory/wso2/wso2.go
@@ -81,3 +81,22 @@ func (d *Directory) GetUserRoles(context.Context, idpdirectory.TenantID, string)
 func (d *Directory) ResolveRuntimeRoles(context.Context, tokenverifier.VerifiedToken, idpdirectory.TenantID) ([]string, error) {
 	return nil, unimplemented("runtime role resolution", "SCIM2 /Roles")
 }
+
+// OrganizationsOfTenant is not implemented (issue #85). WSO2 Identity
+// Server's shape for this is organizations under SCIM2, which this stub
+// does not model.
+func (d *Directory) OrganizationsOfTenant(context.Context, idpdirectory.TenantID, idpdirectory.OrganizationSearch) (idpdirectory.Page[idpdirectory.OrganizationRef], error) {
+	return idpdirectory.Page[idpdirectory.OrganizationRef]{}, unimplemented("organization search", "SCIM2 organizations")
+}
+
+// OrganizationsOfUser is not implemented. It would use SCIM2's own
+// organization membership representation for a user.
+func (d *Directory) OrganizationsOfUser(context.Context, idpdirectory.TenantID, string) ([]idpdirectory.OrganizationRef, error) {
+	return nil, unimplemented("a user's organizations", "SCIM2 organizations")
+}
+
+// MembersOfOrganization is not implemented. It would use SCIM2's own
+// organization membership representation.
+func (d *Directory) MembersOfOrganization(context.Context, idpdirectory.TenantID, string, idpdirectory.PageRequest) (idpdirectory.Page[idpdirectory.UserRef], error) {
+	return idpdirectory.Page[idpdirectory.UserRef]{}, unimplemented("organization members", "SCIM2 organizations")
+}

--- a/libs/idpdirectory/wso2/wso2_test.go
+++ b/libs/idpdirectory/wso2/wso2_test.go
@@ -7,9 +7,24 @@ import (
 	"testing"
 
 	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/directorycontract"
 	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory/wso2"
 	"github.com/tishan-harischandra/cerbos-poc/libs/tokenverifier"
 )
+
+// The shared cross-tenant contract (issue #85): even a stub that implements
+// none of the organization reads must never answer with data for a tenant
+// it does not serve - ErrUnimplemented satisfies that as surely as
+// ErrUnknownTenant would.
+func TestDirectoryContract(t *testing.T) {
+	directorycontract.Run(t, func(t *testing.T) (idpdirectory.IdentityDirectory, idpdirectory.TenantID) {
+		directory, err := wso2.New(wso2.Config{BaseURL: "https://identity.internal", TenantID: "tenant-a"})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		return directory, idpdirectory.TenantID("tenant-b")
+	})
+}
 
 // The stub proves the seam: it satisfies the whole port, so a second provider
 // needs no change to the interface, and it fails loudly on every operation, so
@@ -51,6 +66,18 @@ func TestEveryOperationReportsThatItIsNotImplemented(t *testing.T) {
 		},
 		"ResolveRuntimeRoles": func() error {
 			_, err := port.ResolveRuntimeRoles(ctx, tokenverifier.VerifiedToken{}, "tenant-a")
+			return err
+		},
+		"OrganizationsOfTenant": func() error {
+			_, err := port.OrganizationsOfTenant(ctx, "tenant-a", idpdirectory.OrganizationSearch{})
+			return err
+		},
+		"OrganizationsOfUser": func() error {
+			_, err := port.OrganizationsOfUser(ctx, "tenant-a", "user-doctor")
+			return err
+		},
+		"MembersOfOrganization": func() error {
+			_, err := port.MembersOfOrganization(ctx, "tenant-a", "org-north", idpdirectory.PageRequest{})
 			return err
 		},
 	}

--- a/scripts/tests/organizations-e2e.sh
+++ b/scripts/tests/organizations-e2e.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# The identity directory's organization reads, end to end (issue #85):
+# a real Keycloak, a real service-account token, and the ADS's own proxy
+# through to the Admin Console.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+# shellcheck source=scripts/tests/lib-token.sh
+source scripts/tests/lib-token.sh
+
+PORT="${ADMIN_CONSOLE_PORT:-4200}"
+ADS_URL="http://127.0.0.1:${PORT}/api/ads"
+failures=0
+
+command -v jq >/dev/null 2>&1 || { echo "organizations-e2e: jq is required" >&2; exit 1; }
+wait_for_keycloak || exit 1
+
+pass() { echo "ok   $1"; }
+fail() { echo "FAIL $1"; failures=$((failures + 1)); }
+
+admin_token="$(token_for user-admin)" || exit 1
+
+echo "--- organizations of a tenant ---"
+
+response="$(curl -sS --max-time 10 -H "Authorization: Bearer ${admin_token}" \
+  "${ADS_URL}/internal/directory/organizations")"
+aliases="$(jq -r '.items[].alias' <<<"${response}" 2>/dev/null | sort)"
+if [[ "${aliases}" == $'north-hospital\nsouth-hospital' ]]; then
+  pass "the tenant's own organizations are listed"
+else
+  fail "the tenant's own organizations are listed (was: ${response})"
+fi
+
+north_id="$(jq -r '.items[] | select(.alias == "north-hospital") | .externalId' <<<"${response}")"
+if [[ -z "${north_id}" || "${north_id}" == "null" ]]; then
+  fail "north-hospital's external id could not be read (headers were: ${response})"
+fi
+
+echo
+echo "--- members of an organization ---"
+
+if [[ -n "${north_id}" && "${north_id}" != "null" ]]; then
+  members_response="$(curl -sS --max-time 10 -H "Authorization: Bearer ${admin_token}" \
+    "${ADS_URL}/internal/directory/organizations/${north_id}/members")"
+  usernames="$(jq -r '.items[].username' <<<"${members_response}" 2>/dev/null | sort)"
+  if grep -qx "user-doctor" <<<"${usernames}"; then
+    pass "the organization's own members are listed"
+  else
+    fail "the organization's own members are listed (was: ${members_response})"
+  fi
+fi
+
+echo
+echo "--- organizations of a user ---"
+
+user_orgs_response="$(curl -sS --max-time 10 -H "Authorization: Bearer ${admin_token}" \
+  "${ADS_URL}/internal/directory/users/user-doctor-multi/organizations")"
+user_aliases="$(jq -r '.items[].alias' <<<"${user_orgs_response}" 2>/dev/null | sort)"
+if [[ "${user_aliases}" == $'north-hospital\nsouth-hospital' ]]; then
+  pass "a user's own memberships are listed"
+else
+  fail "a user's own memberships are listed (was: ${user_orgs_response})"
+fi
+
+echo
+echo "--- a cross-tenant lookup is refused, not filtered or empty ---"
+
+status="$(curl -sS --max-time 10 -o /tmp/organizations-cross-tenant.json -w '%{http_code}' \
+  -H "Authorization: Bearer ${admin_token}" \
+  --get "${ADS_URL}/internal/directory/organizations" --data-urlencode "tenantId=tenant-b")"
+if [[ "${status}" == "400" ]]; then
+  pass "naming another tenant in the request is refused outright"
+else
+  fail "naming another tenant in the request is refused outright (HTTP ${status}: $(cat /tmp/organizations-cross-tenant.json))"
+fi
+rm -f /tmp/organizations-cross-tenant.json
+
+echo
+echo "--- the admin credential stays server side ---"
+
+if curl -sS --max-time 10 -H "Authorization: Bearer ${admin_token}" \
+  "${ADS_URL}/internal/directory/organizations" | grep -qi "client_secret\|password"; then
+  fail "the organizations response echoed a credential"
+else
+  pass "no browser-reachable response carries the IdP admin credential"
+fi
+
+if (( failures > 0 )); then
+  echo
+  echo "${failures} organizations failure(s)"
+  exit 1
+fi
+
+echo
+echo "organizations end to end passed"

--- a/tests/architecture/organizationwrites.go
+++ b/tests/architecture/organizationwrites.go
@@ -1,0 +1,73 @@
+package architecture
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"regexp"
+	"strings"
+)
+
+// organizationAdapterFiles are the identity directory adapters' own files -
+// the "adapter surface" issue #85's acceptance criterion names. Keycloak
+// stays the only place an organization or a membership is created or
+// changed; this platform only ever reads them.
+var organizationAdapterFiles = map[string]bool{
+	"libs/idpdirectory/keycloak/keycloak.go": true,
+	"libs/idpdirectory/wso2/wso2.go":         true,
+}
+
+var organizationFuncName = regexp.MustCompile(`(?i)organization`)
+
+// writeHTTPMethods are the net/http method constants a read never needs.
+var writeHTTPMethods = map[string]bool{
+	"MethodPost":   true,
+	"MethodPut":    true,
+	"MethodPatch":  true,
+	"MethodDelete": true,
+}
+
+// ScanForOrganizationWrite reports a write HTTP method used inside a
+// function whose name is about organizations or their memberships. It is
+// scoped to those functions, not the whole file, so a legitimate write
+// elsewhere in the same adapter - minting the service-account token, for
+// instance - is not mistaken for one.
+func ScanForOrganizationWrite(filename, src string) ([]Finding, error) {
+	if !organizationAdapterFiles[strings.ReplaceAll(filename, "\\", "/")] {
+		return nil, nil
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, src, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", filename, err)
+	}
+
+	var findings []Finding
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil || !organizationFuncName.MatchString(fn.Name.Name) {
+			continue
+		}
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			selector, ok := node.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := selector.X.(*ast.Ident)
+			if !ok || pkg.Name != "http" || !writeHTTPMethods[selector.Sel.Name] {
+				return true
+			}
+			findings = append(findings, Finding{
+				File:   filename,
+				Line:   fset.Position(selector.Pos()).Line,
+				Symbol: fn.Name.Name + ": http." + selector.Sel.Name,
+				Message: "no write path to organizations or memberships exists in this platform " +
+					"(issue #85); Keycloak is the sole system of record",
+			})
+			return true
+		})
+	}
+	return findings, nil
+}

--- a/tests/architecture/organizationwrites_test.go
+++ b/tests/architecture/organizationwrites_test.go
@@ -1,0 +1,112 @@
+package architecture_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/tests/architecture"
+)
+
+// The constraint issue #85 asks for explicitly: no write path to
+// organizations or memberships exists anywhere in this platform.
+func TestNoAdapterWritesAnOrganizationOrMembership(t *testing.T) {
+	root := repoRoot(t)
+
+	var findings []architecture.Finding
+	for _, path := range goFiles(t, root) {
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatalf("relativising %s: %v", path, err)
+		}
+
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+
+		fileFindings, err := architecture.ScanForOrganizationWrite(filepath.ToSlash(relative), string(source))
+		if err != nil {
+			t.Fatalf("scanning %s: %v", relative, err)
+		}
+		findings = append(findings, fileFindings...)
+	}
+
+	if len(findings) > 0 {
+		var report strings.Builder
+		report.WriteString("a write path to organizations or memberships was found:\n")
+		for _, finding := range findings {
+			report.WriteString("  " + finding.String() + "\n")
+		}
+		t.Fatal(report.String())
+	}
+}
+
+// An architecture test that cannot fail is decoration.
+func TestTheCheckerCatchesAnOrganizationWrite(t *testing.T) {
+	const violation = `package keycloak
+
+import "net/http"
+
+func (d *Directory) AddOrganizationMember(ctx context.Context, id string) error {
+	request, _ := http.NewRequestWithContext(ctx, http.MethodPost, d.adminPath("organizations", id, "members"), nil)
+	_, err := d.http.Do(request)
+	return err
+}
+`
+
+	findings, err := architecture.ScanForOrganizationWrite("libs/idpdirectory/keycloak/keycloak.go", violation)
+	if err != nil {
+		t.Fatalf("ScanForOrganizationWrite: %v", err)
+	}
+	if len(findings) != 1 || findings[0].Symbol != "AddOrganizationMember: http.MethodPost" {
+		t.Errorf("findings = %v, want one for the write in AddOrganizationMember", findings)
+	}
+}
+
+// A write elsewhere in the same adapter file - minting the service-account
+// token, say - must not be mistaken for an organization write.
+func TestTheCheckerIgnoresAnUnrelatedWriteInTheSameFile(t *testing.T) {
+	const source = `package keycloak
+
+import "net/http"
+
+func (d *Directory) serviceAccountToken(ctx context.Context) (string, error) {
+	request, _ := http.NewRequestWithContext(ctx, http.MethodPost, d.tokenEndpoint(), nil)
+	_, err := d.http.Do(request)
+	return "", err
+}
+`
+
+	findings, err := architecture.ScanForOrganizationWrite("libs/idpdirectory/keycloak/keycloak.go", source)
+	if err != nil {
+		t.Fatalf("ScanForOrganizationWrite: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("an unrelated write was flagged: %v", findings)
+	}
+}
+
+// The checker only scans the identity directory adapters, not every file in
+// the repository.
+func TestTheCheckerIgnoresFilesOutsideTheAdapterSurface(t *testing.T) {
+	const violation = `package somewhereelse
+
+import "net/http"
+
+func DeleteOrganization(ctx context.Context) error {
+	request, _ := http.NewRequestWithContext(ctx, http.MethodDelete, "https://example.test/organizations/1", nil)
+	_, err := http.DefaultClient.Do(request)
+	return err
+}
+`
+
+	findings, err := architecture.ScanForOrganizationWrite("apps/ads/internal/somewhereelse/somewhereelse.go", violation)
+	if err != nil {
+		t.Fatalf("ScanForOrganizationWrite: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("a file outside the adapter surface was flagged: %v", findings)
+	}
+}


### PR DESCRIPTION
## What changed

- `libs/idpdirectory`: three new port reads - `OrganizationsOfTenant`,
  `OrganizationsOfUser` and `MembersOfOrganization` - paged the same way
  `SearchUsers`/`SearchRoles` already are, or unpaged like `GetUserRoles`
  where a bounded per-user list makes paging pointless.
- `libs/idpdirectory/keycloak`: implements all three against Keycloak's
  real Organizations admin REST API
  (`/organizations`, `/organizations/{id}/members`,
  `/organizations/members/{id}/organizations`).
- `libs/idpdirectory/wso2`: the stub gains the same three methods,
  reporting `ErrUnimplemented` like every other operation it does not
  model.
- `libs/idpdirectory/directorycontract`: a new shared contract suite -
  every adapter must refuse a cross-tenant organization lookup with an
  error, never a filtered or empty result. Run against both the Keycloak
  adapter (a real refusal) and the WSO2 stub (`ErrUnimplemented` also
  satisfies "never returns data for a tenant it does not serve").
- `tests/architecture`: a new check scanning the identity directory
  adapters' own files for a write HTTP method inside any function whose
  name is about organizations or memberships - the "no write path exists,
  enforced by an architecture test" criterion.
- `apps/ads/internal/directoryapi`: three new handlers proxying the reads
  above to the Admin Console, the same way user/role search already are.
- `apps/admin-console`: a new Organizations module lists a tenant's
  organizations and, on selection, an organization's members; the
  user-override screen now shows a selected user's hospital memberships
  before granting or revoking a permission.
- `deploy/keycloak/realm-tenant-a.json` / `realm-tenant-b.json`: the
  per-tenant service account gains `manage-realm` - the finding below
  explains why.
- `scripts/tests/organizations-e2e.sh`: end-to-end coverage against a real
  `make up` stack, wired into `make smoke`.

## A measured finding: no narrower permission exists for the list reads

Wiring the two listing endpoints (`OrganizationsOfTenant`,
`MembersOfOrganization`) against a real Keycloak 26.4 found they hard-require
the realm-management client role `manage-realm` - a materially broader grant
than a read-only feature should need, and there is no narrower alternative in
this Keycloak version. The third read (`OrganizationsOfUser`) needed nothing
beyond the roles already granted for issues #76/#77. See
`docs/MEASURED_FINDINGS.md#listing-organizations-requires-the-broad-manage-realm-role-issue-85`
for the investigation. The grant is still scoped to one tenant's own service
account (issue #76's per-tenant isolation), so a leaked credential still
exposes only that tenant, but it is a real widening of that credential's
power that the architecture test on this platform's own adapter code cannot
see or bound - recorded rather than declared a clean read-only story.

## Acceptance criteria

- [x] The directory port exposes organizations of a tenant, organizations of
      a user, and members of an organization, with paging consistent with
      the existing reads
- [x] The shared directory contract suite covers all three reads, so every
      adapter is held to the same behaviour
- [x] A cross-tenant lookup returns an error, not a filtered or empty result
- [x] Each tenant has its own service-account client and secret, referenced
      by the registry and mounted by file rather than passed by value -
      already true since issues #76/#77; unchanged here
- [x] The Admin Console lists a tenant's organizations and an organization's
      members
- [x] The Admin Console shows a user's hospital memberships when granting or
      revoking a permission
- [x] No write path to organizations or memberships exists anywhere in this
      platform, enforced by an architecture test on the adapter surface

## How it was verified

- `bash scripts/go.sh libs/idpdirectory test ./...`
- `bash scripts/go.sh apps/ads test ./...`
- `make arch-test`
- `npx nx test admin-console`, `npx nx lint admin-console`,
  `npx nx build admin-console`
- Full `make up` stack, rebuilt with the new `manage-realm` grant, then
  `make smoke` (every existing e2e suite plus the new
  `scripts/tests/organizations-e2e.sh`) - all green.


Closes #85
