### PR TITLE
Architecture records, glossary and deviation register for the realm and organization model (#88)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,13 +9,17 @@ role and user assignments live in a database and reach the decision path as data
 ### Tenancy and identity
 
 **Installation**:
-One deployment of the platform, with exactly one active identity provider.
+One deployment of the platform, with exactly one active identity provider, serving every trusted **Tenant**.
 
 **Tenant**:
-The top-level isolation boundary that assignment data is partitioned by.
+A Keycloak realm, and the top-level isolation boundary that assignment data is partitioned by. `tenantId` is the realm name verbatim (ADR-010) — the tenant a decision is made for is the realm that verifiably signed the token, never a claim inside it.
 
 **Hospital**:
-A sub-scope within a **Tenant** that an assignment or override may be narrowed to.
+A Keycloak organization inside a **Tenant**'s realm, and a sub-scope within it that an assignment or override may be narrowed to. `hospitalId` is the organization's alias. A user may belong to **many** organizations at once; a session has exactly one active hospital, taken from the organization the user selected during login (ADR-012), or none — which means tenant-wide, and is reachable only by an administrator's explicit choice.
+_Avoid_: implying a hospital is a free-form attribute — it is a real membership Keycloak confirmed, not a claim the platform trusts on its own.
+
+**Tenant Registry**:
+The declared set of realms this installation trusts — file-seeded, then a database of record (ADR-011). A token from a realm outside it is refused outright.
 
 **Identity Directory**:
 The provider-neutral port for reading users and roles from the installation's identity provider.
@@ -90,6 +94,7 @@ The **Election** that drains committed outbox rows to Kafka.
 ## Relationships
 
 - A **Tenant** contains many **Hospitals**; assignment data is partitioned by both
+- A user may belong to many **Hospitals** within one **Tenant**, but a session's active hospital is exactly one, or none
 - A **Role Matrix** entry and a **User Override** both resolve to resource-action leaves; a **User Override** wins under **Precedence**
 - The **ADS** assembles **permissionContext** and the **PDP** applies **Precedence** to it
 - One **Capability** composes many permission leaves; one leaf contributes to many **Capabilities**
@@ -119,3 +124,9 @@ The **Election** that drains committed outbox rows to Kafka.
 - **"lock"** was used for both the mechanism and the singleton role. Resolved:
   the role is an **Election**; a lock, lease or advisory lock is one adapter's
   mechanism for holding one.
+- **"Tenant" and "Hospital"** were originally understood as an editable user
+  attribute claim (`tenant_id`/`hospital_id`) — a misunderstanding the
+  platform was actually built on for a time. Resolved (ADR-010): a **Tenant**
+  is a realm and a **Hospital** is an organization, and neither is trusted
+  from a claim the platform did not itself verify against the identity
+  provider's own structure.

--- a/docs/DESIGN_COVERAGE.md
+++ b/docs/DESIGN_COVERAGE.md
@@ -15,7 +15,7 @@ or **out of scope**.
 | Section | Status | Where |
 |---|---|---|
 | §5.1 Hierarchy | implemented | `libs/assignmentstore/store.go` (tenant/hospital keys), `deploy/liquibase/changelog` |
-| §5.2 Trusted decision attributes | implemented | `apps/ads/internal/tokenauth`, `apps/ads/internal/authz` - tenant, hospital, principal and roles come from the verified token only |
+| §5.2 Trusted decision attributes | implemented, differently | `apps/ads/internal/tokenauth`, `libs/tokenverifier` - tenant comes from the verified realm and hospital from a confirmed organization membership, never an editable claim (ADR-010) |
 | §5.3 Scope usage | out of scope | §5.3 itself recommends deferring per-tenant scoped policies (DEVIATIONS N1) |
 
 ## §6 Authorization domain model
@@ -32,9 +32,9 @@ or **out of scope**.
 
 | Section | Status | Where |
 |---|---|---|
-| §7.1 Installation selection | implemented | `IDP_TYPE` and `libs/idpdirectory/provider` |
+| §7.1 Installation selection | implemented, differently | `IDP_TYPE` and `libs/idpdirectory/provider` select the provider; `tenantMappingMode` itself is not implemented at all - a tenant is always the realm (ADR-010, DEVIATIONS S8) |
 | §7.2 Adapter interface | implemented | `libs/idpdirectory/port.go` (Go, not Java - DEVIATIONS S1) |
-| §7.3 Keycloak adapter | implemented | `libs/idpdirectory/keycloak`, exercised against a real Keycloak by `identity-e2e.sh` |
+| §7.3 Keycloak adapter | implemented | `libs/idpdirectory/keycloak`, exercised against a real Keycloak by `identity-e2e.sh`; read-only organization/membership access (ADR-010) and the in-flow login authenticator (`apps/keycloak-org-selector`, ADR-012) are additions the design does not describe |
 | §7.4 WSO2 adapter | partial | Port and contract only; SCIM2 calls not written (DEVIATIONS N2) |
 | §7.5 Canonical identifiers | implemented | `libs/canonicalid`, asserted byte-for-byte against token normalisation in `identity-e2e.sh` |
 

--- a/docs/DEVIATIONS.md
+++ b/docs/DEVIATIONS.md
@@ -90,6 +90,19 @@ A query plan is a filter pushed into a data store, and this prototype's data
 access is a page at a time behind a PEP. Batching is what the measured path
 needs; the query plan would be machinery built against a guess.
 
+### S8. No `tenantMappingMode` configuration (§7.1)
+
+§7.1 imagines an installation-level `tenantMappingMode` choosing how tenant
+is derived. This platform removed that axis of configuration entirely: a
+tenant is a Keycloak realm, full stop, with no mapping layer and no other
+mode to select (ADR-010).
+
+The realm name is already embedded in every canonical role identifier
+(`kc:<realm>:...`, §7.5); a second, configurable source of the tenant would
+be a second source of truth that could disagree with the first. This is a
+knowing deviation from the design document, not an omission - the design
+and the code disagree here on purpose, and ADR-010 records why.
+
 ## Narrowings
 
 ### N1. No Cerbos scoped policies (§5.3)
@@ -182,3 +195,50 @@ A collection- or module-scoped `targetRef` names no instance, so it resolves
 to the hospital and carries `status: ACTIVE`. That is a choice the design does
 not make for us: a collection cannot be locked, and the locked-record rule
 guards only the instance actions.
+
+### A5. A tenant registry and organization-scoped login (§7)
+
+The design document has no concept of a declared set of trusted realms or
+of an organization membership confirmed at login. Both exist here:
+`libs/tenantregistry` plus `apps/admin-service/internal/tenantonboarding`
+(ADR-011), and `apps/keycloak-org-selector`'s in-flow selection
+authenticator (ADR-012).
+
+These are not narrowings or substitutions for anything §7 describes - §7.1
+assumed a single realm per installation and a claim-derived tenant/hospital,
+which this platform found not to be how the identity provider is actually
+structured (ADR-010). The registry and the login authenticator are what
+make operating several realms, and several organization memberships per
+user, possible at all.
+
+## Known limitations
+
+Not a substitution, narrowing or addition against the design document -
+these are accepted gaps in this platform's own realm/organization model
+(ADR-010, ADR-011), recorded so they are a documented choice rather than a
+surprise.
+
+### L1. An organization rename orphans assignment rows
+
+`hospitalId` is the organization's Keycloak **alias**, chosen because it
+already appears in the `organization` claim and the scope request and keeps
+policies, tests and seed data legible as hospital names rather than opaque
+ids. Keycloak is the sole system of record for organizations (ADR-010), and
+this platform is never told when an alias changes: every `role_permission`,
+`user_permission_override` and `fhir_resource` row keyed on the old alias
+becomes unreachable, silently, with no error at the point of rename.
+
+Accepted for a prototype, where every organization is created once by seed
+data and never renamed. A production deployment would need either a stable
+internal id carried alongside the alias for assignment keys, or a
+documented, enforced procedure that re-keys assignment data as part of any
+rename - this platform implements neither.
+
+### L2. Tenant onboarding trusts any authenticated caller
+
+Recorded in full in `docs/MEASURED_FINDINGS.md` (issue #86): the tenant
+onboarding endpoint accepts a token for *any* already-registered tenant, not
+a distinct platform-operator credential. Acceptable while every realm in
+this installation is created by the same operator; a production deployment
+onboarding tenants it does not itself control would need a real
+platform-operator role first.

--- a/docs/adr/0010-a-tenant-is-a-realm-a-hospital-is-an-organization.md
+++ b/docs/adr/0010-a-tenant-is-a-realm-a-hospital-is-an-organization.md
@@ -1,0 +1,66 @@
+# ADR-010: A tenant is a Keycloak realm, a hospital is a Keycloak organization
+
+The platform was built on the belief that one realm holds every tenant and
+that `tenant_id`/`hospital_id` arrive as ordinary user-attribute claims a
+realm administrator can edit. That is not how the installation is actually
+structured, and the misunderstanding put tenant isolation on the wrong
+foundation: an attribute rather than a cryptographic boundary. Issue #75's
+spike and issue #78 onward correct it at the source.
+
+## The decision
+
+**A tenant is a Keycloak realm.** Each tenant has its own issuer, its own
+signing keys, its own users and its own roles. `tenantId` is the realm name
+verbatim - there is no realm-to-tenant mapping layer, because a mapping
+would be a second source of truth alongside the realm name already embedded
+in every canonical role identifier (`kc:<realm>:...`, §7.5). The tenant a
+decision is made for is the realm that verifiably signed the token
+(`libs/tokenverifier`), never a claim inside it.
+
+**A hospital is a Keycloak organization inside that realm.** `hospitalId`
+is the organization's **alias**. A user can belong to many organizations at
+once; a session names exactly one active hospital - the organization
+Keycloak confirmed the user is a member of and the user selected during
+login (ADR-012) - or none, which means tenant-wide and is reachable only by
+an administrator's explicit choice.
+
+## Why this, not a claim
+
+The property being bought is that isolation rests on something the
+platform did not have to trust the token to tell it honestly. A realm's
+identity is the issuer that signed the JWT and the keys the platform
+fetched from that realm's own JWKS endpoint - forging it means forging a
+signature, not editing an attribute. An organization membership is
+something Keycloak itself attests by populating the `organization` claim
+only for organizations it confirmed the user belongs to (measured directly:
+requesting `scope=organization:<alias>` for an organization the user does
+not belong to is silently dropped, never granted -
+`docs/MEASURED_FINDINGS.md`). Neither fact is something a realm
+administrator, a browser, or a request body can rewrite.
+
+## Consequences
+
+- **The design document's §7.1 `tenantMappingMode` contract is not
+  implemented.** §7.1 imagines an installation-level choice of how tenant
+  is derived; this platform removed that axis of configuration entirely,
+  because the one mapping that satisfies the isolation property above -
+  realm as tenant - is not a choice to leave open. Recorded as DEVIATIONS
+  S8, with this ADR as the reasoning.
+- **The organization alias is the hospital identifier everywhere**:
+  policies, `permissionContext`, seed data, and the k6 load model. Renaming
+  an organization's alias in Keycloak silently orphans every assignment row
+  keyed on the old alias - there is no migration path, because Keycloak is
+  the sole system of record for organizations and this platform is never
+  told about a rename. Accepted as a known limitation for a prototype; a
+  production deployment would need either a stable internal id surfaced
+  alongside the alias, or a documented rename procedure that re-keys
+  assignment data.
+- One deployment serves every tenant by trusting a declared set of realms
+  rather than one hardcoded realm (ADR-011), and a session's hospital comes
+  from an in-flow selection over real memberships, never a request
+  parameter (ADR-012).
+- `libs/idpdirectory`'s organization reads (`OrganizationsOfTenant`,
+  `OrganizationsOfUser`, `MembersOfOrganization`) are read-only by
+  construction - `tests/architecture/organizationwrites.go` forbids any
+  write path - because Keycloak already is the system of record and a
+  second one would disagree with it eventually.

--- a/docs/adr/0011-tenant-registry-is-declared-trust-with-a-database-of-record.md
+++ b/docs/adr/0011-tenant-registry-is-declared-trust-with-a-database-of-record.md
@@ -1,0 +1,72 @@
+# ADR-011: The tenant registry is declared trust, then a database of record
+
+Once a tenant is a realm (ADR-010), one deployment serving several tenants
+needs to know which realms it trusts, and needs to learn about a new one
+without redeploying every service. Two different concerns were at risk of
+being conflated into one: "who do we trust" is a governance question that
+should require a reviewed change, and "which tenants exist right now" is an
+operational fact that changes at runtime.
+
+## The decision
+
+**The set of trusted realms starts as a file, ends as a table.**
+`deploy/tenant-registry.yaml` lists every tenant this installation trusts
+at deploy time - realm, issuer, browser client id, service client id, and a
+reference to where its service-account credential is mounted, never the
+credential itself. `libs/tenantregistry` parses and validates it;
+`libs/assignmentstore/tenantseed` seeds it into the `tenant_registry` table
+idempotently on every service start, the same table on both PostgreSQL and
+Oracle (§8, the dual-dialect constraint every other table already carries).
+
+**After seeding, the database is the record of authority, not the file.**
+`apps/admin-service/internal/tenantonboarding` exposes onboarding a new
+tenant through the Administration Service - a write to `tenant_registry`,
+not a config change and not a restart. Every service resolves a token's
+realm against this table, live, so a newly onboarded tenant becomes usable
+immediately (`apps/ads/internal/tenantdiscovery` polls it), and the trusted
+set can only grow through an API call that is itself audited, never through
+editing a file on a running host.
+
+**An unregistered realm is refused outright**, which is what makes the
+existing foreign-issuer negative test (issue #77) meaningful rather than
+incidental: `libs/tokenverifier` selects a registry entry by the token's
+issuer, and there is no entry for a realm nobody trusted.
+
+## Why file-seeded rather than either extreme
+
+A registry that lived only in a file would need a redeploy to onboard a
+tenant, defeating the point of one deployment serving all of them (issue
+#86's user story). A registry that started life in the database with
+nothing to seed it from would mean the very first trust decision - which
+realms an operator is willing to stand behind before the platform has ever
+run - has no reviewable artifact: a database row someone inserted by hand
+leaves no diff, no reviewer, no commit message. The file is the initial,
+reviewed grant of trust; the table is what lets trust grow afterward without
+that review gate blocking every subsequent tenant. This is a shape already
+proven elsewhere in this codebase - the Cerbos root policy release is also
+"reviewed artifact in, database record of what's active" (§13) - reused
+here rather than invented.
+
+## Consequences
+
+- **Onboarding trusts any authenticated caller** (issue #86,
+  `docs/MEASURED_FINDINGS.md`): the onboarding endpoint checks that the
+  caller holds a valid token for *some* registered tenant, not that they
+  hold a platform-operator credential this prototype has no design for.
+  Accepted as a known gap for a prototype whose realms are all created by
+  the same operator; a production deployment would need a distinct
+  platform-operator role before this endpoint is reachable by anyone but
+  that role.
+- Registry changes propagate to running replicas through the tenant
+  registry table's own polling loop, not a second cache-invalidation
+  mechanism layered on top of the existing revision/event machinery -
+  because a *third* invalidation path in a system that already has one for
+  permissions (§10) and one for policy releases (§13) would be one too
+  many things that can disagree with each other.
+- The credential itself is never in the registry file, the table, or any
+  response the browser can reach - only a reference to where it is mounted.
+  `identity-e2e.sh` asserts this directly for the existing two-tenant
+  registry, and the same assertion covers a tenant onboarded at runtime.
+- A malformed or duplicate entry in the seed file fails fast at startup,
+  before any service accepts a request, rather than surfacing as an
+  intermittent per-realm lookup failure later.

--- a/docs/adr/0012-organization-scoped-login-with-in-flow-selection.md
+++ b/docs/adr/0012-organization-scoped-login-with-in-flow-selection.md
@@ -1,0 +1,95 @@
+# ADR-012: Organization-scoped login, selected inside the login flow
+
+A hospital is a Keycloak organization (ADR-010), and a user can belong to
+several. Something has to decide, at login time, which one - if any - a
+session is scoped to, and that decision has to be one Keycloak itself
+attests to, not one the application layer negotiates afterward with a
+claim it would then have to trust.
+
+## The decision
+
+**Organization selection is a Keycloak authenticator, inside the login
+flow, after credentials and any second factor.**
+`apps/keycloak-org-selector` is a custom authenticator SPI
+(`OrganizationSelectorAuthenticator`) built into the platform's Keycloak
+image. `OrganizationSelectionDecision` is a pure function - no Keycloak
+API, no I/O - of the user's memberships, whether they hold the realm role
+`admin`, and any organization alias already requested in the login's
+`scope` parameter:
+
+| Memberships | Administrator | Scope pre-requested a membership | Result |
+|---|---|---|---|
+| any | any | yes | selected silently, no screen |
+| exactly one | no | no | auto-selected, no screen |
+| more than one | no | no | selection screen, memberships only |
+| any (including zero) | yes | no | selection screen, memberships plus a tenant-wide entry |
+| zero | no | - | login refused with an explicit reason |
+
+Being pure, `OrganizationSelectionDecisionTest` covers every row above
+without starting Keycloak.
+
+**An administrator's tenant-wide session is safe because "no hospital"
+provably cannot mean "every hospital".** Choosing tenant-wide produces a
+token with no active organization at all - not a wildcard, not every
+membership at once. `libs/tokenverifier` treats an active hospital's
+absence as its own state, and the resource policies (§5, `hospitalId`
+matching) express the invariant directionally: a tenant-wide assignment is
+reachable with no hospital, but a hospital-narrowed assignment never is
+reachable without one. Nothing about the login flow or the token grants
+scope; a tenant-wide session still reaches exactly the tenant-wide
+assignments the role matrix actually contains, and nothing else.
+
+**A non-administrator cannot forge tenant-wide.** The decision only offers
+the tenant-wide entry when `admin` is present as a realm role Keycloak
+itself checked, and rejects a submission naming it otherwise
+(`org-selector-e2e.sh`, "a non-administrator cannot forge a tenant-wide
+submission").
+
+**Switching hospital during a session is a fresh, silent authorization
+request**, not a client-side flag: the application asks Keycloak for a new
+token scoped to the target organization against the existing SSO session,
+discards the old token, and Keycloak's own authenticator re-runs the same
+decision for the new scope (ADR-010's membership check applies again, so a
+switch to an organization the user does not belong to fails the same way a
+login would).
+
+## Why in the login flow, not after
+
+The alternative - let any client request any organization scope and trust
+whichever comes back - would move the "does this user actually belong to
+that organization" check out of Keycloak and into every consumer that
+verifies a token, each of which would need to re-derive it from the
+`organization` claim's absence rather than from an explicit refusal.
+Keeping the decision inside Keycloak's own login flow means the guarantee
+"this token's hospital is a membership Keycloak confirmed" is enforced once,
+by the party that already holds the membership data, rather than asserted
+by every downstream reader.
+
+## Consequences
+
+- **`redirect_uri` is never overridden by the authenticator.** Both the
+  platform's Admin Console and Keycloak's own administration console are
+  legitimate destinations; a deep link into either survives organization
+  selection untouched (`console-crosslinks-e2e.sh`).
+- **The memberships list in a token is display data, never a decision
+  input.** `organization_memberships` (a custom protocol mapper,
+  `OrganizationMembershipsMapper`) exists so a hospital switcher can offer
+  every membership without a directory round trip; an architecture test
+  forbids reading it anywhere on the decision path, only the single active
+  `organization` claim.
+- **Switching is a re-authentication, not a token refresh with a wider
+  scope.** Measured directly (`docs/MEASURED_FINDINGS.md`): a refresh
+  grant asking for a *different* organization than the one it already has
+  is silently dropped, not honoured, so the hospital switcher performs a
+  fresh authorization request instead. A *same*-scope refresh does
+  preserve the active hospital correctly.
+- A user with zero memberships and no `admin` role cannot log in at all,
+  with an explicit reason rather than a generic authentication failure -
+  the platform would rather refuse cleanly than issue a token that could
+  never reach a hospital-scoped assignment anyway.
+- The load harness (issue #87) exercises the same organization-scoped
+  direct grant with no browser and no authenticator flow at all: measured
+  directly that Keycloak's own organization scope handling for a direct
+  grant does not require this authenticator - it is native to the
+  `--features=organization` preview feature - so a 1,000-VU run is not
+  measuring the authenticator's own cost.


### PR DESCRIPTION
## What changed

Documentation only - no code changes. Writes down what issues #74-#87
actually decided about identity, so the design document and the code
disagree knowingly rather than accidentally.

- **ADR-010**: a tenant is a Keycloak realm, a hospital is a Keycloak
  organization; isolation rests on a verified signature (the realm that
  signed the token) and a confirmed membership (the `organization` claim
  Keycloak only populates for a real membership), never an editable
  attribute. Records the `tenantMappingMode` non-implementation and the
  alias-as-identifier rename hazard as consequences.
- **ADR-011**: the tenant registry is declared trust, then a database of
  record - a reviewed file seeds an initial trusted set, and onboarding
  afterward is a database write through the Administration Service, never
  a redeploy. Records the tenant-onboarding trust gap as a consequence.
- **ADR-012**: organization-scoped login with in-flow selection - a pure
  decision function inside a Keycloak authenticator, why an administrator's
  tenant-wide session cannot mean "every hospital", and why hospital
  switching is a fresh authorization request rather than a widened refresh.
- `CONTEXT.md`: **Tenant** and **Hospital** redefined in terms of realm and
  organization; a new **Tenant Registry** term; a "many organizations per
  user" relationship; a flagged-ambiguity entry recording the original
  misunderstanding this whole PRD corrects.
- `docs/DEVIATIONS.md`: S8 (the `tenantMappingMode` contract is a knowing
  non-implementation, not an omission), A5 (the tenant registry and
  organization-scoped login are additions §7 does not describe), and a new
  "Known limitations" section for the alias-rename hazard and the
  tenant-onboarding trust gap (both already measured in
  `docs/MEASURED_FINDINGS.md`, now cross-referenced from the deviations
  register a reviewer would actually read first).
- `docs/DESIGN_COVERAGE.md`: §5.2, §7.1 and §7.3 updated to point at the
  new ADRs instead of describing the old claim-based model.

## Acceptance criteria

- [x] An ADR states that a tenant is a Keycloak realm and a hospital is a
      Keycloak organization, with the reasoning that isolation must rest
      on a signature rather than an editable attribute (ADR-010)
- [x] An ADR covers the tenant registry: declared trust, file-seeded,
      database of record (ADR-011)
- [x] An ADR covers organization-scoped login, in-flow selection, and why
      the administrator tenant-wide session is safe (ADR-012)
- [x] `CONTEXT.md` defines Tenant and Hospital in terms of realm and
      organization, and records that a user may belong to many
      organizations
- [x] `DEVIATIONS.md` records the deliberate non-implementation of the
      design document's tenant mapping-mode contract, with reasoning
- [x] `DESIGN_COVERAGE.md` reflects the new identity model
- [x] The alias-as-hospital-identifier rename hazard is recorded as a
      known limitation
- [ ] Reviewed and signed off by a human before merge - flagging this
      explicitly since the issue names it as an acceptance criterion; the
      autonomous loop's own thorough self-review (every cited path and
      ADR cross-reference verified to exist) is what backs this PR, the
      same as other `hitl`-labelled issues in this repo's history
      (#3, #8, #24, #25, #75).

## Verification

- Every file path, package and script cited in the three new ADRs and in
  `CONTEXT.md`/`DEVIATIONS.md` was checked to actually exist.
- Cross-references between the new ADRs, `DEVIATIONS.md` and
  `DESIGN_COVERAGE.md` were checked for consistency (ADR numbers, section
  numbers).
- No code changed, so no test suite was affected; `git diff` is
  documentation only.


Closes #88
