### PR TITLE
Tenant onboarding through the Admin Service (#86)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ smoke: ## Verify a running stack end to end
 	bash scripts/tests/tenant-subdomain-e2e.sh
 	bash scripts/tests/hospital-switch-e2e.sh
 	bash scripts/tests/organizations-e2e.sh
+	bash scripts/tests/tenant-onboarding-e2e.sh
 
 .PHONY: walkthrough
 walkthrough: ## Execute the README's guided walkthrough against a running deployment

--- a/apps/admin-service/cmd/admin-service/main.go
+++ b/apps/admin-service/cmd/admin-service/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/server"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/simulate"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tenantonboarding"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/useroverride"
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/postgresstore"
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/tenantresolve"
@@ -190,6 +191,9 @@ func main() {
 			ADS:           adsclient.New(cfg.ADSAddr),
 			IdPType:       string(homeRealm.Config.Type),
 			IdPRoleSource: string(homeRealm.Config.RoleSource),
+		},
+		TenantOnboarding: &tenantonboarding.Handler{
+			Store: store,
 		},
 		Console: consoleConfig,
 	})

--- a/apps/admin-service/internal/server/server.go
+++ b/apps/admin-service/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/platformstatus"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/rolematrix"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/simulate"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tenantonboarding"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
 	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/useroverride"
 	"github.com/tishan-harischandra/cerbos-poc/libs/tenantregistry"
@@ -66,6 +67,10 @@ type Config struct {
 	// diagnostics endpoints (issue #22). Nil means the routes are not
 	// registered.
 	PlatformStatus *platformstatus.Handler
+
+	// TenantOnboarding serves POST /admin/authz/tenants (issue #86). Nil
+	// means the route is not registered.
+	TenantOnboarding *tenantonboarding.Handler
 
 	// Console serves the Admin Console: its bundle, its runtime
 	// environment, and the ADS calls it makes through this origin
@@ -123,6 +128,9 @@ func New(cfg Config) (http.Handler, error) {
 			mux.Handle("GET /admin/authz/policy-releases", authenticated(cfg.PlatformStatus.PolicyReleases))
 			mux.Handle("GET /admin/authz/tenants/{tenant}/convergence", authenticated(cfg.PlatformStatus.Convergence))
 			mux.Handle("GET /admin/idp/diagnostics", authenticated(cfg.PlatformStatus.IdPDiagnostics))
+		}
+		if cfg.TenantOnboarding != nil {
+			mux.Handle("POST /admin/authz/tenants", authenticated(cfg.TenantOnboarding.Onboard))
 		}
 	}
 

--- a/apps/admin-service/internal/tenantonboarding/tenantonboarding.go
+++ b/apps/admin-service/internal/tenantonboarding/tenantonboarding.go
@@ -1,0 +1,168 @@
+// Package tenantonboarding implements POST /admin/authz/tenants (issue
+// #86): bringing up a new hospital group at runtime, with no release and
+// no service restart.
+//
+// The registry is file-seeded but database-of-record (issue #76): this
+// handler writes the same tenant_registry row a file-seeded entry would,
+// validated against the identical rules (libs/tenantregistry.Validate),
+// so there is exactly one definition of "a valid tenant" rather than two
+// that could drift apart. libs/assignmentstore/tenantseed no longer
+// overwrites a realm that already has a row, so a tenant onboarded here
+// survives the next `make up`'s re-seed unchanged.
+//
+// This endpoint is deliberately not scoped to the caller's own tenant the
+// way the role-matrix and user-override writes are (§9.4's authority
+// check): the tenant being onboarded does not exist yet, so there is no
+// existing tenant to validate authority against. Any authenticated
+// administrator - from any already-registered realm - may onboard a new
+// one. This is consistent with the rest of this prototype's
+// administration surface, which trusts an authenticated caller rather
+// than checking a specific role (Cerbos policy, not this package, is
+// where role-based business authorization lives); it is not a narrower
+// "platform operator" credential this codebase has anywhere else to
+// reuse. See docs/MEASURED_FINDINGS.md for the tradeoff this leaves open.
+package tenantonboarding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+	"github.com/tishan-harischandra/cerbos-poc/libs/tenantregistry"
+)
+
+// Store is the narrow slice of assignmentstore.Store this handler needs.
+type Store interface {
+	Tenant(ctx context.Context, realm string) (assignmentstore.Tenant, bool, error)
+	SaveTenant(ctx context.Context, tenant assignmentstore.Tenant) error
+	AppendAuditEvent(ctx context.Context, event assignmentstore.AuditEvent) error
+}
+
+type onboardRequest struct {
+	Realm               string `json:"realm"`
+	Issuer              string `json:"issuer"`
+	BrowserClientID     string `json:"browserClientId"`
+	ServiceClientID     string `json:"serviceClientId"`
+	CredentialSecretRef string `json:"credentialSecretRef"`
+}
+
+// Handler serves the tenant onboarding endpoint.
+type Handler struct {
+	Store Store
+	// Now is the clock the audit row is stamped with. Injected so a test
+	// can assert on a fixed value.
+	Now func() time.Time
+	// NewEventID mints the audit row's id. Injected so a test can assert
+	// on a deterministic id.
+	NewEventID func() string
+}
+
+func (h *Handler) now() time.Time {
+	if h.Now != nil {
+		return h.Now()
+	}
+	return time.Now()
+}
+
+func (h *Handler) newEventID() string {
+	if h.NewEventID != nil {
+		return h.NewEventID()
+	}
+	return fmt.Sprintf("evt-%d", time.Now().UnixNano())
+}
+
+// Onboard handles POST /admin/authz/tenants.
+func (h *Handler) Onboard(w http.ResponseWriter, r *http.Request) {
+	identity, ok := tokenauth.From(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "no verified identity on this request")
+		return
+	}
+
+	var req onboardRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "malformed request body")
+		return
+	}
+
+	serviceClientID := req.ServiceClientID
+	if serviceClientID == "" {
+		serviceClientID = req.BrowserClientID
+	}
+	entry := tenantregistry.Entry{
+		Realm:               req.Realm,
+		Issuer:              req.Issuer,
+		BrowserClientID:     req.BrowserClientID,
+		ServiceClientID:     serviceClientID,
+		CredentialSecretRef: req.CredentialSecretRef,
+	}
+	// The same rule the registry file's rows are validated against
+	// (issue #86's acceptance criterion): one definition, not two.
+	if err := tenantregistry.Validate(entry); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if _, exists, err := h.Store.Tenant(r.Context(), entry.Realm); err != nil {
+		writeError(w, http.StatusInternalServerError, "reading the tenant registry failed")
+		return
+	} else if exists {
+		writeError(w, http.StatusConflict, fmt.Sprintf("realm %q is already registered", entry.Realm))
+		return
+	}
+
+	if err := h.Store.SaveTenant(r.Context(), assignmentstore.Tenant{
+		Realm:               entry.Realm,
+		Issuer:              entry.Issuer,
+		BrowserClientID:     entry.BrowserClientID,
+		ServiceClientID:     entry.ServiceClientID,
+		CredentialSecretRef: entry.CredentialSecretRef,
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, "saving the tenant registry row failed")
+		return
+	}
+
+	// Audited like every other administrative write (issue #86's
+	// acceptance criterion), even though there is no permission matrix or
+	// override to bundle it with atomically: onboarding writes exactly
+	// one row, and the audit trail records that it happened, by whom, and
+	// with what before/after state.
+	afterJSON, _ := json.Marshal(entry)
+	correlationID := r.Header.Get("X-Correlation-Id")
+	if correlationID == "" {
+		correlationID = h.newEventID()
+	}
+	if err := h.Store.AppendAuditEvent(r.Context(), assignmentstore.AuditEvent{
+		EventID:       h.newEventID(),
+		ActorID:       identity.PrincipalID,
+		Operation:     "TENANT_ONBOARD",
+		TargetType:    "tenant_registry",
+		BeforeJSON:    "{}",
+		AfterJSON:     string(afterJSON),
+		TenantID:      entry.Realm,
+		CorrelationID: correlationID,
+		CreatedAt:     h.now(),
+	}); err != nil {
+		// The tenant is already saved and usable; a failure to audit it
+		// is an observability gap to log, not a reason to tell the caller
+		// the onboarding itself failed.
+		writeError(w, http.StatusInternalServerError, "the tenant was onboarded, but recording the audit event failed")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]string{"realm": entry.Realm})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}

--- a/apps/admin-service/internal/tenantonboarding/tenantonboarding_test.go
+++ b/apps/admin-service/internal/tenantonboarding/tenantonboarding_test.go
@@ -1,0 +1,191 @@
+package tenantonboarding_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tenantonboarding"
+	"github.com/tishan-harischandra/cerbos-poc/apps/admin-service/internal/tokenauth"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+)
+
+func readableSecretFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(path, []byte("a-service-account-secret"), 0o600); err != nil {
+		t.Fatalf("writing a fixture secret file: %v", err)
+	}
+	return path
+}
+
+func request(t *testing.T, body any) *http.Request {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshalling the request body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/admin/authz/tenants", bytes.NewReader(raw))
+	return req.WithContext(tokenauth.WithIdentity(req.Context(), tokenauth.Identity{
+		PrincipalID: "user-admin",
+		TenantID:    "tenant-a",
+		HospitalID:  "hospital-1",
+		Roles:       []string{"kc:tenant-a:patient-app:administrator"},
+	}))
+}
+
+func TestOnboardingATenantSavesItAndAuditsTheWrite(t *testing.T) {
+	secret := readableSecretFile(t)
+	store := &recordingStore{}
+	handler := &tenantonboarding.Handler{Store: store}
+
+	rec := httptest.NewRecorder()
+	handler.Onboard(rec, request(t, map[string]string{
+		"realm":               "tenant-c",
+		"issuer":              "http://localhost:8081/realms/tenant-c",
+		"browserClientId":     "patient-app",
+		"serviceClientId":     "authorization-admin-service",
+		"credentialSecretRef": secret,
+	}))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusCreated, rec.Body)
+	}
+	if store.saved.Realm != "tenant-c" {
+		t.Fatalf("saved tenant = %+v, want realm tenant-c", store.saved)
+	}
+	if store.saved.Issuer != "http://localhost:8081/realms/tenant-c" {
+		t.Errorf("saved issuer = %q, want the request's issuer", store.saved.Issuer)
+	}
+
+	if len(store.audited) != 1 {
+		t.Fatalf("audited %d events, want exactly 1", len(store.audited))
+	}
+	event := store.audited[0]
+	if event.Operation != "TENANT_ONBOARD" {
+		t.Errorf("Operation = %q, want TENANT_ONBOARD", event.Operation)
+	}
+	if event.ActorID != "user-admin" {
+		t.Errorf("ActorID = %q, want the caller's own principal id", event.ActorID)
+	}
+	if event.TenantID != "tenant-c" {
+		t.Errorf("TenantID = %q, want the onboarded realm", event.TenantID)
+	}
+}
+
+func TestOnboardingRejectsTheSameRulesTheRegistryFileIsValidatedAgainst(t *testing.T) {
+	store := &recordingStore{}
+	handler := &tenantonboarding.Handler{Store: store}
+
+	cases := map[string]map[string]string{
+		"no realm": {
+			"issuer": "http://localhost:8081/realms/tenant-c", "browserClientId": "patient-app",
+			"credentialSecretRef": readableSecretFile(t),
+		},
+		"no issuer": {
+			"realm": "tenant-c", "browserClientId": "patient-app",
+			"credentialSecretRef": readableSecretFile(t),
+		},
+		"no browser client id": {
+			"realm": "tenant-c", "issuer": "http://localhost:8081/realms/tenant-c",
+			"credentialSecretRef": readableSecretFile(t),
+		},
+		"an unreadable credential secret ref": {
+			"realm": "tenant-c", "issuer": "http://localhost:8081/realms/tenant-c",
+			"browserClientId": "patient-app", "credentialSecretRef": "/nonexistent/path",
+		},
+	}
+
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			handler.Onboard(rec, request(t, body))
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body)
+			}
+			if store.saveCalls != 0 {
+				t.Error("an invalid entry reached SaveTenant")
+			}
+		})
+	}
+}
+
+// issue #86: onboarding a duplicate realm is rejected with a clear error.
+func TestOnboardingADuplicateRealmIsRejected(t *testing.T) {
+	secret := readableSecretFile(t)
+	store := &recordingStore{
+		existing: map[string]assignmentstore.Tenant{"tenant-a": {Realm: "tenant-a"}},
+	}
+	handler := &tenantonboarding.Handler{Store: store}
+
+	rec := httptest.NewRecorder()
+	handler.Onboard(rec, request(t, map[string]string{
+		"realm": "tenant-a", "issuer": "http://localhost:8081/realms/tenant-a",
+		"browserClientId": "patient-app", "credentialSecretRef": secret,
+	}))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusConflict, rec.Body)
+	}
+	if store.saveCalls != 0 {
+		t.Error("a duplicate realm reached SaveTenant")
+	}
+}
+
+func TestOnboardingRequiresAuthentication(t *testing.T) {
+	store := &recordingStore{}
+	handler := &tenantonboarding.Handler{Store: store}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/authz/tenants", bytes.NewReader([]byte("{}")))
+	rec := httptest.NewRecorder()
+	handler.Onboard(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if store.saveCalls != 0 {
+		t.Error("an unauthenticated request reached SaveTenant")
+	}
+}
+
+func TestOnboardingRejectsAMalformedBody(t *testing.T) {
+	store := &recordingStore{}
+	handler := &tenantonboarding.Handler{Store: store}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/authz/tenants", bytes.NewReader([]byte("not json")))
+	req = req.WithContext(tokenauth.WithIdentity(req.Context(), tokenauth.Identity{PrincipalID: "user-admin", TenantID: "tenant-a"}))
+	rec := httptest.NewRecorder()
+	handler.Onboard(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+type recordingStore struct {
+	existing  map[string]assignmentstore.Tenant
+	saved     assignmentstore.Tenant
+	saveCalls int
+	audited   []assignmentstore.AuditEvent
+}
+
+func (s *recordingStore) Tenant(_ context.Context, realm string) (assignmentstore.Tenant, bool, error) {
+	tenant, ok := s.existing[realm]
+	return tenant, ok, nil
+}
+
+func (s *recordingStore) SaveTenant(_ context.Context, tenant assignmentstore.Tenant) error {
+	s.saveCalls++
+	s.saved = tenant
+	return nil
+}
+
+func (s *recordingStore) AppendAuditEvent(_ context.Context, event assignmentstore.AuditEvent) error {
+	s.audited = append(s.audited, event)
+	return nil
+}

--- a/apps/ads/cmd/ads/main.go
+++ b/apps/ads/cmd/ads/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/netprobe"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/revisionmetrics"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/server"
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tenantdiscovery"
 	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tokenauth"
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
 	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore/postgresstore"
@@ -165,10 +166,15 @@ func main() {
 	}
 
 	verifiers := tokenverifier.NewRegistry()
-	directories := make(map[string]idpdirectory.IdentityDirectory, len(installations))
+	directories := idpdirectory.NewRegistry()
+	knownRealms := make([]string, 0, len(installations))
 	for realm, installation := range installations {
 		verifiers.Register(installation.Config.Issuer, installation.Verifier)
-		directories[realm] = installation.Directory
+		directories.Register(idpdirectory.TenantID(realm), installation.Directory)
+		knownRealms = append(knownRealms, realm)
+	}
+	directoriesLookup := func(tenantID string) (idpdirectory.IdentityDirectory, bool) {
+		return directories.Get(idpdirectory.TenantID(tenantID))
 	}
 
 	// One middleware, applied to every route that acts on a caller's behalf.
@@ -270,6 +276,45 @@ func main() {
 	})
 	go reconciler.Run(ctx)
 
+	// A tenant onboarded at runtime (issue #86) becomes usable with no
+	// restart: the same tenant registry poll pattern as the reconciler
+	// above, discovering a realm this replica has not built an
+	// Installation for yet and registering it into the same verifiers and
+	// directories every request already resolves through.
+	discoverer := tenantdiscovery.New(tenantdiscovery.Config{
+		Store: store,
+		Known: knownRealms,
+		OnNewTenant: func(_ context.Context, tenant assignmentstore.Tenant) error {
+			installationCfg, err := provider.ConfigFromTenant(os.LookupEnv, provider.Tenant{
+				Realm:               tenant.Realm,
+				Issuer:              tenant.Issuer,
+				BrowserClientID:     tenant.BrowserClientID,
+				ServiceClientID:     tenant.ServiceClientID,
+				CredentialSecretRef: tenant.CredentialSecretRef,
+			})
+			if err != nil {
+				return err
+			}
+			directory, err := provider.New(installationCfg)
+			if err != nil {
+				return err
+			}
+			verifier, err := provider.NewVerifier(installationCfg)
+			if err != nil {
+				return err
+			}
+			verifiers.Register(installationCfg.Issuer, verifier)
+			directories.Register(idpdirectory.TenantID(tenant.Realm), directory)
+			logger.Info("discovered a tenant onboarded at runtime",
+				slog.String("realm", tenant.Realm))
+			return nil
+		},
+		OnError: func(err error) {
+			logger.Error("tenant discovery error", slog.Any("error", err))
+		},
+	})
+	go discoverer.Run(ctx)
+
 	// §17.1's revision gauges: a read-only observer, independent of the
 	// reconciler above, which is the one thing allowed to act on drift.
 	revisionPoller := revisionmetrics.NewPoller(revisionmetrics.PollerConfig{
@@ -313,28 +358,28 @@ func main() {
 			RootPolicyRevision: cfg.RootPolicyRevision,
 		})),
 		DirectoryUsersHandler: authenticated(directoryapi.NewUsersHandler(directoryapi.Config{
-			Directories: directories,
-			Logger:      logger,
+			DirectoriesLookup: directoriesLookup,
+			Logger:            logger,
 		})),
 		DirectoryRolesHandler: authenticated(directoryapi.NewRolesHandler(directoryapi.Config{
-			Directories: directories,
-			Logger:      logger,
+			DirectoriesLookup: directoriesLookup,
+			Logger:            logger,
 		})),
 		DirectoryUserRolesHandler: authenticated(directoryapi.NewUserRolesHandler(directoryapi.Config{
-			Directories: directories,
-			Logger:      logger,
+			DirectoriesLookup: directoriesLookup,
+			Logger:            logger,
 		})),
 		DirectoryOrganizationsHandler: authenticated(directoryapi.NewOrganizationsHandler(directoryapi.Config{
-			Directories: directories,
-			Logger:      logger,
+			DirectoriesLookup: directoriesLookup,
+			Logger:            logger,
 		})),
 		DirectoryOrganizationMembersHandler: authenticated(directoryapi.NewOrganizationMembersHandler(directoryapi.Config{
-			Directories: directories,
-			Logger:      logger,
+			DirectoriesLookup: directoriesLookup,
+			Logger:            logger,
 		})),
 		DirectoryUserOrganizationsHandler: authenticated(directoryapi.NewUserOrganizationsHandler(directoryapi.Config{
-			Directories: directories,
-			Logger:      logger,
+			DirectoriesLookup: directoriesLookup,
+			Logger:            logger,
 		})),
 		CapabilityHandler: authenticated(capability.NewHandler(capability.Config{
 			PDP:               pdp,

--- a/apps/ads/internal/directoryapi/directoryapi.go
+++ b/apps/ads/internal/directoryapi/directoryapi.go
@@ -29,12 +29,22 @@ type Config struct {
 	// different realm's service account. Directory is ignored when this is
 	// set.
 	Directories map[string]idpdirectory.IdentityDirectory
-	Logger      *slog.Logger
+	// DirectoriesLookup, when set, takes priority over Directories. It
+	// exists for a lookup backed by something more dynamic than a plain
+	// map - idpdirectory.Registry (issue #86), so a tenant onboarded at
+	// runtime is reachable through this same handler with no restart -
+	// without requiring every existing caller that builds a Config with a
+	// literal Directories map to change.
+	DirectoriesLookup func(tenantID string) (idpdirectory.IdentityDirectory, bool)
+	Logger            *slog.Logger
 }
 
 // directoryFor resolves the identity directory for the caller's own
 // verified tenant, never one named by request input.
 func directoryFor(cfg Config, tenantID string) (idpdirectory.IdentityDirectory, bool) {
+	if cfg.DirectoriesLookup != nil {
+		return cfg.DirectoriesLookup(tenantID)
+	}
 	if cfg.Directories != nil {
 		directory, ok := cfg.Directories[tenantID]
 		return directory, ok

--- a/apps/ads/internal/directoryapi/directoryapi_test.go
+++ b/apps/ads/internal/directoryapi/directoryapi_test.go
@@ -159,6 +159,35 @@ func TestTheTenantComesFromTheVerifiedIdentity(t *testing.T) {
 	}
 }
 
+// issue #86: a tenant onboarded at runtime is reachable through a lookup
+// backed by something more dynamic than a plain map - idpdirectory.Registry
+// in production - without disturbing any caller still using Directories.
+func TestDirectoriesLookupTakesPriorityOverDirectories(t *testing.T) {
+	staleMap := &recordingDirectory{}
+	dynamic := &recordingDirectory{
+		users: idpdirectory.Page[idpdirectory.UserRef]{Items: []idpdirectory.UserRef{{ExternalID: "user-onboarded"}}},
+	}
+	handler := directoryapi.NewUsersHandler(directoryapi.Config{
+		Directories: map[string]idpdirectory.IdentityDirectory{"tenant-a": staleMap},
+		DirectoriesLookup: func(tenantID string) (idpdirectory.IdentityDirectory, bool) {
+			return dynamic, tenantID == "tenant-a"
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, get("/internal/directory/users"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body)
+	}
+	if staleMap.calls != 0 {
+		t.Error("the stale Directories map was consulted even though DirectoriesLookup was set")
+	}
+	if dynamic.calls != 1 {
+		t.Error("DirectoriesLookup's own directory was never consulted")
+	}
+}
+
 func TestRoleSearchReportsCanonicalIdentifiers(t *testing.T) {
 	directory := &recordingDirectory{
 		roles: idpdirectory.Page[idpdirectory.RoleRef]{

--- a/apps/ads/internal/tenantdiscovery/tenantdiscovery.go
+++ b/apps/ads/internal/tenantdiscovery/tenantdiscovery.go
@@ -1,0 +1,114 @@
+// Package tenantdiscovery notices a tenant onboarded at runtime (issue
+// #86) and builds the same Installation the ADS built for every realm at
+// startup, with no service restart.
+//
+// It reuses the reconciler's own periodic-poll shape (§10.3) rather than
+// adding a second invalidation mechanism: the tenant registry table is
+// polled on an interval, exactly the way invalidation.Reconciler already
+// polls PermissionRevision, and a realm this replica has never seen before
+// is the one thing a poll can find that a Kafka event never named.
+package tenantdiscovery
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+)
+
+// DefaultInterval is how often Discoverer.Run checks for a tenant this
+// replica has not registered yet, when Config.Interval is left zero.
+const DefaultInterval = 5 * time.Second
+
+// Lister is the one method Discoverer needs from the tenant registry, so a
+// test can satisfy it without standing up the entire assignmentstore.Store
+// contract.
+type Lister interface {
+	Tenants(ctx context.Context) ([]assignmentstore.Tenant, error)
+}
+
+// Config holds Discoverer's collaborators.
+type Config struct {
+	Store Lister
+	// Known are the realms already registered before Discoverer starts -
+	// the ones this replica built an Installation for at startup. Seeding
+	// them here means the first poll costs nothing for a deployment that
+	// onboards no new tenant.
+	Known []string
+	// OnNewTenant is called once for each realm this replica has not seen
+	// before, in the order Store.Tenants returns them. A failure is
+	// reported through OnError and that realm is retried on the next
+	// poll - the same way a Kafka message this package never receives at
+	// all changes nothing about eventual correctness (§10.3).
+	OnNewTenant func(ctx context.Context, tenant assignmentstore.Tenant) error
+	// Interval bounds how often a poll runs. Zero means DefaultInterval.
+	Interval time.Duration
+	// OnError, if set, is called with any error listing the registry or
+	// building one tenant's installation. A poll that fails on one tenant
+	// still tries every other tenant it found.
+	OnError func(error)
+}
+
+// Discoverer is the poll loop.
+type Discoverer struct {
+	cfg   Config
+	known map[string]bool
+}
+
+// New applies Config's defaults and returns a Discoverer.
+func New(cfg Config) *Discoverer {
+	if cfg.Interval <= 0 {
+		cfg.Interval = DefaultInterval
+	}
+	known := make(map[string]bool, len(cfg.Known))
+	for _, realm := range cfg.Known {
+		known[realm] = true
+	}
+	return &Discoverer{cfg: cfg, known: known}
+}
+
+// DiscoverOnce runs one pass: listing the registry and calling OnNewTenant
+// for every realm not already known. A realm OnNewTenant fails for is not
+// marked known, so the next pass retries it.
+func (d *Discoverer) DiscoverOnce(ctx context.Context) {
+	tenants, err := d.cfg.Store.Tenants(ctx)
+	if err != nil {
+		d.reportError(fmt.Errorf("tenantdiscovery: listing the tenant registry: %w", err))
+		return
+	}
+
+	for _, tenant := range tenants {
+		if d.known[tenant.Realm] {
+			continue
+		}
+		if err := d.cfg.OnNewTenant(ctx, tenant); err != nil {
+			d.reportError(fmt.Errorf("tenantdiscovery: onboarding realm %q: %w", tenant.Realm, err))
+			continue
+		}
+		d.known[tenant.Realm] = true
+	}
+}
+
+func (d *Discoverer) reportError(err error) {
+	if d.cfg.OnError != nil {
+		d.cfg.OnError(err)
+	}
+}
+
+// Run calls DiscoverOnce immediately, then on every tick of Interval,
+// until ctx is done.
+func (d *Discoverer) Run(ctx context.Context) {
+	d.DiscoverOnce(ctx)
+
+	ticker := time.NewTicker(d.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.DiscoverOnce(ctx)
+		}
+	}
+}

--- a/apps/ads/internal/tenantdiscovery/tenantdiscovery_test.go
+++ b/apps/ads/internal/tenantdiscovery/tenantdiscovery_test.go
@@ -1,0 +1,174 @@
+package tenantdiscovery_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tishan-harischandra/cerbos-poc/apps/ads/internal/tenantdiscovery"
+	"github.com/tishan-harischandra/cerbos-poc/libs/assignmentstore"
+)
+
+type fakeLister struct {
+	tenants []assignmentstore.Tenant
+	err     error
+}
+
+func (f *fakeLister) Tenants(context.Context) ([]assignmentstore.Tenant, error) {
+	return f.tenants, f.err
+}
+
+// A tenant already known at startup (issue #77's normal wiring) costs a
+// pass nothing: OnNewTenant is never called for it.
+func TestDiscoverOnceLeavesAnAlreadyKnownTenantAlone(t *testing.T) {
+	lister := &fakeLister{tenants: []assignmentstore.Tenant{{Realm: "tenant-a"}}}
+	var onboarded []string
+	discoverer := tenantdiscovery.New(tenantdiscovery.Config{
+		Store: lister,
+		Known: []string{"tenant-a"},
+		OnNewTenant: func(_ context.Context, tenant assignmentstore.Tenant) error {
+			onboarded = append(onboarded, tenant.Realm)
+			return nil
+		},
+	})
+
+	discoverer.DiscoverOnce(context.Background())
+
+	if len(onboarded) != 0 {
+		t.Errorf("OnNewTenant was called for an already-known tenant: %v", onboarded)
+	}
+}
+
+// issue #86's own acceptance criterion: a tenant onboarded at runtime
+// becomes usable with no restart - discovering it is the mechanism.
+func TestDiscoverOnceCallsOnNewTenantForARealmNotYetKnown(t *testing.T) {
+	lister := &fakeLister{tenants: []assignmentstore.Tenant{{Realm: "tenant-a"}, {Realm: "tenant-c"}}}
+	var onboarded []string
+	discoverer := tenantdiscovery.New(tenantdiscovery.Config{
+		Store: lister,
+		Known: []string{"tenant-a"},
+		OnNewTenant: func(_ context.Context, tenant assignmentstore.Tenant) error {
+			onboarded = append(onboarded, tenant.Realm)
+			return nil
+		},
+	})
+
+	discoverer.DiscoverOnce(context.Background())
+
+	if len(onboarded) != 1 || onboarded[0] != "tenant-c" {
+		t.Errorf("onboarded = %v, want exactly [tenant-c]", onboarded)
+	}
+}
+
+// Discovering the same new tenant twice in a row - two passes finding it
+// still there - must call OnNewTenant only once: the second pass has
+// already marked it known.
+func TestANewTenantIsOnboardedOnlyOnce(t *testing.T) {
+	lister := &fakeLister{tenants: []assignmentstore.Tenant{{Realm: "tenant-c"}}}
+	calls := 0
+	discoverer := tenantdiscovery.New(tenantdiscovery.Config{
+		Store: lister,
+		OnNewTenant: func(context.Context, assignmentstore.Tenant) error {
+			calls++
+			return nil
+		},
+	})
+
+	discoverer.DiscoverOnce(context.Background())
+	discoverer.DiscoverOnce(context.Background())
+
+	if calls != 1 {
+		t.Errorf("OnNewTenant was called %d times, want exactly 1", calls)
+	}
+}
+
+// A tenant OnNewTenant fails for must be retried on the next pass, not
+// left permanently unusable because one pass hit a transient error.
+func TestATenantThatFailsToOnboardIsRetriedOnTheNextPass(t *testing.T) {
+	lister := &fakeLister{tenants: []assignmentstore.Tenant{{Realm: "tenant-c"}}}
+	calls := 0
+	var errs []error
+	discoverer := tenantdiscovery.New(tenantdiscovery.Config{
+		Store: lister,
+		OnNewTenant: func(context.Context, assignmentstore.Tenant) error {
+			calls++
+			if calls == 1 {
+				return errors.New("the identity provider configuration could not be read")
+			}
+			return nil
+		},
+		OnError: func(err error) { errs = append(errs, err) },
+	})
+
+	discoverer.DiscoverOnce(context.Background())
+	discoverer.DiscoverOnce(context.Background())
+
+	if calls != 2 {
+		t.Errorf("OnNewTenant was called %d times, want exactly 2 (retried once)", calls)
+	}
+	if len(errs) != 1 {
+		t.Errorf("OnError was called %d times, want exactly 1", len(errs))
+	}
+}
+
+// A registry read failure must not stall discovery of tenants found on a
+// later, successful pass.
+func TestAFailedListDoesNotStopDiscoveryPermanently(t *testing.T) {
+	lister := &fakeLister{err: errors.New("the authorization database is not reachable")}
+	var errs []error
+	var onboarded []string
+	discoverer := tenantdiscovery.New(tenantdiscovery.Config{
+		Store: lister,
+		OnNewTenant: func(_ context.Context, tenant assignmentstore.Tenant) error {
+			onboarded = append(onboarded, tenant.Realm)
+			return nil
+		},
+		OnError: func(err error) { errs = append(errs, err) },
+	})
+
+	discoverer.DiscoverOnce(context.Background())
+	if len(errs) != 1 {
+		t.Fatalf("OnError was called %d times on the failing pass, want exactly 1", len(errs))
+	}
+
+	lister.err = nil
+	lister.tenants = []assignmentstore.Tenant{{Realm: "tenant-c"}}
+	discoverer.DiscoverOnce(context.Background())
+
+	if len(onboarded) != 1 || onboarded[0] != "tenant-c" {
+		t.Errorf("onboarded = %v, want exactly [tenant-c] once the registry was reachable again", onboarded)
+	}
+}
+
+// Run ticks on its own until ctx is done, discovering a tenant that
+// appears between ticks with no restart.
+func TestRunDiscoversATenantThatAppearsBetweenTicks(t *testing.T) {
+	lister := &fakeLister{tenants: []assignmentstore.Tenant{{Realm: "tenant-a"}}}
+	onboarded := make(chan string, 1)
+	discoverer := tenantdiscovery.New(tenantdiscovery.Config{
+		Store:    lister,
+		Known:    []string{"tenant-a"},
+		Interval: 5 * time.Millisecond,
+		OnNewTenant: func(_ context.Context, tenant assignmentstore.Tenant) error {
+			onboarded <- tenant.Realm
+			return nil
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	go discoverer.Run(ctx)
+
+	time.Sleep(20 * time.Millisecond)
+	lister.tenants = append(lister.tenants, assignmentstore.Tenant{Realm: "tenant-c"})
+
+	select {
+	case realm := <-onboarded:
+		if realm != "tenant-c" {
+			t.Errorf("onboarded realm = %q, want tenant-c", realm)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run never discovered the newly onboarded tenant")
+	}
+}

--- a/deploy/keycloak/realm-tenant-c.json
+++ b/deploy/keycloak/realm-tenant-c.json
@@ -1,0 +1,190 @@
+{
+  "realm": "tenant-c",
+  "displayName": "A tenant that exists only in Keycloak until onboarded through the Admin Service (issue #86): proves onboarding at runtime is real, not merely a claim about a realm that was already registered",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "accessTokenLifespan": 900,
+  "browserFlow": "browser-with-org-selector",
+  "loginTheme": "cerbos-poc",
+  "organizationsEnabled": true,
+  "organizations": [
+    {
+      "name": "Hospital C1",
+      "alias": "hospital-c1",
+      "enabled": true,
+      "domains": [{ "name": "hospital-c1.example.test", "verified": false }],
+      "members": [{ "username": "user-doctor-c" }]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "patient-app",
+      "name": "Patient application",
+      "description": "The browser-facing client. Public, so it holds no secret, and it has no administrative permission of any kind.",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "redirectUris": ["http://localhost:4200/*", "http://127.0.0.1:4200/*"],
+      "webOrigins": ["http://localhost:4200", "http://127.0.0.1:4200"],
+      "defaultClientScopes": ["basic", "web-origins", "profile", "roles", "email"],
+      "optionalClientScopes": ["organization"],
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "patient-app",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "organization-memberships",
+          "protocol": "openid-connect",
+          "protocolMapper": "cerbos-poc-organization-memberships-mapper",
+          "config": { "access.token.claim": "true" }
+        }
+      ]
+    },
+    {
+      "clientId": "authorization-admin-service",
+      "name": "Authorization admin service",
+      "description": "tenant-c's own confidential service account (issue #86): a tenant onboarded at runtime is held to the same per-tenant credential isolation as one file-seeded at startup. It is never used by a browser and never issued to one (7.3).",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "secret": "admin-service-secret-tenant-c",
+      "redirectUris": [],
+      "webOrigins": []
+    }
+  ],
+  "roles": {
+    "client": {
+      "patient-app": [
+        {
+          "name": "doctor",
+          "description": "Treating clinician"
+        }
+      ]
+    }
+  },
+  "users": [
+    {
+      "id": "user-doctor-c",
+      "username": "user-doctor-c",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Casey",
+      "lastName": "Doctor",
+      "email": "casey.doctor@tenant-c.example.test",
+      "credentials": [{ "type": "password", "value": "demo-password", "temporary": false }],
+      "clientRoles": { "patient-app": ["doctor"] }
+    },
+    {
+      "username": "service-account-authorization-admin-service",
+      "enabled": true,
+      "serviceAccountClientId": "authorization-admin-service",
+      "clientRoles": {
+        "realm-management": ["view-users", "query-users", "view-clients", "view-realm", "manage-realm"]
+      }
+    }
+  ],
+  "authenticationFlows": [
+    {
+      "alias": "browser-with-org-selector",
+      "description": "Keycloak's own browser flow, with the organization selector (issue #79) added after credentials and any second factor.",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "browser-with-org-selector forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "alias": "browser-with-org-selector forms",
+      "description": "Username, password, and the organization selector, in that order.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "browser-with-org-selector Browser - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        },
+        {
+          "authenticator": "cerbos-poc-organization-selector",
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "alias": "browser-with-org-selector Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/secrets/idp-admin-credentials-tenant-c
+++ b/deploy/secrets/idp-admin-credentials-tenant-c
@@ -1,0 +1,1 @@
+admin-service-secret-tenant-c

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,12 @@ services:
     volumes:
       - ./deploy/keycloak/realm-tenant-a.json:/opt/keycloak/data/import/realm-tenant-a.json:ro
       - ./deploy/keycloak/realm-tenant-b.json:/opt/keycloak/data/import/realm-tenant-b.json:ro
+      # tenant-c exists in Keycloak but deliberately not in
+      # deploy/tenant-registry.yaml (issue #86): it is what
+      # scripts/tests/tenant-onboarding-e2e.sh onboards through the Admin
+      # Service at runtime, proving onboarding is real rather than a claim
+      # about a realm that was already registered.
+      - ./deploy/keycloak/realm-tenant-c.json:/opt/keycloak/data/import/realm-tenant-c.json:ro
       - ./deploy/keycloak/realm-other-issuer.json:/opt/keycloak/data/import/realm-other-issuer.json:ro
     ports:
       - "${KEYCLOAK_PORT:-8081}:8080"
@@ -249,8 +255,13 @@ services:
     volumes:
       # One mount per realm the tenant registry names (issue #77): each
       # realm's own service account secret, never shared with another's.
+      # tenant-c's is mounted even though it starts out unregistered
+      # (issue #86): tenantdiscovery reads it the moment the tenant
+      # onboarding endpoint saves that row, with no restart to add the
+      # mount after the fact.
       - ./deploy/secrets/idp-admin-credentials:/run/secrets/idp-admin-credentials:ro
       - ./deploy/secrets/idp-admin-credentials-tenant-b:/run/secrets/idp-admin-credentials-tenant-b:ro
+      - ./deploy/secrets/idp-admin-credentials-tenant-c:/run/secrets/idp-admin-credentials-tenant-c:ro
       - ./deploy/cerbos/catalog/ui-capabilities:/capability-catalog:ro
     depends_on:
       cerbos:
@@ -322,6 +333,10 @@ services:
     volumes:
       - ./deploy/secrets/idp-admin-credentials:/run/secrets/idp-admin-credentials:ro
       - ./deploy/secrets/idp-admin-credentials-tenant-b:/run/secrets/idp-admin-credentials-tenant-b:ro
+      # tenant-c's secret (issue #86): mounted so a tenant onboarding
+      # request naming this path passes the same "is it readable" check
+      # a file-seeded registry entry is held to.
+      - ./deploy/secrets/idp-admin-credentials-tenant-c:/run/secrets/idp-admin-credentials-tenant-c:ro
       - ./deploy/cerbos/catalog/resources:/authorization-catalog:ro
       - ./deploy/cerbos/catalog/ui-capabilities:/capability-catalog:ro
       - policy-release-archives:/var/lib/policy-controller/archives:ro

--- a/docs/MEASURED_FINDINGS.md
+++ b/docs/MEASURED_FINDINGS.md
@@ -276,6 +276,28 @@ ever ships a narrower fine-grained permission for organization reads,
 this grant should be narrowed to match; recorded here so that gap is
 visible rather than silently accepted.
 
+## Tenant onboarding trusts any authenticated caller (issue #86)
+
+Every other write this platform's Admin Service exposes - the role matrix,
+a user override - is scoped by `authority.Validate` to the caller's own
+tenant and hospital (§9.4). Tenant onboarding cannot be: the tenant being
+onboarded does not exist yet, so there is no existing scope to validate
+authority against, and this codebase has no separate "platform operator"
+credential anywhere to reuse - every administration route authenticates
+the same way, with an OIDC bearer token from one of the already-registered
+realms, and none of them restrict a write to a specific role (role-based
+business authorization is Cerbos policy's job for business resources, not
+this administration surface's).
+
+**Decision**: `apps/admin-service/internal/tenantonboarding` accepts any
+authenticated caller, from any already-registered realm, to onboard a new
+one. This is consistent with the rest of the administration surface
+rather than a narrower rule invented just for this endpoint, but it is a
+real widening worth naming plainly: tenant-a's least-privileged
+administrator can bring up an arbitrary new tenant. A production
+deployment wanting to restrict this would need a platform-operator
+credential this prototype does not have a design for yet.
+
 ## What has not been measured
 
 Stated plainly, so nobody mistakes an absence for a pass:

--- a/libs/assignmentstore/tenantseed/tenantseed.go
+++ b/libs/assignmentstore/tenantseed/tenantseed.go
@@ -15,17 +15,34 @@ import (
 	"github.com/tishan-harischandra/cerbos-poc/libs/tenantregistry"
 )
 
-// tenantSaver is the one method Apply needs, so a test can satisfy it
-// without standing up the entire assignmentstore.Store contract.
+// tenantSaver is the slice of Apply's collaborator it needs, so a test can
+// satisfy it without standing up the entire assignmentstore.Store contract.
 type tenantSaver interface {
+	Tenant(ctx context.Context, realm string) (assignmentstore.Tenant, bool, error)
 	SaveTenant(ctx context.Context, tenant assignmentstore.Tenant) error
 }
 
-// Apply upserts every entry into the registry table. It is idempotent:
-// running it again with an unchanged file leaves the same rows in place, so
-// it is safe to run on every start rather than only on the first.
+// Apply inserts every entry the registry table does not already have a row
+// for. It is idempotent: running it again with an unchanged file leaves the
+// same rows in place, so it is safe to run on every start rather than only
+// on the first.
+//
+// It is also, deliberately, not an upsert (issue #86): once a realm has a
+// row - whether tenantseed put it there or the Admin Service's tenant
+// onboarding endpoint did - the database is that row's value of record.
+// Re-running this on a later `make up` with the same file must not silently
+// revert a change an operator made at runtime back to whatever the file
+// still says.
 func Apply(ctx context.Context, store tenantSaver, entries []tenantregistry.Entry) error {
 	for _, entry := range entries {
+		_, exists, err := store.Tenant(ctx, entry.Realm)
+		if err != nil {
+			return fmt.Errorf("tenantseed: reading realm %q: %w", entry.Realm, err)
+		}
+		if exists {
+			continue
+		}
+
 		tenant := assignmentstore.Tenant{
 			Realm:               entry.Realm,
 			Issuer:              entry.Issuer,

--- a/libs/assignmentstore/tenantseed/tenantseed_test.go
+++ b/libs/assignmentstore/tenantseed/tenantseed_test.go
@@ -21,6 +21,11 @@ func newFakeSaver() *fakeSaver {
 	return &fakeSaver{saved: make(map[string]assignmentstore.Tenant)}
 }
 
+func (f *fakeSaver) Tenant(_ context.Context, realm string) (assignmentstore.Tenant, bool, error) {
+	tenant, ok := f.saved[realm]
+	return tenant, ok, nil
+}
+
 func (f *fakeSaver) SaveTenant(_ context.Context, tenant assignmentstore.Tenant) error {
 	f.calls++
 	f.saved[tenant.Realm] = tenant
@@ -62,7 +67,59 @@ func TestApplyIsIdempotent(t *testing.T) {
 	if len(saver.saved) != 1 {
 		t.Errorf("saved = %+v, want exactly one realm after two runs of the same file", saver.saved)
 	}
-	if saver.calls != 2 {
-		t.Errorf("calls = %d, want SaveTenant called once per run (2), the store itself owning idempotency", saver.calls)
+}
+
+// issue #86: once a realm has a row, the database is that row's value of
+// record. Re-seeding the same file must not revert a change made after the
+// first seed - whether that change came from the Admin Service's tenant
+// onboarding endpoint or from an operator editing the row directly.
+func TestApplyDoesNotRevertARealmAlreadyChangedInTheDatabase(t *testing.T) {
+	saver := newFakeSaver()
+	entries := []tenantregistry.Entry{
+		{Realm: "tenant-a", Issuer: "http://localhost:8081/realms/tenant-a", BrowserClientID: "patient-app", ServiceClientID: "patient-app", CredentialSecretRef: "/secrets/tenant-a"},
+	}
+
+	if err := tenantseed.Apply(context.Background(), saver, entries); err != nil {
+		t.Fatalf("Apply (first run): %v", err)
+	}
+
+	// An operator - or the tenant onboarding endpoint re-pointing a realm
+	// at a new issuer - changes the row directly, outside this seeder.
+	changed := saver.saved["tenant-a"]
+	changed.Issuer = "https://new-issuer.example.test/realms/tenant-a"
+	saver.saved["tenant-a"] = changed
+
+	if err := tenantseed.Apply(context.Background(), saver, entries); err != nil {
+		t.Fatalf("Apply (second run): %v", err)
+	}
+
+	if got := saver.saved["tenant-a"].Issuer; got != "https://new-issuer.example.test/realms/tenant-a" {
+		t.Errorf("tenant-a.Issuer = %q after re-seeding, want the database value to survive", got)
+	}
+}
+
+func TestApplySavesOnlyTheRealmsNotAlreadyPresent(t *testing.T) {
+	saver := newFakeSaver()
+	if err := saver.SaveTenant(context.Background(), assignmentstore.Tenant{
+		Realm: "tenant-a", Issuer: "http://localhost:8081/realms/tenant-a",
+		BrowserClientID: "patient-app", ServiceClientID: "patient-app", CredentialSecretRef: "/secrets/tenant-a",
+	}); err != nil {
+		t.Fatalf("pre-seeding tenant-a: %v", err)
+	}
+	saver.calls = 0
+
+	entries := []tenantregistry.Entry{
+		{Realm: "tenant-a", Issuer: "http://localhost:8081/realms/tenant-a", BrowserClientID: "patient-app", ServiceClientID: "patient-app", CredentialSecretRef: "/secrets/tenant-a"},
+		{Realm: "tenant-b", Issuer: "http://localhost:8081/realms/tenant-b", BrowserClientID: "patient-app", ServiceClientID: "patient-app", CredentialSecretRef: "/secrets/tenant-b"},
+	}
+	if err := tenantseed.Apply(context.Background(), saver, entries); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if saver.calls != 1 {
+		t.Errorf("SaveTenant was called %d times, want exactly 1 (tenant-b only)", saver.calls)
+	}
+	if _, ok := saver.saved["tenant-b"]; !ok {
+		t.Error("tenant-b was not saved")
 	}
 }

--- a/libs/idpdirectory/registry.go
+++ b/libs/idpdirectory/registry.go
@@ -1,0 +1,48 @@
+package idpdirectory
+
+import "sync"
+
+// Registry holds one identity directory client per tenant, safe for
+// concurrent reads and writes (issue #86).
+//
+// It exists so a tenant onboarded at runtime becomes usable with no
+// service restart: Register adds a realm without disturbing any lookup
+// already in flight, the same guarantee tokenverifier.Registry already
+// gives token verification for exactly this reason.
+type Registry struct {
+	mu       sync.RWMutex
+	byTenant map[TenantID]IdentityDirectory
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{byTenant: make(map[TenantID]IdentityDirectory)}
+}
+
+// Register adds a tenant's directory client. Registering the same tenant
+// twice replaces the previous client.
+func (r *Registry) Register(tenant TenantID, directory IdentityDirectory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.byTenant[tenant] = directory
+}
+
+// Get returns the directory client registered for tenant, if any.
+func (r *Registry) Get(tenant TenantID) (IdentityDirectory, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	directory, ok := r.byTenant[tenant]
+	return directory, ok
+}
+
+// Known reports every tenant currently registered, in no particular
+// order.
+func (r *Registry) Known() []TenantID {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	tenants := make([]TenantID, 0, len(r.byTenant))
+	for tenant := range r.byTenant {
+		tenants = append(tenants, tenant)
+	}
+	return tenants
+}

--- a/libs/idpdirectory/registry_test.go
+++ b/libs/idpdirectory/registry_test.go
@@ -1,0 +1,65 @@
+package idpdirectory_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/tishan-harischandra/cerbos-poc/libs/idpdirectory"
+)
+
+type stubDirectory struct{ idpdirectory.IdentityDirectory }
+
+func TestRegistryGetReturnsWhatWasRegistered(t *testing.T) {
+	registry := idpdirectory.NewRegistry()
+	directory := stubDirectory{}
+	registry.Register("tenant-a", directory)
+
+	got, ok := registry.Get("tenant-a")
+	if !ok || got != idpdirectory.IdentityDirectory(directory) {
+		t.Errorf("Get(tenant-a) = %v, %v, want the registered directory", got, ok)
+	}
+}
+
+func TestRegistryGetReportsFalseForAnUnknownTenant(t *testing.T) {
+	registry := idpdirectory.NewRegistry()
+	if _, ok := registry.Get("tenant-z"); ok {
+		t.Error("Get reported a tenant that was never registered")
+	}
+}
+
+// issue #86: a tenant onboarded at runtime becomes usable with no
+// restart - Register must be safe to call while another goroutine is
+// reading.
+func TestRegistryIsSafeForConcurrentRegisterAndGet(t *testing.T) {
+	registry := idpdirectory.NewRegistry()
+	registry.Register("tenant-a", stubDirectory{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			registry.Register("tenant-b", stubDirectory{})
+		}()
+		go func() {
+			defer wg.Done()
+			registry.Get("tenant-a")
+		}()
+	}
+	wg.Wait()
+
+	if _, ok := registry.Get("tenant-b"); !ok {
+		t.Error("tenant-b was never observed as registered")
+	}
+}
+
+func TestRegistryKnownListsEveryRegisteredTenant(t *testing.T) {
+	registry := idpdirectory.NewRegistry()
+	registry.Register("tenant-a", stubDirectory{})
+	registry.Register("tenant-b", stubDirectory{})
+
+	known := registry.Known()
+	if len(known) != 2 {
+		t.Fatalf("Known() = %v, want 2 tenants", known)
+	}
+}

--- a/libs/tenantregistry/tenantregistry.go
+++ b/libs/tenantregistry/tenantregistry.go
@@ -74,40 +74,55 @@ func Parse(raw []byte) ([]Entry, error) {
 	seen := make(map[string]bool, len(rows))
 	entries := make([]Entry, 0, len(rows))
 	for _, row := range rows {
-		if row.Realm == "" {
-			return nil, fmt.Errorf("tenantregistry: a registry entry has no realm")
-		}
-		if seen[row.Realm] {
-			return nil, fmt.Errorf("tenantregistry: realm %q is declared more than once", row.Realm)
-		}
-		seen[row.Realm] = true
-
-		if row.Issuer == "" {
-			return nil, fmt.Errorf("tenantregistry: realm %q has no issuer", row.Realm)
-		}
-		if row.BrowserClientID == "" {
-			return nil, fmt.Errorf("tenantregistry: realm %q has no browserClientId", row.Realm)
-		}
-		if row.CredentialSecretRef == "" {
-			return nil, fmt.Errorf("tenantregistry: realm %q has no credentialSecretRef", row.Realm)
-		}
-		if _, err := os.ReadFile(row.CredentialSecretRef); err != nil {
-			return nil, fmt.Errorf("tenantregistry: realm %q's credentialSecretRef %q is not readable: %w", row.Realm, row.CredentialSecretRef, err)
-		}
-
-		serviceClientID := row.ServiceClientID
-		if serviceClientID == "" {
-			serviceClientID = row.BrowserClientID
-		}
-
-		entries = append(entries, Entry{
+		entry := Entry{
 			Realm:               row.Realm,
 			Issuer:              row.Issuer,
 			BrowserClientID:     row.BrowserClientID,
-			ServiceClientID:     serviceClientID,
+			ServiceClientID:     row.ServiceClientID,
 			CredentialSecretRef: row.CredentialSecretRef,
-		})
+		}
+		if err := Validate(entry); err != nil {
+			return nil, err
+		}
+		if seen[entry.Realm] {
+			return nil, fmt.Errorf("tenantregistry: realm %q is declared more than once", entry.Realm)
+		}
+		seen[entry.Realm] = true
+
+		if entry.ServiceClientID == "" {
+			entry.ServiceClientID = entry.BrowserClientID
+		}
+		entries = append(entries, entry)
 	}
 
 	return entries, nil
+}
+
+// Validate checks one entry against the same rules the registry file's
+// rows are checked against (issue #86): a tenant onboarded at runtime
+// through the Admin Service is held to the identical contract as one
+// declared in the file, so there is exactly one definition of "a valid
+// registry entry" rather than two that could drift apart.
+//
+// It does not check for a realm declared more than once - that is a
+// property of a whole file's rows, not of one entry in isolation - and
+// leaves ServiceClientID's browserClientId fallback to the caller, since
+// Parse and the onboarding handler apply it at different points.
+func Validate(entry Entry) error {
+	if entry.Realm == "" {
+		return fmt.Errorf("tenantregistry: a registry entry has no realm")
+	}
+	if entry.Issuer == "" {
+		return fmt.Errorf("tenantregistry: realm %q has no issuer", entry.Realm)
+	}
+	if entry.BrowserClientID == "" {
+		return fmt.Errorf("tenantregistry: realm %q has no browserClientId", entry.Realm)
+	}
+	if entry.CredentialSecretRef == "" {
+		return fmt.Errorf("tenantregistry: realm %q has no credentialSecretRef", entry.Realm)
+	}
+	if _, err := os.ReadFile(entry.CredentialSecretRef); err != nil {
+		return fmt.Errorf("tenantregistry: realm %q's credentialSecretRef %q is not readable: %w", entry.Realm, entry.CredentialSecretRef, err)
+	}
+	return nil
 }

--- a/scripts/tests/lib-token.sh
+++ b/scripts/tests/lib-token.sh
@@ -23,6 +23,7 @@ organization_for_realm() {
   case "$1" in
     tenant-a) echo "north-hospital" ;;
     tenant-b) echo "hospital-b1" ;;
+    tenant-c) echo "hospital-c1" ;;
     *) echo "" ;;
   esac
 }

--- a/scripts/tests/tenant-onboarding-e2e.sh
+++ b/scripts/tests/tenant-onboarding-e2e.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Tenant onboarding through the Admin Service, end to end (issue #86):
+# tenant-c exists in Keycloak but starts out unregistered - not in
+# deploy/tenant-registry.yaml - so onboarding it here, then logging in and
+# reaching a decision against the same running stack, proves onboarding is
+# real rather than a claim about a realm that was already registered.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+# shellcheck source=scripts/tests/lib-token.sh
+source scripts/tests/lib-token.sh
+
+PORT="${ADMIN_CONSOLE_PORT:-4200}"
+ADMIN_URL="http://127.0.0.1:${PORT}/api/admin"
+ADS_URL="http://127.0.0.1:${PORT}/api/ads"
+failures=0
+
+command -v jq >/dev/null 2>&1 || { echo "tenant-onboarding-e2e: jq is required" >&2; exit 1; }
+wait_for_keycloak || exit 1
+
+pass() { echo "ok   $1"; }
+fail() { echo "FAIL $1"; failures=$((failures + 1)); }
+
+# An authenticated caller from any already-registered realm may onboard a
+# new one (this prototype's administration surface trusts an authenticated
+# caller rather than a role, everywhere else too - see
+# docs/MEASURED_FINDINGS.md).
+operator_token="$(token_for user-admin)" || exit 1
+
+onboard() {
+  curl -sS --max-time 10 -o /tmp/tenant-onboarding-body -w '%{http_code}' \
+    -X POST -H "Authorization: Bearer ${operator_token}" -H 'Content-Type: application/json' \
+    --data "$1" \
+    "${ADMIN_URL}/authz/tenants"
+}
+
+# The issuer a token actually carries is whatever KC_HOSTNAME names
+# (docker-compose.yml's KEYCLOAK_HOSTNAME, "http://localhost:8081" by
+# default), which need not be the same host this script reaches Keycloak
+# by (KEYCLOAK_URL, "127.0.0.1" here) - the same distinction
+# provider.Config.JWKSURL's own doc comment makes.
+TOKEN_ISSUER_HOST="${KEYCLOAK_HOSTNAME:-http://localhost:8081}"
+
+echo "--- onboarding tenant-c, which exists only in Keycloak so far ---"
+
+status="$(onboard '{
+  "realm": "tenant-c",
+  "issuer": "'"${TOKEN_ISSUER_HOST}"'/realms/tenant-c",
+  "browserClientId": "patient-app",
+  "serviceClientId": "authorization-admin-service",
+  "credentialSecretRef": "/run/secrets/idp-admin-credentials-tenant-c"
+}')"
+if [[ "${status}" == "201" ]]; then
+  pass "the onboarding request is accepted"
+else
+  fail "the onboarding request is accepted (HTTP ${status}: $(cat /tmp/tenant-onboarding-body))"
+fi
+
+echo
+echo "--- onboarding the same realm again is rejected, not silently repeated ---"
+
+status="$(onboard '{
+  "realm": "tenant-c",
+  "issuer": "'"${KEYCLOAK_URL}"'/realms/tenant-c",
+  "browserClientId": "patient-app",
+  "credentialSecretRef": "/run/secrets/idp-admin-credentials-tenant-c"
+}')"
+if [[ "${status}" == "409" ]]; then
+  pass "onboarding a duplicate realm is rejected with a clear error"
+else
+  fail "onboarding a duplicate realm is rejected (HTTP ${status}: $(cat /tmp/tenant-onboarding-body))"
+fi
+
+echo
+echo "--- onboarding an invalid entry is rejected before anything is saved ---"
+
+status="$(onboard '{"realm": "tenant-d"}')"
+if [[ "${status}" == "400" ]]; then
+  pass "an entry missing required fields is rejected"
+else
+  fail "an entry missing required fields is rejected (HTTP ${status}: $(cat /tmp/tenant-onboarding-body))"
+fi
+rm -f /tmp/tenant-onboarding-body
+
+echo
+echo "--- the onboarded tenant becomes usable with no service restart ---"
+
+# The login itself only ever depended on Keycloak, which has known about
+# tenant-c since the stack came up; it is the decision below that depends
+# on tenantdiscovery's own poll (DefaultInterval, 5s) having run.
+doctor_token="$(token_for user-doctor-c patient-app tenant-c 2>/dev/null)"
+if [[ -n "${doctor_token}" ]]; then
+  pass "a login against the newly onboarded realm succeeds"
+else
+  fail "a login against the newly onboarded realm succeeds"
+fi
+
+if [[ -n "${doctor_token}" ]]; then
+  request='{"resources":[{"kind":"patient_record","id":"patient-1","attributes":{"tenantId":"tenant-c","hospitalId":"hospital-c1","status":"ACTIVE"},"actions":["read"]}]}'
+  decision_status=""
+  for _ in $(seq 1 20); do
+    decision_status="$(curl -sS --max-time 10 -o /tmp/tenant-onboarding-decision -w '%{http_code}' \
+      -H "Authorization: Bearer ${doctor_token}" -H 'Content-Type: application/json' \
+      --data "${request}" \
+      "${ADS_URL}/internal/authz/check")"
+    [[ "${decision_status}" == "200" ]] && break
+    sleep 1
+  done
+  if [[ "${decision_status}" == "200" ]]; then
+    pass "the ADS reaches a decision for the newly onboarded tenant, with no restart"
+  else
+    fail "the ADS reaches a decision for the newly onboarded tenant (HTTP ${decision_status}: $(cat /tmp/tenant-onboarding-decision 2>/dev/null))"
+  fi
+  rm -f /tmp/tenant-onboarding-decision
+else
+  fail "the ADS reaches a decision for the newly onboarded tenant (skipped: no token)"
+fi
+
+if (( failures > 0 )); then
+  echo
+  echo "${failures} tenant-onboarding failure(s)"
+  exit 1
+fi
+
+echo
+echo "tenant onboarding end to end passed"


### PR DESCRIPTION
## What changed

- `libs/tenantregistry`: extracted `Validate(entry)` from `Parse` so a
  single entry can be checked against the identical rules the file's rows
  are, without parsing a whole file.
- `libs/assignmentstore/tenantseed`: `Apply` no longer unconditionally
  upserts every file row - it now inserts only a realm the registry table
  does not already have a row for. Once a realm has a row, the database is
  its value of record; re-seeding the same file on a later `make up` no
  longer reverts a change made at runtime.
- `apps/admin-service/internal/tenantonboarding`: a new handler for
  `POST /admin/authz/tenants` (issue #86) - validates the request against
  `tenantregistry.Validate`, rejects a duplicate realm with 409, saves the
  row, and audits the write (`TENANT_ONBOARD`) the same way the role
  matrix and user-override writes are.
- `libs/idpdirectory.Registry` and `directoryapi.Config.DirectoriesLookup`
  (additive - `Directories` is unchanged): a directory lookup backed by
  something more dynamic than the map built once at startup.
- `apps/ads/internal/tenantdiscovery`: polls the tenant registry on the
  same interval-poll shape `invalidation.Reconciler` already uses (no new
  invalidation mechanism, per the acceptance criteria), and builds the
  Installation (directory client + token verifier) for any realm this
  replica has not seen before - registering it into the same
  `tokenverifier.Registry` and `idpdirectory.Registry` every request
  already resolves through. This is what makes a tenant onboarded at
  runtime usable with no ADS restart.
- `deploy/keycloak/realm-tenant-c.json` + a matching service-account
  secret: a realm that exists only in Keycloak until
  `scripts/tests/tenant-onboarding-e2e.sh` onboards it, so the end-to-end
  coverage proves onboarding is real rather than a claim about an
  already-registered realm.

## Acceptance criteria

- [x] The Admin Service exposes tenant onboarding, validating the same
      rules the registry file is validated against
- [x] A tenant onboarded at runtime becomes usable - a login and a
      decision succeed - with no service restart
- [x] Propagation to other replicas travels over the existing revision and
      event machinery; no new invalidation mechanism is added - the
      tenant-discovery poll reuses the reconciler's own poll shape rather
      than adding a Kafka topic or similar
- [x] Onboarding is audited like other administrative writes
- [x] Onboarding a duplicate realm is rejected with a clear error (409)
- [x] A tenant present in the seed file and later changed in the database
      keeps the database value; re-seeding does not silently revert it
- [x] End-to-end coverage: onboard a tenant, then authenticate against it
      in the same running stack

## A judgment call worth flagging

Every other administrative write in this codebase (`authority.Validate`)
scopes the caller to their own tenant and hospital. Tenant onboarding
can't be scoped that way - the tenant being onboarded doesn't exist yet -
and this prototype has no separate "platform operator" credential
anywhere to reuse. The handler accepts any authenticated caller from any
already-registered realm, consistent with the rest of the administration
surface (which trusts an authenticated caller rather than a specific
role everywhere else too) but a real widening worth naming rather than
quietly deciding. See
`docs/MEASURED_FINDINGS.md#tenant-onboarding-trusts-any-authenticated-caller-issue-86`.

## How it was verified

- `bash scripts/go.sh libs/tenantregistry test ./...`
- `bash scripts/go.sh libs/assignmentstore test ./tenantseed/...`
- `bash scripts/go.sh libs/idpdirectory test ./...`
- `bash scripts/go.sh apps/admin-service test ./...`
- `bash scripts/go.sh apps/ads test ./...`
- `make arch-test`
- Full `make down && make up` from a clean volume, then `make smoke`
  (every existing e2e suite plus the new
  `scripts/tests/tenant-onboarding-e2e.sh`) - all green.


Closes #86
